### PR TITLE
refactor: move PsiMetrics to sentinel-common for cross-crate reuse

### DIFF
--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod agent_config;
 pub mod components;
+pub mod psi;
 pub mod room;
 pub mod types;
 

--- a/crates/sentinel-common/src/psi.rs
+++ b/crates/sentinel-common/src/psi.rs
@@ -1,0 +1,72 @@
+//! PSI (Pressure Stall Information) types and parsing.
+//!
+//! Shared between sentinel-sandbox (cgroups) and sentinel-ebpf (monitoring).
+
+use anyhow::{anyhow, Result};
+
+/// PSI (Pressure Stall Information) Metriken.
+#[derive(Debug, Clone, Default)]
+pub struct PsiMetrics {
+    pub avg10: f64,
+    pub avg60: f64,
+    pub avg300: f64,
+    pub total: u64,
+}
+
+/// Parsed eine PSI-Zeile im Format: "some avg10=0.00 avg60=0.00 avg300=0.00 total=0"
+pub fn parse_psi(content: &str) -> Result<PsiMetrics> {
+    // Finde die erste Zeile die mit "some" beginnt
+    let line = content
+        .lines()
+        .find(|l| l.starts_with("some"))
+        .ok_or_else(|| anyhow!("No 'some' line found in PSI content"))?;
+
+    let mut metrics = PsiMetrics::default();
+
+    // Parse die Werte
+    for part in line.split_whitespace().skip(1) {
+        // skip "some"
+        if let Some((key, value)) = part.split_once('=') {
+            match key {
+                "avg10" => metrics.avg10 = value.parse()?,
+                "avg60" => metrics.avg60 = value.parse()?,
+                "avg300" => metrics.avg300 = value.parse()?,
+                "total" => metrics.total = value.parse()?,
+                _ => {}
+            }
+        }
+    }
+
+    Ok(metrics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn psi_parse_some_line() {
+        let content =
+            "some avg10=1.50 avg60=2.30 avg300=0.10 total=12345\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0";
+        let metrics = parse_psi(content).unwrap();
+        assert_eq!(metrics.avg10, 1.50);
+        assert_eq!(metrics.avg60, 2.30);
+        assert_eq!(metrics.avg300, 0.10);
+        assert_eq!(metrics.total, 12345);
+    }
+
+    #[test]
+    fn psi_parse_missing_some_line() {
+        let content = "full avg10=0.00 avg60=0.00 avg300=0.00 total=0";
+        assert!(parse_psi(content).is_err());
+    }
+
+    #[test]
+    fn psi_default_is_zero() {
+        let metrics = PsiMetrics::default();
+        assert_eq!(metrics.avg10, 0.0);
+        assert_eq!(metrics.avg60, 0.0);
+        assert_eq!(metrics.avg300, 0.0);
+        assert_eq!(metrics.total, 0);
+    }
+}

--- a/crates/sentinel-sandbox/Cargo.toml
+++ b/crates/sentinel-sandbox/Cargo.toml
@@ -7,4 +7,5 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+sentinel-common = { path = "../sentinel-common" }
 tracing = { workspace = true }

--- a/crates/sentinel-sandbox/src/cgroups.rs
+++ b/crates/sentinel-sandbox/src/cgroups.rs
@@ -1,6 +1,7 @@
 //! cgroups v2 resource limits and PSI monitoring.
 
-use anyhow::{anyhow, Result};
+// PsiMetrics and parse_psi live in sentinel-common for cross-crate reuse.
+pub use sentinel_common::psi::{parse_psi, PsiMetrics};
 
 /// Resource limits fuer cgroups v2.
 #[derive(Debug, Clone)]
@@ -27,42 +28,6 @@ impl Default for CgroupLimits {
 /// Erzeugt den cgroup v2 Pfad fuer einen Agenten.
 pub fn cgroup_path(name: &str) -> String {
     format!("/sys/fs/cgroup/sentinel/{name}")
-}
-
-/// PSI (Pressure Stall Information) Metriken.
-#[derive(Debug, Clone, Default)]
-pub struct PsiMetrics {
-    pub avg10: f64,
-    pub avg60: f64,
-    pub avg300: f64,
-    pub total: u64,
-}
-
-/// Parsed eine PSI-Zeile im Format: "some avg10=0.00 avg60=0.00 avg300=0.00 total=0"
-pub fn parse_psi(content: &str) -> Result<PsiMetrics> {
-    // Finde die erste Zeile die mit "some" beginnt
-    let line = content
-        .lines()
-        .find(|l| l.starts_with("some"))
-        .ok_or_else(|| anyhow!("No 'some' line found in PSI content"))?;
-
-    let mut metrics = PsiMetrics::default();
-
-    // Parse die Werte
-    for part in line.split_whitespace().skip(1) {
-        // skip "some"
-        if let Some((key, value)) = part.split_once('=') {
-            match key {
-                "avg10" => metrics.avg10 = value.parse()?,
-                "avg60" => metrics.avg60 = value.parse()?,
-                "avg300" => metrics.avg300 = value.parse()?,
-                "total" => metrics.total = value.parse()?,
-                _ => {}
-            }
-        }
-    }
-
-    Ok(metrics)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Move `PsiMetrics` struct and `parse_psi()` function from `sentinel-sandbox::cgroups` to `sentinel-common::psi`
- Re-export from sentinel-sandbox for backward compatibility
- Required by sentinel-ebpf (#25) which needs PSI types without depending on sentinel-sandbox

## Changes
- **NEW** `crates/sentinel-common/src/psi.rs` - PsiMetrics + parse_psi() + 3 unit tests
- `crates/sentinel-common/src/lib.rs` - Added `pub mod psi`
- `crates/sentinel-sandbox/Cargo.toml` - Added sentinel-common dependency
- `crates/sentinel-sandbox/src/cgroups.rs` - Replaced local definitions with `pub use sentinel_common::psi::{parse_psi, PsiMetrics}`

## Verification
- `cargo remote -- check --workspace`: OK
- `cargo remote -- test --workspace`: ALL tests green (including sentinel-sandbox acceptance tests)
- `cargo fmt --all -- --check`: Clean
- Backward compatible: `sentinel_sandbox::cgroups::parse_psi` and `sentinel_sandbox::PsiMetrics` still work

## Test plan
- [x] sentinel-common psi unit tests (3 tests)
- [x] sentinel-sandbox unit tests (re-export works)
- [x] sentinel-sandbox acceptance tests (AC #16.05 parse_psi)
- [x] Full workspace compilation

Blocks: #25