### PR TITLE
fix: cargo fmt, clippy warnings, and missing CHANGELOG

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -157,10 +157,14 @@ _Hier werden Erkenntnisse dokumentiert die waehrend der Implementierung gewonnen
 _Format: Datum, Kontext, was gelernt wurde._
 
 ### NIEMALS (gelernt)
-_(noch leer - wird waehrend Implementierung befuellt)_
+- 2026-02-11: PR mergen ohne `make ci` (fmt+clippy+test) lokal/remote verifiziert zu haben. CI war FAILING nach Merge.
 
 ### IMMER (gelernt)
-_(noch leer - wird waehrend Implementierung befuellt)_
+- 2026-02-11: `cargo fmt --all -- --check` + `cargo clippy -- -D warnings` VOR Push ausfuehren. Nicht nur `cargo test`.
+- 2026-02-11: CHANGELOG.md bei JEDEM PR aktualisieren, nicht erst nachtraeglich.
+- 2026-02-11: Consumer-Crates muessen Feature-Gates in eigener Cargo.toml deklarieren: `telemetry = ["sentinel-telemetry/telemetry"]`
+- 2026-02-11: `cargo remote -- fmt` synct formatierte Files NICHT zurueck. `cargo fmt` lokal ausfuehren (ist kein Build).
 
 ### Kontext-Wissen
-_(noch leer - wird waehrend Implementierung befuellt)_
+- 2026-02-11: BioStateUpdate::new() hat bewusst viele Args (10) - `#[allow(clippy::too_many_arguments)]` ist ok.
+- 2026-02-11: rustfmt Version auf Build-Server und lokal koennen abweichen - IMMER CI-kompatible Version verifizieren.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI/CD with path-based filtering (Rust, Go, Bun, FlatBuffer)
 - Security audit workflow (cargo audit, govulncheck)
 - Release automation with changelog extraction
+- `sentinel-common` crate: newtypes (AgentId, RoomId, Tick, Timestamp), domain structs, validation
+- `sentinel-zenoh` crate: Zenoh pub/sub wrapper with topic management
+- `sentinel-redb` crate: embedded key-value store for agent/room state
+- `sentinel-limbo` crate: SQLite-based message and event log
+- `sentinel-telemetry` crate: cross-cutting observability (metrics, health, errors, export)
+- Telemetry retrofit: Counter/Histogram instrumentation in redb, zenoh, limbo crates
+- TelemetryTransport trait for decoupled metric publishing
+
+### Fixed
+
+- Clippy `manual_range_contains` warnings in sentinel-common validation
+- Clippy `type_complexity` warning in telemetry test mock
+- `cargo fmt` formatting across workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "anyhow",
  "rusqlite",
  "sentinel-common",
+ "sentinel-telemetry",
  "serde",
  "serde_json",
  "tempfile",
@@ -2480,6 +2481,7 @@ dependencies = [
  "anyhow",
  "redb",
  "sentinel-common",
+ "sentinel-telemetry",
  "serde",
  "tempfile",
  "tracing",
@@ -2520,6 +2522,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "sentinel-common",
+ "sentinel-telemetry",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -92,8 +92,16 @@ mod tests {
     #[test]
     fn test_bio_state_valid() {
         let bio = BioStateUpdate::new(
-            AgentId(1), 45.5, 72.0, 95.0, 30.0, 55.0, 20.0, 80.0,
-            Timestamp(2000), Tick(100),
+            AgentId(1),
+            45.5,
+            72.0,
+            95.0,
+            30.0,
+            55.0,
+            20.0,
+            80.0,
+            Timestamp(2000),
+            Tick(100),
         );
         assert!(bio.is_ok());
         let bio = bio.unwrap();
@@ -104,20 +112,46 @@ mod tests {
     fn test_bio_state_boundary_valid() {
         // Exact boundaries: 0.0 and 100.0 are valid
         assert!(BioStateUpdate::new(
-            AgentId(1), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            Timestamp(0), Tick(0),
-        ).is_ok());
+            AgentId(1),
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_ok());
         assert!(BioStateUpdate::new(
-            AgentId(1), 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0,
-            Timestamp(0), Tick(0),
-        ).is_ok());
+            AgentId(1),
+            100.0,
+            100.0,
+            100.0,
+            100.0,
+            100.0,
+            100.0,
+            100.0,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_ok());
     }
 
     #[test]
     fn test_bio_state_invalid_negative() {
         let result = BioStateUpdate::new(
-            AgentId(1), -1.0, 72.0, 95.0, 30.0, 55.0, 20.0, 80.0,
-            Timestamp(2000), Tick(100),
+            AgentId(1),
+            -1.0,
+            72.0,
+            95.0,
+            30.0,
+            55.0,
+            20.0,
+            80.0,
+            Timestamp(2000),
+            Tick(100),
         );
         assert!(result.is_err());
     }
@@ -125,8 +159,16 @@ mod tests {
     #[test]
     fn test_bio_state_invalid_over_100() {
         let result = BioStateUpdate::new(
-            AgentId(1), 45.5, 101.0, 95.0, 30.0, 55.0, 20.0, 80.0,
-            Timestamp(2000), Tick(100),
+            AgentId(1),
+            45.5,
+            101.0,
+            95.0,
+            30.0,
+            55.0,
+            20.0,
+            80.0,
+            Timestamp(2000),
+            Tick(100),
         );
         assert!(result.is_err());
     }
@@ -136,8 +178,12 @@ mod tests {
     #[test]
     fn test_mood_update_valid() {
         let mood = MoodUpdate::new(
-            AgentId(1), 0.5, 0.7, Emotion::Happy,
-            Timestamp(3000), Tick(150),
+            AgentId(1),
+            0.5,
+            0.7,
+            Emotion::Happy,
+            Timestamp(3000),
+            Tick(150),
         );
         assert!(mood.is_ok());
     }
@@ -145,37 +191,67 @@ mod tests {
     #[test]
     fn test_mood_update_boundary_valid() {
         assert!(MoodUpdate::new(
-            AgentId(1), -1.0, 0.0, Emotion::Neutral,
-            Timestamp(0), Tick(0),
-        ).is_ok());
+            AgentId(1),
+            -1.0,
+            0.0,
+            Emotion::Neutral,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_ok());
         assert!(MoodUpdate::new(
-            AgentId(1), 1.0, 1.0, Emotion::Excited,
-            Timestamp(0), Tick(0),
-        ).is_ok());
+            AgentId(1),
+            1.0,
+            1.0,
+            Emotion::Excited,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_ok());
     }
 
     #[test]
     fn test_mood_update_invalid_valence() {
         assert!(MoodUpdate::new(
-            AgentId(1), -1.1, 0.5, Emotion::Neutral,
-            Timestamp(0), Tick(0),
-        ).is_err());
+            AgentId(1),
+            -1.1,
+            0.5,
+            Emotion::Neutral,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_err());
         assert!(MoodUpdate::new(
-            AgentId(1), 1.1, 0.5, Emotion::Neutral,
-            Timestamp(0), Tick(0),
-        ).is_err());
+            AgentId(1),
+            1.1,
+            0.5,
+            Emotion::Neutral,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_err());
     }
 
     #[test]
     fn test_mood_update_invalid_arousal() {
         assert!(MoodUpdate::new(
-            AgentId(1), 0.5, -0.1, Emotion::Neutral,
-            Timestamp(0), Tick(0),
-        ).is_err());
+            AgentId(1),
+            0.5,
+            -0.1,
+            Emotion::Neutral,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_err());
         assert!(MoodUpdate::new(
-            AgentId(1), 0.5, 1.1, Emotion::Neutral,
-            Timestamp(0), Tick(0),
-        ).is_err());
+            AgentId(1),
+            0.5,
+            1.1,
+            Emotion::Neutral,
+            Timestamp(0),
+            Tick(0),
+        )
+        .is_err());
     }
 
     // ── Serialization ───────────────────────────

--- a/crates/sentinel-common/src/types.rs
+++ b/crates/sentinel-common/src/types.rs
@@ -29,7 +29,7 @@ pub struct AgentId(pub u16);
 
 impl AgentId {
     pub fn new(id: u16) -> Result<Self, ValidationError> {
-        if id >= 1 && id <= 54 {
+        if (1..=54).contains(&id) {
             Ok(Self(id))
         } else {
             Err(ValidationError::InvalidAgentId(id))
@@ -62,7 +62,9 @@ impl fmt::Display for RoomId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 pub struct Tick(pub u64);
 
 impl fmt::Display for Tick {
@@ -71,7 +73,9 @@ impl fmt::Display for Tick {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
 pub struct Timestamp(pub u64);
 
 impl fmt::Display for Timestamp {
@@ -168,6 +172,7 @@ pub struct BioStateUpdate {
 }
 
 impl BioStateUpdate {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         agent_id: AgentId,
         hunger: f32,
@@ -181,7 +186,7 @@ impl BioStateUpdate {
         tick: Tick,
     ) -> Result<Self, ValidationError> {
         fn validate(field: &str, value: f32) -> Result<(), ValidationError> {
-            if value >= 0.0 && value <= 100.0 {
+            if (0.0..=100.0).contains(&value) {
                 Ok(())
             } else {
                 Err(ValidationError::OutOfRange {
@@ -245,7 +250,7 @@ impl MoodUpdate {
         timestamp: Timestamp,
         tick: Tick,
     ) -> Result<Self, ValidationError> {
-        if valence < -1.0 || valence > 1.0 {
+        if !(-1.0..=1.0).contains(&valence) {
             return Err(ValidationError::OutOfRange {
                 field: "valence".to_string(),
                 value: valence,
@@ -253,7 +258,7 @@ impl MoodUpdate {
                 max: 1.0,
             });
         }
-        if arousal < 0.0 || arousal > 1.0 {
+        if !(0.0..=1.0).contains(&arousal) {
             return Err(ValidationError::OutOfRange {
                 field: "arousal".to_string(),
                 value: arousal,

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -243,7 +243,9 @@ impl ChatStore {
         let summary = summary.to_string();
 
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let conn = conn.lock().map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+            let conn = conn
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
             conn.execute(
                 "UPDATE meetings SET ended_at = ?1, summary = ?2 WHERE id = ?3",
                 params![ended, summary, meeting_id],

--- a/crates/sentinel-telemetry/src/export.rs
+++ b/crates/sentinel-telemetry/src/export.rs
@@ -33,7 +33,11 @@ use crate::metrics::{MetricsRegistry, MetricsSnapshot};
 /// Also useful for testing (mock transport) and alternative outputs.
 pub trait TelemetryTransport: Send + Sync {
     /// Publish serialized data to a topic.
-    fn publish(&self, topic: &str, payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    fn publish(
+        &self,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
 // ──────────────────────────────────────────────
@@ -111,25 +115,25 @@ impl<T: TelemetryTransport> TelemetryExporter<T> {
         for (name, value) in &counters {
             // Extract subsystem from metric name: sentinel.{subsystem}.{op}.{type}
             if let Some(subsystem) = extract_subsystem(name) {
-                let entry = subsystems
-                    .entry(subsystem.to_string())
-                    .or_insert_with(|| crate::metrics::SubsystemMetrics {
+                let entry = subsystems.entry(subsystem.to_string()).or_insert_with(|| {
+                    crate::metrics::SubsystemMetrics {
                         health: crate::health::HealthStatus::Healthy,
                         counters: std::collections::HashMap::new(),
                         histograms: std::collections::HashMap::new(),
-                    });
+                    }
+                });
                 entry.counters.insert(name.clone(), *value);
             }
         }
         for (name, snap) in histograms {
             if let Some(subsystem) = extract_subsystem(&name) {
-                let entry = subsystems
-                    .entry(subsystem.to_string())
-                    .or_insert_with(|| crate::metrics::SubsystemMetrics {
+                let entry = subsystems.entry(subsystem.to_string()).or_insert_with(|| {
+                    crate::metrics::SubsystemMetrics {
                         health: crate::health::HealthStatus::Healthy,
                         counters: std::collections::HashMap::new(),
                         histograms: std::collections::HashMap::new(),
-                    });
+                    }
+                });
                 entry.histograms.insert(name, snap);
             }
         }
@@ -187,13 +191,15 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    type MessageLog = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
+
     /// Mock transport that records all published messages.
     struct MockTransport {
-        messages: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
+        messages: MessageLog,
     }
 
     impl MockTransport {
-        fn new() -> (Self, Arc<Mutex<Vec<(String, Vec<u8>)>>>) {
+        fn new() -> (Self, MessageLog) {
             let messages = Arc::new(Mutex::new(Vec::new()));
             (
                 Self {
@@ -205,7 +211,11 @@ mod tests {
     }
 
     impl TelemetryTransport for MockTransport {
-        fn publish(&self, topic: &str, payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        fn publish(
+            &self,
+            topic: &str,
+            payload: &[u8],
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             self.messages
                 .lock()
                 .unwrap()
@@ -216,8 +226,8 @@ mod tests {
 
     #[test]
     fn test_export_error_event() {
-        use sentinel_common::{AgentId, Tick, Timestamp};
         use crate::errors::{ErrorEvent, ErrorSeverity};
+        use sentinel_common::{AgentId, Tick, Timestamp};
 
         let (transport, messages) = MockTransport::new();
         let exporter = TelemetryExporter::new(transport, ExporterConfig::default());
@@ -246,7 +256,10 @@ mod tests {
     #[test]
     fn test_extract_subsystem() {
         assert_eq!(extract_subsystem("sentinel.redb.read.count"), Some("redb"));
-        assert_eq!(extract_subsystem("sentinel.zenoh.publish.latency_us"), Some("zenoh"));
+        assert_eq!(
+            extract_subsystem("sentinel.zenoh.publish.latency_us"),
+            Some("zenoh")
+        );
         assert_eq!(extract_subsystem("invalid"), None);
         assert_eq!(extract_subsystem("other.prefix.op"), None);
     }

--- a/crates/sentinel-telemetry/src/health.rs
+++ b/crates/sentinel-telemetry/src/health.rs
@@ -86,11 +86,7 @@ impl HealthRegistry {
 
     /// Register a health check for a subsystem.
     /// Overwrites any existing check with the same name.
-    pub fn register(
-        &self,
-        name: &str,
-        check: impl Fn() -> HealthStatus + Send + Sync + 'static,
-    ) {
+    pub fn register(&self, name: &str, check: impl Fn() -> HealthStatus + Send + Sync + 'static) {
         let mut checks = self.checks.write().unwrap();
         checks.insert(name.to_string(), Box::new(check));
     }
@@ -168,9 +164,7 @@ mod tests {
         };
 
         registry.register("zenoh", || HealthStatus::Healthy);
-        registry.register("redb", || {
-            HealthStatus::Degraded("disk slow".to_string())
-        });
+        registry.register("redb", || HealthStatus::Degraded("disk slow".to_string()));
 
         let results = registry.check_all();
         assert_eq!(results.len(), 2);

--- a/crates/sentinel-telemetry/src/lib.rs
+++ b/crates/sentinel-telemetry/src/lib.rs
@@ -15,10 +15,10 @@ pub use context::{
     TraceContext, TELEMETRY_ERRORS, TELEMETRY_HEALTH, TELEMETRY_METRICS, TELEMETRY_TRACES,
 };
 pub use errors::{ClassifiedError, ErrorEvent, ErrorSeverity};
+pub use export::{ExporterConfig, TelemetryExporter, TelemetryTransport};
 pub use health::{HealthRegistry, HealthSnapshot, HealthStatus, SubsystemHealth};
 #[cfg(feature = "telemetry")]
 pub use logging::{init_logging, init_logging_dev};
-pub use export::{ExporterConfig, TelemetryExporter, TelemetryTransport};
 pub use metrics::{
     metric_name, Counter, Histogram, MetricsRegistry, MetricsSnapshot, SubsystemMetrics,
 };

--- a/crates/sentinel-telemetry/src/logging.rs
+++ b/crates/sentinel-telemetry/src/logging.rs
@@ -38,8 +38,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 /// Only available with the `telemetry` feature (default: enabled).
 #[cfg(feature = "telemetry")]
 pub fn init_logging() {
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     tracing_subscriber::registry()
         .with(filter)
@@ -55,8 +54,7 @@ pub fn init_logging() {
 /// Only available with the `telemetry` feature (default: enabled).
 #[cfg(feature = "telemetry")]
 pub fn init_logging_dev() {
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
 
     tracing_subscriber::registry()
         .with(filter)
@@ -75,8 +73,7 @@ mod tests {
     #[test]
     fn test_init_logging_does_not_panic() {
         // try_init statt init um Doppel-Initialisierung zu vermeiden
-        let filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
         let _ = tracing_subscriber::registry()
             .with(filter)
@@ -86,8 +83,7 @@ mod tests {
 
     #[test]
     fn test_init_logging_dev_does_not_panic() {
-        let filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
 
         let _ = tracing_subscriber::registry()
             .with(filter)

--- a/crates/sentinel-telemetry/src/metrics.rs
+++ b/crates/sentinel-telemetry/src/metrics.rs
@@ -101,9 +101,7 @@ impl Histogram {
         sorted.dedup();
 
         let bucket_count = sorted.len() + 1; // +1 fuer +Inf
-        let buckets = (0..bucket_count)
-            .map(|_| AtomicU64::new(0))
-            .collect();
+        let buckets = (0..bucket_count).map(|_| AtomicU64::new(0)).collect();
 
         Self {
             boundaries: sorted,
@@ -131,12 +129,7 @@ impl Histogram {
             let new_bits = new.to_bits();
             if self
                 .sum_bits
-                .compare_exchange_weak(
-                    current_bits,
-                    new_bits,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                )
+                .compare_exchange_weak(current_bits, new_bits, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
                 break;
@@ -250,7 +243,11 @@ impl MetricsRegistry {
         }
         // Slow path: write lock
         let mut counters = self.counters.write().unwrap();
-        Arc::clone(counters.entry(name.to_string()).or_insert_with(|| Arc::new(Counter::new())))
+        Arc::clone(
+            counters
+                .entry(name.to_string())
+                .or_insert_with(|| Arc::new(Counter::new())),
+        )
     }
 
     /// Get or create a histogram by name with given bucket boundaries.
@@ -286,7 +283,11 @@ impl MetricsRegistry {
             .iter()
             .filter_map(|(k, v)| {
                 let val = v.get();
-                if val > 0 { Some((k.clone(), val)) } else { None }
+                if val > 0 {
+                    Some((k.clone(), val))
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -294,7 +295,11 @@ impl MetricsRegistry {
             .iter()
             .filter_map(|(k, v)| {
                 let snap = v.snapshot();
-                if snap.count > 0 { Some((k.clone(), snap)) } else { None }
+                if snap.count > 0 {
+                    Some((k.clone(), snap))
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -460,15 +465,18 @@ mod tests {
 
     #[test]
     fn test_metrics_snapshot_serializable() {
-        use sentinel_common::{Tick, Timestamp};
         use crate::health::HealthStatus;
+        use sentinel_common::{Tick, Timestamp};
 
         let mut subsystems = HashMap::new();
-        subsystems.insert("redb".to_string(), SubsystemMetrics {
-            health: HealthStatus::Healthy,
-            counters: HashMap::from([("ops".to_string(), 42)]),
-            histograms: HashMap::new(),
-        });
+        subsystems.insert(
+            "redb".to_string(),
+            SubsystemMetrics {
+                health: HealthStatus::Healthy,
+                counters: HashMap::from([("ops".to_string(), 42)]),
+                histograms: HashMap::new(),
+            },
+        );
 
         let snap = MetricsSnapshot {
             timestamp: Timestamp(1000),

--- a/crates/sentinel-zenoh/src/lib.rs
+++ b/crates/sentinel-zenoh/src/lib.rs
@@ -81,21 +81,14 @@ impl SentinelBus {
 
     /// Publish an agent action.
     #[instrument(skip(self, payload), level = "trace", fields(agent_id = %agent_id))]
-    pub async fn publish_action(
-        &self,
-        agent_id: AgentId,
-        payload: &[u8],
-    ) -> anyhow::Result<()> {
+    pub async fn publish_action(&self, agent_id: AgentId, payload: &[u8]) -> anyhow::Result<()> {
         self.publish(&topics::agent_action(&agent_id.to_string()), payload)
             .await
     }
 
     /// Subscribe to an agent's perception channel.
     #[instrument(skip(self), level = "debug", fields(agent_id = %agent_id))]
-    pub async fn subscribe_perception(
-        &self,
-        agent_id: AgentId,
-    ) -> anyhow::Result<BusSubscriber> {
+    pub async fn subscribe_perception(&self, agent_id: AgentId) -> anyhow::Result<BusSubscriber> {
         self.subscribe(&topics::agent_perception(&agent_id.to_string()))
             .await
     }
@@ -115,13 +108,8 @@ impl SentinelBus {
     /// Publish a global simulation tick.
     /// Uses raw numeric tick value for compact topic paths (e.g. sentinel/physics/tick/42).
     #[instrument(skip(self, payload), level = "trace", fields(tick = %tick))]
-    pub async fn publish_tick(
-        &self,
-        tick: Tick,
-        payload: &[u8],
-    ) -> anyhow::Result<()> {
-        self.publish(&topics::physics_tick(tick.0), payload)
-            .await
+    pub async fn publish_tick(&self, tick: Tick, payload: &[u8]) -> anyhow::Result<()> {
+        self.publish(&topics::physics_tick(tick.0), payload).await
     }
 
     /// Publish a chaos event.
@@ -152,11 +140,8 @@ mod tests {
             .expect("Failed to publish");
 
         // Receive with timeout
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            subscriber.recv_async(),
-        )
-        .await;
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(5), subscriber.recv_async()).await;
 
         assert!(result.is_ok(), "Should receive message within timeout");
         let sample = result.unwrap().unwrap();

--- a/crates/sentinel-zenoh/src/topics.rs
+++ b/crates/sentinel-zenoh/src/topics.rs
@@ -62,10 +62,7 @@ mod tests {
     #[test]
     fn test_agent_topics() {
         assert_eq!(agent_action("thomas"), "sentinel/agent/thomas/action");
-        assert_eq!(
-            agent_perception("lisa"),
-            "sentinel/agent/lisa/perception"
-        );
+        assert_eq!(agent_perception("lisa"), "sentinel/agent/lisa/perception");
         assert_eq!(agent_state("andreas"), "sentinel/agent/andreas/state");
     }
 
@@ -83,15 +80,15 @@ mod tests {
     fn test_physics_tick() {
         assert_eq!(physics_tick(0), "sentinel/physics/tick/0");
         assert_eq!(physics_tick(42), "sentinel/physics/tick/42");
-        assert_eq!(physics_tick(u64::MAX), format!("sentinel/physics/tick/{}", u64::MAX));
+        assert_eq!(
+            physics_tick(u64::MAX),
+            format!("sentinel/physics/tick/{}", u64::MAX)
+        );
     }
 
     #[test]
     fn test_cortex_inject() {
-        assert_eq!(
-            cortex_inject("thomas"),
-            "sentinel/cortex/inject/thomas"
-        );
+        assert_eq!(cortex_inject("thomas"), "sentinel/cortex/inject/thomas");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Run `cargo fmt --all` across workspace (10 files had formatting issues)
- Fix 5 clippy `-D warnings` errors: `manual_range_contains` (3x), `too_many_arguments`, `type_complexity`
- Add CHANGELOG.md entries for all Sprint 1 crates (common, zenoh, redb, limbo, telemetry)
- Document project learnings in `.claude/CLAUDE.md`

## Context
CI was failing on main after PR #35 merge due to pre-existing fmt issues and clippy warnings that were not caught before push. This fix ensures `make ci` (lint-all + test) passes cleanly.

## Test plan
- [x] `cargo fmt --all -- --check` passes (zero diffs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)