### PR TITLE
deps(redb): upgrade redb from 2.x to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `redb` upgraded from 2.x to 3.1.0 (new `ReadableDatabase` trait, explicit type annotations for `AccessGuard`)
 - CLAUDE.md restructured per `/claudemd` best practices (382→229 lines, domain knowledge moved to rules/)
 
 - All GitHub Actions updated to latest versions and pinned to full commit SHAs (17 actions across 10 workflows)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.dependencies]
 bevy_ecs = "0.15"
 zenoh = "1.1"
-redb = "2.4"
+redb = "3.1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 flatbuffers = "25.12"

--- a/crates/sentinel-redb/src/lib.rs
+++ b/crates/sentinel-redb/src/lib.rs
@@ -1,6 +1,6 @@
 //! redb ACID KV-store for hot agent state and relationships.
 
-use redb::{Database, ReadableTable, TableDefinition};
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use sentinel_common::{AgentId, RoomId};
 use tracing::instrument;
 
@@ -46,7 +46,9 @@ impl StateStore {
         let start = std::time::Instant::now();
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(AGENT_STATE)?;
-        let result = Ok(table.get(agent_id.0)?.map(|v| v.value().to_vec()));
+        let result = Ok(table
+            .get(agent_id.0)?
+            .map(|v: redb::AccessGuard<'_, &[u8]>| v.value().to_vec()));
         #[cfg(feature = "telemetry")]
         {
             let reg = sentinel_telemetry::MetricsRegistry::global();
@@ -106,7 +108,7 @@ impl StateStore {
         let mut ids = Vec::new();
         let iter = table.iter()?;
         for entry in iter {
-            let (key, _) = entry?;
+            let (key, _): (redb::AccessGuard<'_, u16>, redb::AccessGuard<'_, &[u8]>) = entry?;
             ids.push(AgentId(key.value()));
         }
         Ok(ids)
@@ -121,7 +123,9 @@ impl StateStore {
         let key = relationship_key(a, b);
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(RELATIONSHIPS)?;
-        let result = Ok(table.get(key)?.map(|v| v.value().to_vec()));
+        let result = Ok(table
+            .get(key)?
+            .map(|v: redb::AccessGuard<'_, &[u8]>| v.value().to_vec()));
         #[cfg(feature = "telemetry")]
         {
             let reg = sentinel_telemetry::MetricsRegistry::global();
@@ -161,7 +165,9 @@ impl StateStore {
         let start = std::time::Instant::now();
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(PERSONALITY)?;
-        let result = Ok(table.get(agent_id.0)?.map(|v| v.value().to_vec()));
+        let result = Ok(table
+            .get(agent_id.0)?
+            .map(|v: redb::AccessGuard<'_, &[u8]>| v.value().to_vec()));
         #[cfg(feature = "telemetry")]
         {
             let reg = sentinel_telemetry::MetricsRegistry::global();
@@ -200,7 +206,9 @@ impl StateStore {
         let start = std::time::Instant::now();
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(ROOM_STATE)?;
-        let result = Ok(table.get(room_id.0)?.map(|v| v.value().to_vec()));
+        let result = Ok(table
+            .get(room_id.0)?
+            .map(|v: redb::AccessGuard<'_, &[u8]>| v.value().to_vec()));
         #[cfg(feature = "telemetry")]
         {
             let reg = sentinel_telemetry::MetricsRegistry::global();
@@ -332,7 +340,7 @@ mod tests {
         store.set_agent_state(agent(1), b"small").unwrap();
         let path = dir.path().join("test.redb");
         let size = std::fs::metadata(&path).unwrap().len();
-        // redb 2.x mit 4 Tabellen benoetigt ~1.5MB CoW B-Tree Overhead
+        // redb 3.x mit 4 Tabellen: ~1MB (CoW B-Tree Overhead)
         assert!(
             size < 2_097_152,
             "DB should be <2MB initially, was {size} bytes"


### PR DESCRIPTION
## Summary
- Upgrades `redb` from 2.x to 3.1.0 (major version bump)
- Adds `ReadableDatabase` trait import (required since 3.0)
- Adds explicit `AccessGuard` type annotations for closures
- No file format migration needed (we create fresh databases)

Closes #43 (supersedes Dependabot PR)

## Test plan
- [x] `cargo remote -- test --workspace` (122 tests, 0 failures)
- [x] `cargo remote -- clippy -- -D warnings` (zero warnings)
- [x] `cargo fmt --check` (clean)
- [ ] CI cargo-deny check (licenses, advisories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)