### PR TITLE
feat: sentinel-limbo async SQLite integration (rusqlite fallback)

### DIFF
--- a/crates/sentinel-limbo/Cargo.toml
+++ b/crates/sentinel-limbo/Cargo.toml
@@ -8,3 +8,11 @@ tokio = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 sentinel-common = { path = "../sentinel-common" }
+# Fallback: rusqlite statt limbo (limbo v0.0.22 hat keinen Pragma-Setter)
+rusqlite = { version = "0.32", features = ["bundled"] }
+anyhow = "1"
+serde_json = "1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -163,8 +163,8 @@ impl ChatStore {
                     agent_name: row.get(2)?,
                     content: row.get(3)?,
                     emotion: row.get(4)?,
-                    timestamp_ms: row.get::<_, i64>(5)? as u64,
-                    tick: row.get::<_, i64>(6)? as u64,
+                    timestamp: Timestamp(row.get::<_, i64>(5)? as u64),
+                    tick: Tick(row.get::<_, i64>(6)? as u64),
                 })
             })?;
             let mut results = Vec::new();
@@ -184,13 +184,14 @@ impl ChatStore {
         &self,
         room_id: RoomId,
         title: &str,
-        participants: &[String],
+        participants: &[AgentId],
         started_at: Timestamp,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.clone();
         let room_str = room_id.to_string();
         let title = title.to_string();
-        let participants_json = serde_json::to_string(participants)?;
+        let participant_strings: Vec<String> = participants.iter().map(|a| a.to_string()).collect();
+        let participants_json = serde_json::to_string(&participant_strings)?;
         let started = started_at.0 as i64;
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
@@ -304,8 +305,8 @@ pub struct MessageRow {
     pub agent_name: String,
     pub content: String,
     pub emotion: Option<String>,
-    pub timestamp_ms: u64,
-    pub tick: u64,
+    pub timestamp: Timestamp,
+    pub tick: Tick,
 }
 
 // ──────────────────────────────────────────────
@@ -408,8 +409,8 @@ mod tests {
         assert_eq!(messages[0].agent_name, "AGENT-01");
         assert_eq!(messages[0].content, "Guten Morgen!");
         assert_eq!(messages[0].emotion, Some("happy".to_string()));
-        assert_eq!(messages[0].timestamp_ms, 1000);
-        assert_eq!(messages[0].tick, 42);
+        assert_eq!(messages[0].timestamp, Timestamp(1000));
+        assert_eq!(messages[0].tick, Tick(42));
     }
 
     #[tokio::test]
@@ -419,7 +420,7 @@ mod tests {
         let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
         let room = RoomId::new(5).unwrap();
-        let participants = vec!["AGENT-01".to_string(), "AGENT-02".to_string()];
+        let participants = vec![AgentId::new(1).unwrap(), AgentId::new(2).unwrap()];
         let id = store
             .insert_meeting(room, "Sprint Review", &participants, Timestamp(9000))
             .await

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -8,6 +8,7 @@
 //! with tokio::task::spawn_blocking for async compatibility.
 
 use rusqlite::{params, Connection};
+use sentinel_common::{AgentId, Emotion, EventType, RoomId, Tick, Timestamp};
 use std::sync::{Arc, Mutex};
 use tracing::info;
 
@@ -115,26 +116,26 @@ impl ChatStore {
     /// Insert a chat message. Returns the rowid of the inserted row.
     pub async fn insert_message(
         &self,
-        room_id: &str,
-        agent_name: &str,
+        room_id: RoomId,
+        agent_id: AgentId,
         content: &str,
-        emotion: Option<&str>,
-        timestamp_ms: u64,
-        tick: u64,
+        emotion: Option<Emotion>,
+        timestamp: Timestamp,
+        tick: Tick,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.clone();
-        let room_id = room_id.to_string();
-        let agent_name = agent_name.to_string();
+        let room_str = room_id.to_string();
+        let agent_str = agent_id.to_string();
         let content = content.to_string();
-        let emotion = emotion.map(|e| e.to_string());
-        let ts = timestamp_ms as i64;
-        let t = tick as i64;
+        let emotion_str = emotion.map(emotion_to_str);
+        let ts = timestamp.0 as i64;
+        let t = tick.0 as i64;
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
             let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             conn.execute(
                 "INSERT INTO messages (room_id, agent_name, content, emotion, timestamp_ms, tick) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![room_id, agent_name, content, emotion, ts, t],
+                params![room_str, agent_str, content, emotion_str, ts, t],
             )?;
             Ok(conn.last_insert_rowid())
         })
@@ -144,18 +145,18 @@ impl ChatStore {
     /// Get messages for a room, ordered by timestamp descending.
     pub async fn get_room_messages(
         &self,
-        room_id: &str,
+        room_id: RoomId,
         limit: u32,
     ) -> anyhow::Result<Vec<MessageRow>> {
         let conn = self.conn.clone();
-        let room_id = room_id.to_string();
+        let room_str = room_id.to_string();
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<MessageRow>> {
             let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             let mut stmt = conn.prepare(
                 "SELECT id, room_id, agent_name, content, emotion, timestamp_ms, tick FROM messages WHERE room_id = ?1 ORDER BY timestamp_ms DESC LIMIT ?2",
             )?;
-            let rows = stmt.query_map(params![room_id, limit], |row| {
+            let rows = stmt.query_map(params![room_str, limit], |row| {
                 Ok(MessageRow {
                     id: row.get(0)?,
                     room_id: row.get(1)?,
@@ -181,22 +182,22 @@ impl ChatStore {
     /// Returns the rowid of the inserted row.
     pub async fn insert_meeting(
         &self,
-        room_id: &str,
+        room_id: RoomId,
         title: &str,
         participants: &[String],
-        started_at: u64,
+        started_at: Timestamp,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.clone();
-        let room_id = room_id.to_string();
+        let room_str = room_id.to_string();
         let title = title.to_string();
         let participants_json = serde_json::to_string(participants)?;
-        let started = started_at as i64;
+        let started = started_at.0 as i64;
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
             let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             conn.execute(
                 "INSERT INTO meetings (room_id, title, participants, started_at) VALUES (?1, ?2, ?3, ?4)",
-                params![room_id, title, participants_json, started],
+                params![room_str, title, participants_json, started],
             )?;
             Ok(conn.last_insert_rowid())
         })
@@ -207,11 +208,11 @@ impl ChatStore {
     pub async fn end_meeting(
         &self,
         meeting_id: i64,
-        ended_at: u64,
+        ended_at: Timestamp,
         summary: &str,
     ) -> anyhow::Result<()> {
         let conn = self.conn.clone();
-        let ended = ended_at as i64;
+        let ended = ended_at.0 as i64;
         let summary = summary.to_string();
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
@@ -230,25 +231,25 @@ impl ChatStore {
     /// Insert an observation data point. Returns the rowid of the inserted row.
     pub async fn insert_observation(
         &self,
-        agent_name: &str,
+        agent_id: AgentId,
         model: &str,
         metric: &str,
         value: f64,
         context: Option<&str>,
-        timestamp_ms: u64,
+        timestamp: Timestamp,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.clone();
-        let agent_name = agent_name.to_string();
+        let agent_str = agent_id.to_string();
         let model = model.to_string();
         let metric = metric.to_string();
         let context = context.map(|c| c.to_string());
-        let ts = timestamp_ms as i64;
+        let ts = timestamp.0 as i64;
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
             let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             conn.execute(
                 "INSERT INTO observations (agent_name, model, metric, value, context, timestamp_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![agent_name, model, metric, value, context, ts],
+                params![agent_str, model, metric, value, context, ts],
             )?;
             Ok(conn.last_insert_rowid())
         })
@@ -260,24 +261,24 @@ impl ChatStore {
     /// Insert a chaos event. Returns the rowid of the inserted row.
     pub async fn insert_chaos_event(
         &self,
-        event_type: &str,
-        target_room: Option<&str>,
-        target_agent: Option<&str>,
+        event_type: EventType,
+        target_room: Option<RoomId>,
+        target_agent: Option<AgentId>,
         description: &str,
-        timestamp_ms: u64,
+        timestamp: Timestamp,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.clone();
-        let event_type = event_type.to_string();
-        let target_room = target_room.map(|r| r.to_string());
-        let target_agent = target_agent.map(|a| a.to_string());
+        let event_str = event_type_to_str(event_type);
+        let room_str = target_room.map(|r| r.to_string());
+        let agent_str = target_agent.map(|a| a.to_string());
         let description = description.to_string();
-        let ts = timestamp_ms as i64;
+        let ts = timestamp.0 as i64;
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
             let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             conn.execute(
                 "INSERT INTO chaos_events (event_type, target_room, target_agent, description, timestamp_ms) VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![event_type, target_room, target_agent, description, ts],
+                params![event_str, room_str, agent_str, description, ts],
             )?;
             Ok(conn.last_insert_rowid())
         })
@@ -305,6 +306,42 @@ pub struct MessageRow {
     pub emotion: Option<String>,
     pub timestamp_ms: u64,
     pub tick: u64,
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+/// Convert Emotion enum to lowercase string for DB storage.
+fn emotion_to_str(e: Emotion) -> String {
+    match e {
+        Emotion::Neutral => "neutral",
+        Emotion::Happy => "happy",
+        Emotion::Frustrated => "frustrated",
+        Emotion::Stressed => "stressed",
+        Emotion::Relaxed => "relaxed",
+        Emotion::Excited => "excited",
+        Emotion::Bored => "bored",
+        Emotion::Anxious => "anxious",
+        Emotion::Focused => "focused",
+        Emotion::Tired => "tired",
+    }
+    .to_string()
+}
+
+/// Convert EventType enum to snake_case string for DB storage.
+fn event_type_to_str(e: EventType) -> String {
+    match e {
+        EventType::PhoneRing => "phone_ring",
+        EventType::PrinterBroken => "printer_broken",
+        EventType::PackageDelivery => "package_delivery",
+        EventType::SBahnDelay => "sbahn_delay",
+        EventType::FireAlarmDrill => "fire_alarm_drill",
+        EventType::CakeInKitchen => "cake_in_kitchen",
+        EventType::AirConBroken => "air_con_broken",
+        EventType::InternetOutage => "internet_outage",
+    }
+    .to_string()
 }
 
 // ──────────────────────────────────────────────
@@ -350,15 +387,25 @@ mod tests {
         let path = dir.path().join("test.db");
         let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
+        let room = RoomId::new(1).unwrap();
+        let agent = AgentId::new(1).unwrap();
+
         let id = store
-            .insert_message("kueche", "thomas", "Guten Morgen!", Some("happy"), 1000, 42)
+            .insert_message(
+                room,
+                agent,
+                "Guten Morgen!",
+                Some(Emotion::Happy),
+                Timestamp(1000),
+                Tick(42),
+            )
             .await
             .unwrap();
         assert!(id > 0);
 
-        let messages = store.get_room_messages("kueche", 10).await.unwrap();
+        let messages = store.get_room_messages(room, 10).await.unwrap();
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].agent_name, "thomas");
+        assert_eq!(messages[0].agent_name, "AGENT-01");
         assert_eq!(messages[0].content, "Guten Morgen!");
         assert_eq!(messages[0].emotion, Some("happy".to_string()));
         assert_eq!(messages[0].timestamp_ms, 1000);
@@ -371,15 +418,16 @@ mod tests {
         let path = dir.path().join("test.db");
         let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
-        let participants = vec!["thomas".to_string(), "lisa".to_string()];
+        let room = RoomId::new(5).unwrap();
+        let participants = vec!["AGENT-01".to_string(), "AGENT-02".to_string()];
         let id = store
-            .insert_meeting("meetingraum-01", "Sprint Review", &participants, 9000)
+            .insert_meeting(room, "Sprint Review", &participants, Timestamp(9000))
             .await
             .unwrap();
         assert!(id > 0);
 
         store
-            .end_meeting(id, 10800, "Sprint goals achieved")
+            .end_meeting(id, Timestamp(10800), "Sprint goals achieved")
             .await
             .unwrap();
 
@@ -403,8 +451,10 @@ mod tests {
         let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
         // Insert something to trigger WAL file creation
+        let room = RoomId::new(1).unwrap();
+        let agent = AgentId::new(1).unwrap();
         store
-            .insert_message("lobby", "system", "test", None, 1, 1)
+            .insert_message(room, agent, "test", None, Timestamp(1), Tick(1))
             .await
             .unwrap();
 

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -1,1 +1,418 @@
-//! Async SQLite (Limbo) for cold storage: chat archive, observations.
+//! Async SQLite for cold storage: chat archive, observations.
+//!
+//! Cold storage tier for Project Sentinel using rusqlite (SQLite binding).
+//! Stores chat messages, meeting logs, observation data, and chaos events.
+//!
+//! Note: Uses rusqlite as fallback for limbo (v0.0.22) which lacks pragma setter
+//! support in its Rust binding. Same tables, same pragmas, sync API wrapped
+//! with tokio::task::spawn_blocking for async compatibility.
+
+use rusqlite::{params, Connection};
+use std::sync::{Arc, Mutex};
+use tracing::info;
+
+// ──────────────────────────────────────────────
+// SQL Constants
+// ──────────────────────────────────────────────
+
+const CREATE_MESSAGES: &str = "
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    emotion TEXT,
+    timestamp_ms INTEGER NOT NULL,
+    tick INTEGER NOT NULL
+)";
+
+const CREATE_IDX_MESSAGES_ROOM: &str =
+    "CREATE INDEX IF NOT EXISTS idx_messages_room ON messages(room_id, timestamp_ms)";
+
+const CREATE_MEETINGS: &str = "
+CREATE TABLE IF NOT EXISTS meetings (
+    id INTEGER PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    participants TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    summary TEXT
+)";
+
+const CREATE_OBSERVATIONS: &str = "
+CREATE TABLE IF NOT EXISTS observations (
+    id INTEGER PRIMARY KEY,
+    agent_name TEXT NOT NULL,
+    model TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    value REAL NOT NULL,
+    context TEXT,
+    timestamp_ms INTEGER NOT NULL
+)";
+
+const CREATE_IDX_OBSERVATIONS_AGENT: &str =
+    "CREATE INDEX IF NOT EXISTS idx_observations_agent ON observations(agent_name, metric, timestamp_ms)";
+
+const CREATE_CHAOS_EVENTS: &str = "
+CREATE TABLE IF NOT EXISTS chaos_events (
+    id INTEGER PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    target_room TEXT,
+    target_agent TEXT,
+    description TEXT NOT NULL,
+    timestamp_ms INTEGER NOT NULL
+)";
+
+// ──────────────────────────────────────────────
+// ChatStore
+// ──────────────────────────────────────────────
+
+/// Cold storage for chat messages, meetings, observations, and chaos events.
+///
+/// Uses rusqlite (sync SQLite) wrapped with Arc<Mutex<>> for thread-safe
+/// access from async contexts via spawn_blocking.
+pub struct ChatStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl ChatStore {
+    /// Open or create the chat store at the given path.
+    /// Runs performance pragmas and creates all tables.
+    pub async fn open(path: &str) -> anyhow::Result<Self> {
+        let path = path.to_string();
+        let conn = tokio::task::spawn_blocking(move || -> anyhow::Result<Connection> {
+            let conn = Connection::open(&path)?;
+
+            // Performance pragmas (PFLICHT laut Issue-Spec)
+            conn.execute_batch(
+                "PRAGMA journal_mode = WAL;
+                 PRAGMA synchronous = NORMAL;
+                 PRAGMA mmap_size = 268435456;
+                 PRAGMA page_size = 8192;",
+            )?;
+
+            // Create tables
+            conn.execute_batch(CREATE_MESSAGES)?;
+            conn.execute(CREATE_IDX_MESSAGES_ROOM, [])?;
+            conn.execute_batch(CREATE_MEETINGS)?;
+            conn.execute_batch(CREATE_OBSERVATIONS)?;
+            conn.execute(CREATE_IDX_OBSERVATIONS_AGENT, [])?;
+            conn.execute_batch(CREATE_CHAOS_EVENTS)?;
+
+            info!("ChatStore opened at {path}");
+            Ok(conn)
+        })
+        .await??;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    // === MESSAGES ===
+
+    /// Insert a chat message. Returns the rowid of the inserted row.
+    pub async fn insert_message(
+        &self,
+        room_id: &str,
+        agent_name: &str,
+        content: &str,
+        emotion: Option<&str>,
+        timestamp_ms: u64,
+        tick: u64,
+    ) -> anyhow::Result<i64> {
+        let conn = self.conn.clone();
+        let room_id = room_id.to_string();
+        let agent_name = agent_name.to_string();
+        let content = content.to_string();
+        let emotion = emotion.map(|e| e.to_string());
+        let ts = timestamp_ms as i64;
+        let t = tick as i64;
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            conn.execute(
+                "INSERT INTO messages (room_id, agent_name, content, emotion, timestamp_ms, tick) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![room_id, agent_name, content, emotion, ts, t],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .await?
+    }
+
+    /// Get messages for a room, ordered by timestamp descending.
+    pub async fn get_room_messages(
+        &self,
+        room_id: &str,
+        limit: u32,
+    ) -> anyhow::Result<Vec<MessageRow>> {
+        let conn = self.conn.clone();
+        let room_id = room_id.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<MessageRow>> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            let mut stmt = conn.prepare(
+                "SELECT id, room_id, agent_name, content, emotion, timestamp_ms, tick FROM messages WHERE room_id = ?1 ORDER BY timestamp_ms DESC LIMIT ?2",
+            )?;
+            let rows = stmt.query_map(params![room_id, limit], |row| {
+                Ok(MessageRow {
+                    id: row.get(0)?,
+                    room_id: row.get(1)?,
+                    agent_name: row.get(2)?,
+                    content: row.get(3)?,
+                    emotion: row.get(4)?,
+                    timestamp_ms: row.get::<_, i64>(5)? as u64,
+                    tick: row.get::<_, i64>(6)? as u64,
+                })
+            })?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row?);
+            }
+            Ok(results)
+        })
+        .await?
+    }
+
+    // === MEETINGS ===
+
+    /// Insert a meeting record. Participants are serialized as JSON array.
+    /// Returns the rowid of the inserted row.
+    pub async fn insert_meeting(
+        &self,
+        room_id: &str,
+        title: &str,
+        participants: &[String],
+        started_at: u64,
+    ) -> anyhow::Result<i64> {
+        let conn = self.conn.clone();
+        let room_id = room_id.to_string();
+        let title = title.to_string();
+        let participants_json = serde_json::to_string(participants)?;
+        let started = started_at as i64;
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            conn.execute(
+                "INSERT INTO meetings (room_id, title, participants, started_at) VALUES (?1, ?2, ?3, ?4)",
+                params![room_id, title, participants_json, started],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .await?
+    }
+
+    /// End a meeting by setting ended_at and summary.
+    pub async fn end_meeting(
+        &self,
+        meeting_id: i64,
+        ended_at: u64,
+        summary: &str,
+    ) -> anyhow::Result<()> {
+        let conn = self.conn.clone();
+        let ended = ended_at as i64;
+        let summary = summary.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            conn.execute(
+                "UPDATE meetings SET ended_at = ?1, summary = ?2 WHERE id = ?3",
+                params![ended, summary, meeting_id],
+            )?;
+            Ok(())
+        })
+        .await?
+    }
+
+    // === OBSERVATIONS ===
+
+    /// Insert an observation data point. Returns the rowid of the inserted row.
+    pub async fn insert_observation(
+        &self,
+        agent_name: &str,
+        model: &str,
+        metric: &str,
+        value: f64,
+        context: Option<&str>,
+        timestamp_ms: u64,
+    ) -> anyhow::Result<i64> {
+        let conn = self.conn.clone();
+        let agent_name = agent_name.to_string();
+        let model = model.to_string();
+        let metric = metric.to_string();
+        let context = context.map(|c| c.to_string());
+        let ts = timestamp_ms as i64;
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            conn.execute(
+                "INSERT INTO observations (agent_name, model, metric, value, context, timestamp_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![agent_name, model, metric, value, context, ts],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .await?
+    }
+
+    // === CHAOS EVENTS ===
+
+    /// Insert a chaos event. Returns the rowid of the inserted row.
+    pub async fn insert_chaos_event(
+        &self,
+        event_type: &str,
+        target_room: Option<&str>,
+        target_agent: Option<&str>,
+        description: &str,
+        timestamp_ms: u64,
+    ) -> anyhow::Result<i64> {
+        let conn = self.conn.clone();
+        let event_type = event_type.to_string();
+        let target_room = target_room.map(|r| r.to_string());
+        let target_agent = target_agent.map(|a| a.to_string());
+        let description = description.to_string();
+        let ts = timestamp_ms as i64;
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            conn.execute(
+                "INSERT INTO chaos_events (event_type, target_room, target_agent, description, timestamp_ms) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![event_type, target_room, target_agent, description, ts],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .await?
+    }
+
+    /// Get a reference to the inner connection for testing.
+    #[cfg(test)]
+    fn conn(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.conn.lock().unwrap()
+    }
+}
+
+// ──────────────────────────────────────────────
+// Row Types
+// ──────────────────────────────────────────────
+
+/// Row type for message queries.
+#[derive(Debug, Clone)]
+pub struct MessageRow {
+    pub id: i64,
+    pub room_id: String,
+    pub agent_name: String,
+    pub content: String,
+    pub emotion: Option<String>,
+    pub timestamp_ms: u64,
+    pub tick: u64,
+}
+
+// ──────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_open_creates_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
+
+        // Verify all 4 tables exist by querying them
+        let conn = store.conn();
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM meetings", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM observations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM chaos_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_message_insert_and_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
+
+        let id = store
+            .insert_message("kueche", "thomas", "Guten Morgen!", Some("happy"), 1000, 42)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let messages = store.get_room_messages("kueche", 10).await.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].agent_name, "thomas");
+        assert_eq!(messages[0].content, "Guten Morgen!");
+        assert_eq!(messages[0].emotion, Some("happy".to_string()));
+        assert_eq!(messages[0].timestamp_ms, 1000);
+        assert_eq!(messages[0].tick, 42);
+    }
+
+    #[tokio::test]
+    async fn test_meeting_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
+
+        let participants = vec!["thomas".to_string(), "lisa".to_string()];
+        let id = store
+            .insert_meeting("meetingraum-01", "Sprint Review", &participants, 9000)
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        store
+            .end_meeting(id, 10800, "Sprint goals achieved")
+            .await
+            .unwrap();
+
+        // Verify the meeting was updated
+        let conn = store.conn();
+        let (ended_at, summary): (i64, String) = conn
+            .query_row(
+                "SELECT ended_at, summary FROM meetings WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(ended_at, 10800);
+        assert_eq!(summary, "Sprint goals achieved");
+    }
+
+    #[tokio::test]
+    async fn test_wal_mode_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
+
+        // Insert something to trigger WAL file creation
+        store
+            .insert_message("lobby", "system", "test", None, 1, 1)
+            .await
+            .unwrap();
+
+        // Verify WAL mode via pragma
+        let conn = store.conn();
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #8: sentinel-limbo - Cold Storage for Project Sentinel.

### What

- **ChatStore** with async API (tokio::task::spawn_blocking wrapping sync rusqlite)
- **4 tables**: messages, meetings, observations, chaos_events
- **Performance pragmas**: WAL, NORMAL sync, 256MB mmap, 8K page_size
- **4 tests**: table creation, message roundtrip, meeting lifecycle, WAL mode verification

### Backend Decision: rusqlite (Fallback)

Limbo v0.0.22 was evaluated but **lacks pragma setter support** in its Rust binding:
- `pragma_query()` is read-only
- `execute()` rejects PRAGMA statements ("Parse error: Not a valid pragma name")
- Performance pragmas (WAL, synchronous, mmap, page_size) are mandatory per spec

Fallback to rusqlite as explicitly allowed by Issue #8 spec. Same tables, same pragmas, sync API wrapped with `tokio::task::spawn_blocking`.

### Test Evidence

```
running 4 tests
test tests::test_open_creates_tables ... ok
test tests::test_wal_mode_active ... ok
test tests::test_message_insert_and_query ... ok
test tests::test_meeting_lifecycle ... ok
test result: ok. 4 passed; 0 failed; 0 ignored
```

### Acceptance Criteria Checklist

- [x] `cargo remote -- test -p sentinel-limbo` runs without errors
- [x] All 4 tables created at `open()` (IF NOT EXISTS)
- [x] Performance pragmas set at initialization (WAL, NORMAL, mmap, page_size)
- [x] Messages Insert + Query roundtrip proven
- [x] Meeting Lifecycle works (create + end)
- [x] WAL mode active (verified via PRAGMA journal_mode)
- [x] `cargo remote -- check --workspace` compiles
- [x] Limbo fallback to rusqlite documented

Closes #8