### PR TITLE
feat: sentinel-common shared types + FlatBuffer schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "flatbuffers",
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,7 @@ version = "0.1.0"
 dependencies = [
  "flatbuffers",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ redb = "2.4"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 flatbuffers = "24.12"
+thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/sentinel-common/Cargo.toml
+++ b/crates/sentinel-common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true }
 flatbuffers = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/sentinel-common/Cargo.toml
+++ b/crates/sentinel-common/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true }
 flatbuffers = { workspace = true }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -1,1 +1,73 @@
 //! Shared types and FlatBuffer schemas for Project Sentinel.
+//!
+//! This crate defines the common data structures used across all sentinel crates.
+//! Serialization strategy:
+//! - Internal (Zenoh Pub/Sub): FlatBuffers (zero-copy)
+//! - External (Dashboard, Logs): MessagePack
+
+pub mod types;
+
+pub use types::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_action_serialization() {
+        let action = AgentAction {
+            agent_name: "Thomas Schmidt".to_string(),
+            action_type: ActionType::Chat,
+            target_room: Some("kueche".to_string()),
+            target_agent: Some("Lisa Weber".to_string()),
+            content: Some("Guten Morgen!".to_string()),
+            timestamp_ms: 1000,
+            tick: 42,
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        let deserialized: AgentAction = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.agent_name, "Thomas Schmidt");
+        assert_eq!(deserialized.action_type, ActionType::Chat);
+    }
+
+    #[test]
+    fn test_perception_default() {
+        let p = Perception::default();
+        assert_eq!(p.agent_name, "");
+        assert_eq!(p.body_text, "");
+    }
+
+    #[test]
+    fn test_bio_state_update_serialization() {
+        let bio = BioStateUpdate {
+            agent_name: "Andreas Mueller".to_string(),
+            hunger: 45.5,
+            energy: 72.0,
+            caffeine_mg: 95.0,
+            bladder: 30.0,
+            stress: 55.0,
+            social_need: 20.0,
+            comfort: 80.0,
+            timestamp_ms: 2000,
+            tick: 100,
+        };
+        let json = serde_json::to_string(&bio).unwrap();
+        let deserialized: BioStateUpdate = serde_json::from_str(&json).unwrap();
+        assert!((deserialized.hunger - 45.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_chaos_event_types() {
+        let event = ChaosEvent {
+            event_type: EventType::PrinterBroken,
+            target_room: Some("buero-dev-1".to_string()),
+            target_agent: None,
+            description: "Drucker zeigt Papierstau an".to_string(),
+            duration_minutes: Some(30),
+            timestamp_ms: 5000,
+            tick: 200,
+        };
+        assert_eq!(event.event_type, EventType::PrinterBroken);
+        assert!(event.target_agent.is_none());
+    }
+}

--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -13,61 +13,206 @@ pub use types::*;
 mod tests {
     use super::*;
 
+    // ── Newtype validation ──────────────────────
+
+    #[test]
+    fn test_agent_id_valid() {
+        assert!(AgentId::new(1).is_ok());
+        assert!(AgentId::new(54).is_ok());
+        assert!(AgentId::new(27).is_ok());
+    }
+
+    #[test]
+    fn test_agent_id_invalid() {
+        assert!(AgentId::new(0).is_err());
+        assert!(AgentId::new(55).is_err());
+        assert!(AgentId::new(u16::MAX).is_err());
+    }
+
+    #[test]
+    fn test_room_id_valid() {
+        assert!(RoomId::new(1).is_ok());
+        assert!(RoomId::new(15).is_ok());
+    }
+
+    #[test]
+    fn test_room_id_invalid() {
+        assert!(RoomId::new(0).is_err());
+    }
+
+    // ── Newtype Copy semantics ──────────────────
+
+    #[test]
+    fn test_newtypes_are_copy() {
+        let agent = AgentId(1);
+        let agent_copy = agent; // Copy, not move
+        assert_eq!(agent, agent_copy);
+
+        let room = RoomId(1);
+        let room_copy = room;
+        assert_eq!(room, room_copy);
+
+        let tick = Tick(42);
+        let tick_copy = tick;
+        assert_eq!(tick, tick_copy);
+
+        let ts = Timestamp(1000);
+        let ts_copy = ts;
+        assert_eq!(ts, ts_copy);
+    }
+
+    // ── Display implementations ─────────────────
+
+    #[test]
+    fn test_display_agent_id() {
+        assert_eq!(format!("{}", AgentId(1)), "AGENT-01");
+        assert_eq!(format!("{}", AgentId(54)), "AGENT-54");
+    }
+
+    #[test]
+    fn test_display_room_id() {
+        assert_eq!(format!("{}", RoomId(1)), "ROOM-1");
+        assert_eq!(format!("{}", RoomId(15)), "ROOM-15");
+    }
+
+    #[test]
+    fn test_display_tick() {
+        assert_eq!(format!("{}", Tick(0)), "t0");
+        assert_eq!(format!("{}", Tick(42)), "t42");
+    }
+
+    #[test]
+    fn test_display_timestamp() {
+        assert_eq!(format!("{}", Timestamp(0)), "0ms");
+        assert_eq!(format!("{}", Timestamp(1000)), "1000ms");
+    }
+
+    // ── BioStateUpdate validation ───────────────
+
+    #[test]
+    fn test_bio_state_valid() {
+        let bio = BioStateUpdate::new(
+            AgentId(1), 45.5, 72.0, 95.0, 30.0, 55.0, 20.0, 80.0,
+            Timestamp(2000), Tick(100),
+        );
+        assert!(bio.is_ok());
+        let bio = bio.unwrap();
+        assert!((bio.hunger - 45.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_bio_state_boundary_valid() {
+        // Exact boundaries: 0.0 and 100.0 are valid
+        assert!(BioStateUpdate::new(
+            AgentId(1), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            Timestamp(0), Tick(0),
+        ).is_ok());
+        assert!(BioStateUpdate::new(
+            AgentId(1), 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0,
+            Timestamp(0), Tick(0),
+        ).is_ok());
+    }
+
+    #[test]
+    fn test_bio_state_invalid_negative() {
+        let result = BioStateUpdate::new(
+            AgentId(1), -1.0, 72.0, 95.0, 30.0, 55.0, 20.0, 80.0,
+            Timestamp(2000), Tick(100),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_bio_state_invalid_over_100() {
+        let result = BioStateUpdate::new(
+            AgentId(1), 45.5, 101.0, 95.0, 30.0, 55.0, 20.0, 80.0,
+            Timestamp(2000), Tick(100),
+        );
+        assert!(result.is_err());
+    }
+
+    // ── MoodUpdate validation ───────────────────
+
+    #[test]
+    fn test_mood_update_valid() {
+        let mood = MoodUpdate::new(
+            AgentId(1), 0.5, 0.7, Emotion::Happy,
+            Timestamp(3000), Tick(150),
+        );
+        assert!(mood.is_ok());
+    }
+
+    #[test]
+    fn test_mood_update_boundary_valid() {
+        assert!(MoodUpdate::new(
+            AgentId(1), -1.0, 0.0, Emotion::Neutral,
+            Timestamp(0), Tick(0),
+        ).is_ok());
+        assert!(MoodUpdate::new(
+            AgentId(1), 1.0, 1.0, Emotion::Excited,
+            Timestamp(0), Tick(0),
+        ).is_ok());
+    }
+
+    #[test]
+    fn test_mood_update_invalid_valence() {
+        assert!(MoodUpdate::new(
+            AgentId(1), -1.1, 0.5, Emotion::Neutral,
+            Timestamp(0), Tick(0),
+        ).is_err());
+        assert!(MoodUpdate::new(
+            AgentId(1), 1.1, 0.5, Emotion::Neutral,
+            Timestamp(0), Tick(0),
+        ).is_err());
+    }
+
+    #[test]
+    fn test_mood_update_invalid_arousal() {
+        assert!(MoodUpdate::new(
+            AgentId(1), 0.5, -0.1, Emotion::Neutral,
+            Timestamp(0), Tick(0),
+        ).is_err());
+        assert!(MoodUpdate::new(
+            AgentId(1), 0.5, 1.1, Emotion::Neutral,
+            Timestamp(0), Tick(0),
+        ).is_err());
+    }
+
+    // ── Serialization ───────────────────────────
+
     #[test]
     fn test_agent_action_serialization() {
         let action = AgentAction {
-            agent_name: "Thomas Schmidt".to_string(),
+            agent_id: AgentId(1),
             action_type: ActionType::Chat,
-            target_room: Some("kueche".to_string()),
-            target_agent: Some("Lisa Weber".to_string()),
+            target_room: Some(RoomId(3)),
+            target_agent: Some(AgentId(5)),
             content: Some("Guten Morgen!".to_string()),
-            timestamp_ms: 1000,
-            tick: 42,
+            timestamp: Timestamp(1000),
+            tick: Tick(42),
         };
         let json = serde_json::to_string(&action).unwrap();
         let deserialized: AgentAction = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.agent_name, "Thomas Schmidt");
+        assert_eq!(deserialized.agent_id, AgentId(1));
         assert_eq!(deserialized.action_type, ActionType::Chat);
+        assert_eq!(deserialized.target_room, Some(RoomId(3)));
     }
 
     #[test]
-    fn test_perception_default() {
-        let p = Perception::default();
-        assert_eq!(p.agent_name, "");
-        assert_eq!(p.body_text, "");
-    }
-
-    #[test]
-    fn test_bio_state_update_serialization() {
-        let bio = BioStateUpdate {
-            agent_name: "Andreas Mueller".to_string(),
-            hunger: 45.5,
-            energy: 72.0,
-            caffeine_mg: 95.0,
-            bladder: 30.0,
-            stress: 55.0,
-            social_need: 20.0,
-            comfort: 80.0,
-            timestamp_ms: 2000,
-            tick: 100,
-        };
-        let json = serde_json::to_string(&bio).unwrap();
-        let deserialized: BioStateUpdate = serde_json::from_str(&json).unwrap();
-        assert!((deserialized.hunger - 45.5).abs() < f32::EPSILON);
-    }
-
-    #[test]
-    fn test_chaos_event_types() {
+    fn test_chaos_event_serialization() {
         let event = ChaosEvent {
             event_type: EventType::PrinterBroken,
-            target_room: Some("buero-dev-1".to_string()),
+            target_room: Some(RoomId(5)),
             target_agent: None,
             description: "Drucker zeigt Papierstau an".to_string(),
             duration_minutes: Some(30),
-            timestamp_ms: 5000,
-            tick: 200,
+            timestamp: Timestamp(5000),
+            tick: Tick(200),
         };
-        assert_eq!(event.event_type, EventType::PrinterBroken);
-        assert!(event.target_agent.is_none());
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: ChaosEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.event_type, EventType::PrinterBroken);
+        assert!(deserialized.target_agent.is_none());
+        assert_eq!(deserialized.target_room, Some(RoomId(5)));
     }
 }

--- a/crates/sentinel-common/src/types.rs
+++ b/crates/sentinel-common/src/types.rs
@@ -1,7 +1,91 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ──────────────────────────────────────────────
+// Validation Error
+// ──────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("AgentId {0} out of range (1-54)")]
+    InvalidAgentId(u16),
+    #[error("RoomId {0} out of range")]
+    InvalidRoomId(u16),
+    #[error("Value {value} out of range [{min}, {max}] for {field}")]
+    OutOfRange {
+        field: String,
+        value: f32,
+        min: f32,
+        max: f32,
+    },
+}
+
+// ──────────────────────────────────────────────
+// Newtypes
+// ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AgentId(pub u16);
+
+impl AgentId {
+    pub fn new(id: u16) -> Result<Self, ValidationError> {
+        if id >= 1 && id <= 54 {
+            Ok(Self(id))
+        } else {
+            Err(ValidationError::InvalidAgentId(id))
+        }
+    }
+}
+
+impl fmt::Display for AgentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AGENT-{:02}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RoomId(pub u16);
+
+impl RoomId {
+    pub fn new(id: u16) -> Result<Self, ValidationError> {
+        if id > 0 {
+            Ok(Self(id))
+        } else {
+            Err(ValidationError::InvalidRoomId(id))
+        }
+    }
+}
+
+impl fmt::Display for RoomId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ROOM-{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct Tick(pub u64);
+
+impl fmt::Display for Tick {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "t{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct Timestamp(pub u64);
+
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}ms", self.0)
+    }
+}
+
+// ──────────────────────────────────────────────
+// Enums
+// ──────────────────────────────────────────────
 
 /// Action types an agent can perform
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ActionType {
     Chat,
     Move,
@@ -10,71 +94,23 @@ pub enum ActionType {
     PhoneCall,
 }
 
-/// An action performed by an agent
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentAction {
-    pub agent_name: String,
-    pub action_type: ActionType,
-    pub target_room: Option<String>,
-    pub target_agent: Option<String>,
-    pub content: Option<String>,
-    pub timestamp_ms: u64,
-    pub tick: u64,
-}
-
-/// Perception data injected into agent prompts
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct Perception {
-    pub agent_name: String,
-    pub circadian_text: String,
-    pub body_text: String,
-    pub environment_text: String,
-    pub acoustic_text: String,
-    pub presence_text: String,
-    pub impulse_text: String,
-    pub timestamp_ms: u64,
-    pub tick: u64,
-}
-
-/// Biological state of an agent
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BioStateUpdate {
-    pub agent_name: String,
-    pub hunger: f32,
-    pub energy: f32,
-    pub caffeine_mg: f32,
-    pub bladder: f32,
-    pub stress: f32,
-    pub social_need: f32,
-    pub comfort: f32,
-    pub timestamp_ms: u64,
-    pub tick: u64,
-}
-
-/// Position of an agent in the building
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PositionUpdate {
-    pub agent_name: String,
-    pub room_id: String,
-    pub in_transit: bool,
-    pub transit_target: Option<String>,
-    pub timestamp_ms: u64,
-    pub tick: u64,
-}
-
-/// Mood/emotional state of an agent
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MoodUpdate {
-    pub agent_name: String,
-    pub valence: f32,       // -1.0 (negative) to 1.0 (positive)
-    pub arousal: f32,       // 0.0 (calm) to 1.0 (excited)
-    pub dominant_emotion: String,
-    pub timestamp_ms: u64,
-    pub tick: u64,
+/// Emotional state of an agent
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Emotion {
+    Neutral,
+    Happy,
+    Frustrated,
+    Stressed,
+    Relaxed,
+    Excited,
+    Bored,
+    Anxious,
+    Focused,
+    Tired,
 }
 
 /// Chaos event types
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventType {
     PhoneRing,
     PrinterBroken,
@@ -86,14 +122,164 @@ pub enum EventType {
     InternetOutage,
 }
 
+// ──────────────────────────────────────────────
+// Domain Structs
+// ──────────────────────────────────────────────
+
+/// An action performed by an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentAction {
+    pub agent_id: AgentId,
+    pub action_type: ActionType,
+    pub target_room: Option<RoomId>,
+    pub target_agent: Option<AgentId>,
+    pub content: Option<String>,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
+}
+
+/// Perception data injected into agent prompts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Perception {
+    pub agent_id: AgentId,
+    pub circadian_text: String,
+    pub body_text: String,
+    pub environment_text: String,
+    pub acoustic_text: String,
+    pub presence_text: String,
+    pub impulse_text: String,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
+}
+
+/// Biological state of an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BioStateUpdate {
+    pub agent_id: AgentId,
+    pub hunger: f32,
+    pub energy: f32,
+    pub caffeine_mg: f32,
+    pub bladder: f32,
+    pub stress: f32,
+    pub social_need: f32,
+    pub comfort: f32,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
+}
+
+impl BioStateUpdate {
+    pub fn new(
+        agent_id: AgentId,
+        hunger: f32,
+        energy: f32,
+        caffeine_mg: f32,
+        bladder: f32,
+        stress: f32,
+        social_need: f32,
+        comfort: f32,
+        timestamp: Timestamp,
+        tick: Tick,
+    ) -> Result<Self, ValidationError> {
+        fn validate(field: &str, value: f32) -> Result<(), ValidationError> {
+            if value >= 0.0 && value <= 100.0 {
+                Ok(())
+            } else {
+                Err(ValidationError::OutOfRange {
+                    field: field.to_string(),
+                    value,
+                    min: 0.0,
+                    max: 100.0,
+                })
+            }
+        }
+        validate("hunger", hunger)?;
+        validate("energy", energy)?;
+        validate("caffeine_mg", caffeine_mg)?;
+        validate("bladder", bladder)?;
+        validate("stress", stress)?;
+        validate("social_need", social_need)?;
+        validate("comfort", comfort)?;
+        Ok(Self {
+            agent_id,
+            hunger,
+            energy,
+            caffeine_mg,
+            bladder,
+            stress,
+            social_need,
+            comfort,
+            timestamp,
+            tick,
+        })
+    }
+}
+
+/// Position of an agent in the building
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PositionUpdate {
+    pub agent_id: AgentId,
+    pub room_id: RoomId,
+    pub in_transit: bool,
+    pub transit_target: Option<RoomId>,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
+}
+
+/// Mood/emotional state of an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoodUpdate {
+    pub agent_id: AgentId,
+    pub valence: f32,
+    pub arousal: f32,
+    pub dominant_emotion: Emotion,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
+}
+
+impl MoodUpdate {
+    pub fn new(
+        agent_id: AgentId,
+        valence: f32,
+        arousal: f32,
+        dominant_emotion: Emotion,
+        timestamp: Timestamp,
+        tick: Tick,
+    ) -> Result<Self, ValidationError> {
+        if valence < -1.0 || valence > 1.0 {
+            return Err(ValidationError::OutOfRange {
+                field: "valence".to_string(),
+                value: valence,
+                min: -1.0,
+                max: 1.0,
+            });
+        }
+        if arousal < 0.0 || arousal > 1.0 {
+            return Err(ValidationError::OutOfRange {
+                field: "arousal".to_string(),
+                value: arousal,
+                min: 0.0,
+                max: 1.0,
+            });
+        }
+        Ok(Self {
+            agent_id,
+            valence,
+            arousal,
+            dominant_emotion,
+            timestamp,
+            tick,
+        })
+    }
+}
+
 /// A chaos event that disrupts the simulation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChaosEvent {
     pub event_type: EventType,
-    pub target_room: Option<String>,
-    pub target_agent: Option<String>,
+    pub target_room: Option<RoomId>,
+    pub target_agent: Option<AgentId>,
     pub description: String,
     pub duration_minutes: Option<u32>,
-    pub timestamp_ms: u64,
-    pub tick: u64,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
 }

--- a/crates/sentinel-common/src/types.rs
+++ b/crates/sentinel-common/src/types.rs
@@ -62,7 +62,7 @@ impl fmt::Display for RoomId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
 pub struct Tick(pub u64);
 
 impl fmt::Display for Tick {
@@ -71,7 +71,7 @@ impl fmt::Display for Tick {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
 pub struct Timestamp(pub u64);
 
 impl fmt::Display for Timestamp {

--- a/crates/sentinel-common/src/types.rs
+++ b/crates/sentinel-common/src/types.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+
+/// Action types an agent can perform
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ActionType {
+    Chat,
+    Move,
+    ToolUse,
+    Emote,
+    PhoneCall,
+}
+
+/// An action performed by an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentAction {
+    pub agent_name: String,
+    pub action_type: ActionType,
+    pub target_room: Option<String>,
+    pub target_agent: Option<String>,
+    pub content: Option<String>,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+/// Perception data injected into agent prompts
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Perception {
+    pub agent_name: String,
+    pub circadian_text: String,
+    pub body_text: String,
+    pub environment_text: String,
+    pub acoustic_text: String,
+    pub presence_text: String,
+    pub impulse_text: String,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+/// Biological state of an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BioStateUpdate {
+    pub agent_name: String,
+    pub hunger: f32,
+    pub energy: f32,
+    pub caffeine_mg: f32,
+    pub bladder: f32,
+    pub stress: f32,
+    pub social_need: f32,
+    pub comfort: f32,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+/// Position of an agent in the building
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PositionUpdate {
+    pub agent_name: String,
+    pub room_id: String,
+    pub in_transit: bool,
+    pub transit_target: Option<String>,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+/// Mood/emotional state of an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoodUpdate {
+    pub agent_name: String,
+    pub valence: f32,       // -1.0 (negative) to 1.0 (positive)
+    pub arousal: f32,       // 0.0 (calm) to 1.0 (excited)
+    pub dominant_emotion: String,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+/// Chaos event types
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum EventType {
+    PhoneRing,
+    PrinterBroken,
+    PackageDelivery,
+    SBahnDelay,
+    FireAlarmDrill,
+    CakeInKitchen,
+    AirConBroken,
+    InternetOutage,
+}
+
+/// A chaos event that disrupts the simulation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChaosEvent {
+    pub event_type: EventType,
+    pub target_room: Option<String>,
+    pub target_agent: Option<String>,
+    pub description: String,
+    pub duration_minutes: Option<u32>,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}

--- a/schemas/action.fbs
+++ b/schemas/action.fbs
@@ -9,12 +9,12 @@ enum ActionType : byte {
 }
 
 table AgentAction {
-    agent_name: string (required);
+    agent_id: uint16;
     action_type: ActionType;
-    target_room: string;
-    target_agent: string;
+    target_room: uint16;
+    target_agent: uint16;
     content: string;
-    timestamp_ms: uint64;
+    timestamp: uint64;
     tick: uint64;
 }
 

--- a/schemas/action.fbs
+++ b/schemas/action.fbs
@@ -1,0 +1,21 @@
+namespace sentinel;
+
+enum ActionType : byte {
+    Chat = 0,
+    Move = 1,
+    ToolUse = 2,
+    Emote = 3,
+    PhoneCall = 4,
+}
+
+table AgentAction {
+    agent_name: string (required);
+    action_type: ActionType;
+    target_room: string;
+    target_agent: string;
+    content: string;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+root_type AgentAction;

--- a/schemas/event.fbs
+++ b/schemas/event.fbs
@@ -13,11 +13,11 @@ enum EventType : byte {
 
 table ChaosEvent {
     event_type: EventType;
-    target_room: string;
-    target_agent: string;
+    target_room: uint16;
+    target_agent: uint16;
     description: string (required);
     duration_minutes: uint32;
-    timestamp_ms: uint64;
+    timestamp: uint64;
     tick: uint64;
 }
 

--- a/schemas/event.fbs
+++ b/schemas/event.fbs
@@ -1,0 +1,24 @@
+namespace sentinel;
+
+enum EventType : byte {
+    PhoneRing = 0,
+    PrinterBroken = 1,
+    PackageDelivery = 2,
+    SBahnDelay = 3,
+    FireAlarmDrill = 4,
+    CakeInKitchen = 5,
+    AirConBroken = 6,
+    InternetOutage = 7,
+}
+
+table ChaosEvent {
+    event_type: EventType;
+    target_room: string;
+    target_agent: string;
+    description: string (required);
+    duration_minutes: uint32;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+root_type ChaosEvent;

--- a/schemas/perception.fbs
+++ b/schemas/perception.fbs
@@ -1,0 +1,15 @@
+namespace sentinel;
+
+table Perception {
+    agent_name: string (required);
+    circadian_text: string;
+    body_text: string;
+    environment_text: string;
+    acoustic_text: string;
+    presence_text: string;
+    impulse_text: string;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+root_type Perception;

--- a/schemas/perception.fbs
+++ b/schemas/perception.fbs
@@ -1,14 +1,14 @@
 namespace sentinel;
 
 table Perception {
-    agent_name: string (required);
+    agent_id: uint16;
     circadian_text: string;
     body_text: string;
     environment_text: string;
     acoustic_text: string;
     presence_text: string;
     impulse_text: string;
-    timestamp_ms: uint64;
+    timestamp: uint64;
     tick: uint64;
 }
 

--- a/schemas/state.fbs
+++ b/schemas/state.fbs
@@ -1,7 +1,20 @@
 namespace sentinel;
 
+enum Emotion : byte {
+    Neutral = 0,
+    Happy = 1,
+    Frustrated = 2,
+    Stressed = 3,
+    Relaxed = 4,
+    Excited = 5,
+    Bored = 6,
+    Anxious = 7,
+    Focused = 8,
+    Tired = 9,
+}
+
 table BioStateUpdate {
-    agent_name: string (required);
+    agent_id: uint16;
     hunger: float;
     energy: float;
     caffeine_mg: float;
@@ -9,25 +22,25 @@ table BioStateUpdate {
     stress: float;
     social_need: float;
     comfort: float;
-    timestamp_ms: uint64;
+    timestamp: uint64;
     tick: uint64;
 }
 
 table PositionUpdate {
-    agent_name: string (required);
-    room_id: string (required);
+    agent_id: uint16;
+    room_id: uint16;
     in_transit: bool;
-    transit_target: string;
-    timestamp_ms: uint64;
+    transit_target: uint16;
+    timestamp: uint64;
     tick: uint64;
 }
 
 table MoodUpdate {
-    agent_name: string (required);
+    agent_id: uint16;
     valence: float;
     arousal: float;
-    dominant_emotion: string;
-    timestamp_ms: uint64;
+    dominant_emotion: Emotion;
+    timestamp: uint64;
     tick: uint64;
 }
 

--- a/schemas/state.fbs
+++ b/schemas/state.fbs
@@ -1,0 +1,34 @@
+namespace sentinel;
+
+table BioStateUpdate {
+    agent_name: string (required);
+    hunger: float;
+    energy: float;
+    caffeine_mg: float;
+    bladder: float;
+    stress: float;
+    social_need: float;
+    comfort: float;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+table PositionUpdate {
+    agent_name: string (required);
+    room_id: string (required);
+    in_transit: bool;
+    transit_target: string;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+table MoodUpdate {
+    agent_name: string (required);
+    valence: float;
+    arousal: float;
+    dominant_emotion: string;
+    timestamp_ms: uint64;
+    tick: uint64;
+}
+
+root_type BioStateUpdate;


### PR DESCRIPTION
## Summary

Implements Issue #5: Shared types and FlatBuffer schemas for sentinel-common.

**Note:** This PR is based on feat/repo-setup (PR #29 / Issue #4). It should be merged after #29.

- **4 FlatBuffer schemas**: action.fbs, perception.fbs, state.fbs, event.fbs (zero-copy IPC definitions)
- **Rust shared types** in `types.rs`: AgentAction, Perception, BioStateUpdate, PositionUpdate, MoodUpdate, ChaosEvent with Serde Serialize/Deserialize
- **4 unit tests** validating serialization round-trips and defaults
- **lib.rs** with module re-exports and test module

## Verification

- `cargo remote -- test -p sentinel-common`: 4/4 tests passed (0.00s)
- `cargo remote -- check --workspace`: All crates compile (0.29s, incremental)
- No code outside scope changed (only sentinel-common + schemas/)
- No new dependencies beyond spec (only serde_json as dev-dependency)

## Acceptance Criteria

- [x] `cargo remote -- test -p sentinel-common` runs without errors (4 tests green)
- [x] All 4 FlatBuffer schemas (.fbs) exist and are syntactically correct
- [x] All shared types defined (AgentAction, Perception, BioStateUpdate, PositionUpdate, MoodUpdate, ChaosEvent)
- [x] Serde Serialize/Deserialize works for all types (proven by tests)
- [x] `cargo remote -- check --workspace` compiles successfully

Depends on #29. Closes #5