### PR TITLE
feat(observatory): add MARBLE multi-model benchmark package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sprint 5: `sentinel-hippocampus::sleep` module: NMDA-based sleep cycle with 6-phase state machine (Awake→Collecting→Scoring→Selecting→Consolidating→WakingUp), episode selection by NMDA score with threshold filtering (5 tests)
 - Sprint 5: `sentinel-judge` Go package: Drift detection (personality consistency), Fatigue detection (repetition patterns), Quality scoring (1-5 scale), Model-swap trigger (thread-safe, consecutive bad scores) (18 tests)
 - Sprint 5: `bitnet/build.sh` and `bitnet/README.md` for BitNet b1.58 build instructions
+- Sprint 6: `observatory` Go package: MARBLE multi-model benchmark with 6 metrics (InfoPropagation, GroupPolarization, CommunicationScore, PersonalityConsistency, ResponseCreativity, EmotionalRange), judge integration, in-memory observation store, Markdown + JSON report generator (42 tests)
+- Sprint 6: `config/observatory.toml`: Multi-model observatory configuration (3 shifts: Claude, Llama, Qwen; 4 scenarios; feature flag via SENTINEL_OBSERVATORY)
 
 ### Changed
 

--- a/cmd/cortex-gateway/go.mod
+++ b/cmd/cortex-gateway/go.mod
@@ -4,7 +4,10 @@ go 1.25.0
 
 toolchain go1.25.7
 
-require github.com/prometheus/client_golang v1.23.2
+require (
+	github.com/BurntSushi/toml v1.6.0
+	github.com/prometheus/client_golang v1.23.2
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/cmd/cortex-gateway/go.sum
+++ b/cmd/cortex-gateway/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/cmd/cortex-gateway/internal/acceptance/gateway_test.go
+++ b/cmd/cortex-gateway/internal/acceptance/gateway_test.go
@@ -75,11 +75,11 @@ func TestAC_13_03_ProviderInterface(t *testing.T) {
 // AC-13-04: Claude provider sends correct Anthropic API format
 func TestAC_13_04_ClaudeProviderRequest(t *testing.T) {
 	var (
-		receivedAPIKey    string
-		receivedVersion   string
-		receivedPath      string
-		receivedMethod    string
-		receivedBody      []byte
+		receivedAPIKey  string
+		receivedVersion string
+		receivedPath    string
+		receivedMethod  string
+		receivedBody    []byte
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/cortex-gateway/internal/capability/detection.go
+++ b/cmd/cortex-gateway/internal/capability/detection.go
@@ -7,10 +7,10 @@ type Capability string
 
 const (
 	CapStreaming    Capability = "streaming"
-	CapToolUse     Capability = "tool_use"
-	CapVision      Capability = "vision"
+	CapToolUse      Capability = "tool_use"
+	CapVision       Capability = "vision"
 	CapSystemPrompt Capability = "system_prompt"
-	CapJSONMode    Capability = "json_mode"
+	CapJSONMode     Capability = "json_mode"
 	CapFunctionCall Capability = "function_calling"
 )
 
@@ -26,18 +26,18 @@ func New() *ProviderCapabilities {
 		capabilities: map[string]map[Capability]bool{
 			"claude": {
 				CapStreaming:    true,
-				CapToolUse:     true,
-				CapVision:      true,
+				CapToolUse:      true,
+				CapVision:       true,
 				CapSystemPrompt: true,
-				CapJSONMode:    true,
+				CapJSONMode:     true,
 				CapFunctionCall: true,
 			},
 			"ollama": {
 				CapStreaming:    true,
-				CapToolUse:     false,
-				CapVision:      false,
+				CapToolUse:      false,
+				CapVision:       false,
 				CapSystemPrompt: true,
-				CapJSONMode:    false,
+				CapJSONMode:     false,
 				CapFunctionCall: false,
 			},
 		},

--- a/cmd/cortex-gateway/internal/extraction/action.go
+++ b/cmd/cortex-gateway/internal/extraction/action.go
@@ -4,7 +4,7 @@ import "regexp"
 
 // ExtractedAction represents a parsed agent intention from an LLM response.
 type ExtractedAction struct {
-	Type    string `json:"type"`              // "chat", "move", "emote", "tool_use"
+	Type    string `json:"type"` // "chat", "move", "emote", "tool_use"
 	Content string `json:"content"`
 	Target  string `json:"target,omitempty"`
 	Emotion string `json:"emotion,omitempty"`

--- a/cmd/cortex-gateway/internal/normalizer/normalizer.go
+++ b/cmd/cortex-gateway/internal/normalizer/normalizer.go
@@ -39,7 +39,7 @@ type ollamaAPIResponse struct {
 		Role    string `json:"role"`
 		Content string `json:"content"`
 	} `json:"message"`
-	Done         bool `json:"done"`
+	Done          bool  `json:"done"`
 	TotalDuration int64 `json:"total_duration"`
 	EvalCount     int   `json:"eval_count"`
 }

--- a/cmd/cortex-gateway/internal/observatory/config.go
+++ b/cmd/cortex-gateway/internal/observatory/config.go
@@ -1,0 +1,91 @@
+package observatory
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// requiredShifts is the number of shifts the observatory requires.
+const requiredShifts = 3
+
+// envObservatory is the environment variable that overrides the config enabled flag.
+const envObservatory = "SENTINEL_OBSERVATORY"
+
+// ObservatoryConfig is the top-level configuration for the MARBLE observatory.
+type ObservatoryConfig struct {
+	Observatory observatorySection `toml:"observatory"`
+}
+
+// observatorySection holds the observatory-specific settings.
+type observatorySection struct {
+	Enabled   bool           `toml:"enabled"`
+	Shift1    ShiftConfig    `toml:"shift_1"`
+	Shift2    ShiftConfig    `toml:"shift_2"`
+	Shift3    ShiftConfig    `toml:"shift_3"`
+	Scenarios ScenarioConfig `toml:"scenarios"`
+}
+
+// ShiftConfig describes one provider shift in the observatory.
+type ShiftConfig struct {
+	Model    string `toml:"model"`
+	Provider string `toml:"provider"`
+	Agents   int    `toml:"agents"`
+}
+
+// ScenarioConfig lists the scenarios to run in each shift.
+type ScenarioConfig struct {
+	DailyRoutine       bool `toml:"daily_routine"`
+	CrisisResponse     bool `toml:"crisis_response"`
+	CreativeTask       bool `toml:"creative_task"`
+	ConflictResolution bool `toml:"conflict_resolution"`
+}
+
+// LoadConfig reads and validates an observatory TOML configuration from path.
+func LoadConfig(path string) (*ObservatoryConfig, error) {
+	var cfg ObservatoryConfig
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil, fmt.Errorf("decode observatory config: %w", err)
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("validate observatory config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// IsEnabled returns true when the observatory is active. The environment
+// variable SENTINEL_OBSERVATORY=true overrides the config file value.
+func (c *ObservatoryConfig) IsEnabled() bool {
+	if v := os.Getenv(envObservatory); v != "" {
+		return strings.EqualFold(v, "true") || v == "1"
+	}
+	return c.Observatory.Enabled
+}
+
+// Shifts returns the three shift configurations in order.
+func (c *ObservatoryConfig) Shifts() [requiredShifts]ShiftConfig {
+	return [requiredShifts]ShiftConfig{
+		c.Observatory.Shift1,
+		c.Observatory.Shift2,
+		c.Observatory.Shift3,
+	}
+}
+
+// validate checks that the configuration satisfies all invariants.
+func (c *ObservatoryConfig) validate() error {
+	shifts := c.Shifts()
+	for i, s := range shifts {
+		if s.Model == "" {
+			return fmt.Errorf("shift_%d: model must not be empty", i+1)
+		}
+		if s.Provider == "" {
+			return fmt.Errorf("shift_%d: provider must not be empty", i+1)
+		}
+		if s.Agents <= 0 {
+			return fmt.Errorf("shift_%d: agents must be > 0, got %d", i+1, s.Agents)
+		}
+	}
+	return nil
+}

--- a/cmd/cortex-gateway/internal/observatory/config_test.go
+++ b/cmd/cortex-gateway/internal/observatory/config_test.go
@@ -1,0 +1,324 @@
+package observatory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Use the real observatory.toml from the config directory.
+	configPath := filepath.Join("..", "..", "..", "..", "config", "observatory.toml")
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig(%q): %v", configPath, err)
+	}
+
+	// Verify shift 1 (Claude).
+	s1 := cfg.Observatory.Shift1
+	if s1.Model != "claude-sonnet" {
+		t.Errorf("shift_1.model = %q, want %q", s1.Model, "claude-sonnet")
+	}
+	if s1.Provider != "claude" {
+		t.Errorf("shift_1.provider = %q, want %q", s1.Provider, "claude")
+	}
+	if s1.Agents != 15 {
+		t.Errorf("shift_1.agents = %d, want 15", s1.Agents)
+	}
+
+	// Verify shift 2 (Llama).
+	s2 := cfg.Observatory.Shift2
+	if s2.Model != "llama-3.1-70b" {
+		t.Errorf("shift_2.model = %q, want %q", s2.Model, "llama-3.1-70b")
+	}
+	if s2.Provider != "ollama" {
+		t.Errorf("shift_2.provider = %q, want %q", s2.Provider, "ollama")
+	}
+	if s2.Agents != 15 {
+		t.Errorf("shift_2.agents = %d, want 15", s2.Agents)
+	}
+
+	// Verify shift 3 (Qwen).
+	s3 := cfg.Observatory.Shift3
+	if s3.Model != "qwen2.5-72b" {
+		t.Errorf("shift_3.model = %q, want %q", s3.Model, "qwen2.5-72b")
+	}
+	if s3.Provider != "ollama" {
+		t.Errorf("shift_3.provider = %q, want %q", s3.Provider, "ollama")
+	}
+	if s3.Agents != 15 {
+		t.Errorf("shift_3.agents = %d, want 15", s3.Agents)
+	}
+
+	// Verify scenarios.
+	sc := cfg.Observatory.Scenarios
+	if !sc.DailyRoutine {
+		t.Error("scenarios.daily_routine should be true")
+	}
+	if !sc.CrisisResponse {
+		t.Error("scenarios.crisis_response should be true")
+	}
+	if !sc.CreativeTask {
+		t.Error("scenarios.creative_task should be true")
+	}
+	if !sc.ConflictResolution {
+		t.Error("scenarios.conflict_resolution should be true")
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		toml    string
+		wantErr string
+	}{
+		{
+			name: "empty model in shift_1",
+			toml: `
+[observatory]
+enabled = false
+[observatory.shift_1]
+model = ""
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+`,
+			wantErr: "shift_1: model must not be empty",
+		},
+		{
+			name: "empty provider in shift_2",
+			toml: `
+[observatory]
+enabled = false
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama"
+provider = ""
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+`,
+			wantErr: "shift_2: provider must not be empty",
+		},
+		{
+			name: "zero agents in shift_3",
+			toml: `
+[observatory]
+enabled = false
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 0
+[observatory.scenarios]
+`,
+			wantErr: "shift_3: agents must be > 0",
+		},
+		{
+			name: "negative agents",
+			toml: `
+[observatory]
+enabled = false
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = -1
+[observatory.shift_2]
+model = "llama"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+`,
+			wantErr: "shift_1: agents must be > 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempTOML(t, tc.toml)
+			_, err := LoadConfig(path)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := err.Error(); !contains(got, tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", got, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFeatureFlag(t *testing.T) {
+	validTOML := `
+[observatory]
+enabled = false
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+`
+	path := writeTempTOML(t, validTOML)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Default: disabled in config.
+	if cfg.IsEnabled() {
+		t.Error("expected IsEnabled()=false with enabled=false and no env var")
+	}
+
+	// Env var override: "true".
+	t.Setenv("SENTINEL_OBSERVATORY", "true")
+	if !cfg.IsEnabled() {
+		t.Error("expected IsEnabled()=true with SENTINEL_OBSERVATORY=true")
+	}
+
+	// Env var override: "1".
+	t.Setenv("SENTINEL_OBSERVATORY", "1")
+	if !cfg.IsEnabled() {
+		t.Error("expected IsEnabled()=true with SENTINEL_OBSERVATORY=1")
+	}
+
+	// Env var override: "TRUE" (case-insensitive).
+	t.Setenv("SENTINEL_OBSERVATORY", "TRUE")
+	if !cfg.IsEnabled() {
+		t.Error("expected IsEnabled()=true with SENTINEL_OBSERVATORY=TRUE")
+	}
+
+	// Env var override: "false" -> disabled.
+	t.Setenv("SENTINEL_OBSERVATORY", "false")
+	if cfg.IsEnabled() {
+		t.Error("expected IsEnabled()=false with SENTINEL_OBSERVATORY=false")
+	}
+}
+
+func TestConfigDefaults(t *testing.T) {
+	validTOML := `
+[observatory]
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+`
+	path := writeTempTOML(t, validTOML)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// enabled defaults to false (zero value).
+	if cfg.Observatory.Enabled {
+		t.Error("expected enabled=false by default")
+	}
+
+	// Scenarios default to false (zero values).
+	sc := cfg.Observatory.Scenarios
+	if sc.DailyRoutine || sc.CrisisResponse || sc.CreativeTask || sc.ConflictResolution {
+		t.Error("expected all scenarios false by default when not set")
+	}
+}
+
+func TestShifts(t *testing.T) {
+	validTOML := `
+[observatory]
+enabled = true
+[observatory.shift_1]
+model = "a"
+provider = "p1"
+agents = 10
+[observatory.shift_2]
+model = "b"
+provider = "p2"
+agents = 20
+[observatory.shift_3]
+model = "c"
+provider = "p3"
+agents = 30
+[observatory.scenarios]
+`
+	path := writeTempTOML(t, validTOML)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	shifts := cfg.Shifts()
+	if len(shifts) != 3 {
+		t.Fatalf("Shifts() returned %d entries, want 3", len(shifts))
+	}
+	if shifts[0].Model != "a" || shifts[1].Model != "b" || shifts[2].Model != "c" {
+		t.Errorf("Shifts() models = [%q, %q, %q], want [a, b, c]",
+			shifts[0].Model, shifts[1].Model, shifts[2].Model)
+	}
+	if shifts[0].Agents != 10 || shifts[1].Agents != 20 || shifts[2].Agents != 30 {
+		t.Errorf("Shifts() agents = [%d, %d, %d], want [10, 20, 30]",
+			shifts[0].Agents, shifts[1].Agents, shifts[2].Agents)
+	}
+}
+
+// writeTempTOML writes content to a temporary TOML file and returns its path.
+func writeTempTOML(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp TOML: %v", err)
+	}
+	return path
+}
+
+// contains reports whether s contains substr.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/cortex-gateway/internal/observatory/metrics.go
+++ b/cmd/cortex-gateway/internal/observatory/metrics.go
@@ -1,0 +1,203 @@
+package observatory
+
+import (
+	"math"
+	"strings"
+
+	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/judge"
+)
+
+// CalcInfoPropagation calculates how well information spreads through the agent network.
+// Formula: (agentsReached / totalAgents) * accuracy
+// Returns 0.0 if totalAgents is 0.
+func CalcInfoPropagation(totalAgents, agentsReached int, accuracy float64) float64 {
+	if totalAgents <= 0 {
+		return 0.0
+	}
+	ratio := float64(agentsReached) / float64(totalAgents)
+	result := ratio * accuracy
+	return clamp01(result)
+}
+
+// CalcGroupPolarization calculates variance of sentiment values as a polarization indicator.
+// Formula: Σ(xi - mean)² / N (population variance)
+// Low variance = consensus, high variance = polarization.
+// Returns 0.0 for empty input.
+func CalcGroupPolarization(sentiments []float64) float64 {
+	n := len(sentiments)
+	if n == 0 {
+		return 0.0
+	}
+
+	// Calculate mean
+	sum := 0.0
+	for _, s := range sentiments {
+		sum += s
+	}
+	mean := sum / float64(n)
+
+	// Calculate variance
+	variance := 0.0
+	for _, s := range sentiments {
+		diff := s - mean
+		variance += diff * diff
+	}
+	variance /= float64(n)
+
+	return variance
+}
+
+// CalcCommunicationScore integrates with judge.QualityScorer to evaluate message quality.
+// Returns the average QualityScorer score normalized to 0-1 (score / 5.0).
+// Returns 0.0 for empty messages.
+func CalcCommunicationScore(scorer *judge.QualityScorer, agentName string, messages []string) float64 {
+	if len(messages) == 0 {
+		return 0.0
+	}
+
+	totalScore := 0.0
+	for i, msg := range messages {
+		// Use previous messages as recent history for context
+		var history []string
+		if i > 0 {
+			history = messages[:i]
+		}
+		result := scorer.ScoreMessage(agentName, msg, history)
+		totalScore += float64(result.Score)
+	}
+
+	avgScore := totalScore / float64(len(messages))
+	// Normalize to 0-1 range (QualityScorer returns 1-5)
+	return avgScore / 5.0
+}
+
+// CalcPersonalityConsistency uses the DriftDetector to measure how consistent an agent stays.
+// Formula: 1.0 - average DriftScore across all message windows.
+// Returns 1.0 (perfect consistency) for empty windows.
+func CalcPersonalityConsistency(detector *judge.DriftDetector, agentName string, messageWindows [][]string) float64 {
+	if len(messageWindows) == 0 {
+		return 1.0
+	}
+
+	totalDrift := 0.0
+	for _, window := range messageWindows {
+		result := detector.CheckDrift(agentName, window)
+		totalDrift += result.DriftScore
+	}
+
+	avgDrift := totalDrift / float64(len(messageWindows))
+	return clamp01(1.0 - avgDrift)
+}
+
+// CalcResponseCreativity measures lexical diversity through entropy and n-gram uniqueness.
+// Formula: 0.5 * shannonEntropy(tokens) + 0.5 * uniqueBigramRatio
+// Returns 0.0 for empty input.
+func CalcResponseCreativity(responses []string) float64 {
+	if len(responses) == 0 {
+		return 0.0
+	}
+
+	// Collect all tokens from all responses
+	var allTokens []string
+	for _, resp := range responses {
+		tokens := tokenize(resp)
+		allTokens = append(allTokens, tokens...)
+	}
+
+	if len(allTokens) == 0 {
+		return 0.0
+	}
+
+	// Shannon entropy of token distribution (normalized)
+	entropy := shannonEntropy(allTokens)
+
+	// Unique bigram ratio
+	bigramRatio := uniqueNGramRatio(allTokens, 2)
+
+	return clamp01(0.5*entropy + 0.5*bigramRatio)
+}
+
+// CalcEmotionalRange measures the breadth of detected emotions.
+// Formula: len(unique(detectedEmotions)) / possibleEmotions
+// Returns 0.0 if possibleEmotions is 0.
+func CalcEmotionalRange(detectedEmotions []string, possibleEmotions int) float64 {
+	if possibleEmotions <= 0 {
+		return 0.0
+	}
+
+	unique := make(map[string]struct{})
+	for _, e := range detectedEmotions {
+		unique[e] = struct{}{}
+	}
+
+	return clamp01(float64(len(unique)) / float64(possibleEmotions))
+}
+
+// --- Helper functions ---
+
+// clamp01 restricts a value to the [0, 1] range.
+func clamp01(v float64) float64 {
+	if v < 0.0 {
+		return 0.0
+	}
+	if v > 1.0 {
+		return 1.0
+	}
+	return v
+}
+
+// tokenize splits text into lowercase tokens.
+func tokenize(text string) []string {
+	words := strings.Fields(strings.ToLower(text))
+	return words
+}
+
+// shannonEntropy calculates normalized Shannon entropy of a token distribution.
+// Returns a value in [0, 1] where 1 means maximum diversity.
+func shannonEntropy(tokens []string) float64 {
+	if len(tokens) == 0 {
+		return 0.0
+	}
+
+	freq := make(map[string]int)
+	for _, t := range tokens {
+		freq[t]++
+	}
+
+	n := float64(len(tokens))
+	entropy := 0.0
+	for _, count := range freq {
+		p := float64(count) / n
+		if p > 0 {
+			entropy -= p * math.Log2(p)
+		}
+	}
+
+	// Normalize by max possible entropy (log2 of unique token count)
+	uniqueCount := float64(len(freq))
+	if uniqueCount <= 1 {
+		return 0.0
+	}
+	maxEntropy := math.Log2(uniqueCount)
+	if maxEntropy == 0 {
+		return 0.0
+	}
+
+	return entropy / maxEntropy
+}
+
+// uniqueNGramRatio calculates the ratio of unique n-grams to total n-grams.
+func uniqueNGramRatio(tokens []string, n int) float64 {
+	if len(tokens) < n {
+		return 0.0
+	}
+
+	totalNGrams := len(tokens) - n + 1
+	unique := make(map[string]struct{})
+	for i := 0; i <= len(tokens)-n; i++ {
+		ngram := strings.Join(tokens[i:i+n], " ")
+		unique[ngram] = struct{}{}
+	}
+
+	return float64(len(unique)) / float64(totalNGrams)
+}

--- a/cmd/cortex-gateway/internal/observatory/metrics_test.go
+++ b/cmd/cortex-gateway/internal/observatory/metrics_test.go
@@ -1,0 +1,269 @@
+package observatory
+
+import (
+	"math"
+	"testing"
+
+	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/judge"
+)
+
+const floatTolerance = 0.01
+
+func assertInRange(t *testing.T, name string, value, low, high float64) {
+	t.Helper()
+	if value < low || value > high {
+		t.Errorf("%s = %f, want in range [%f, %f]", name, value, low, high)
+	}
+}
+
+func assertApprox(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > floatTolerance {
+		t.Errorf("%s = %f, want approx %f (tolerance %f)", name, got, want, floatTolerance)
+	}
+}
+
+// --- InfoPropagation Tests ---
+
+func TestInfoPropagation(t *testing.T) {
+	// 5/15 agents, 0.9 accuracy -> 0.3
+	score := CalcInfoPropagation(15, 5, 0.9)
+	assertInRange(t, "InfoPropagation(15,5,0.9)", score, 0.29, 0.35)
+}
+
+func TestInfoPropagationZeroAgents(t *testing.T) {
+	score := CalcInfoPropagation(0, 0, 0.9)
+	assertApprox(t, "InfoPropagation(0,0,0.9)", score, 0.0)
+}
+
+func TestInfoPropagationFullPropagation(t *testing.T) {
+	score := CalcInfoPropagation(10, 10, 1.0)
+	assertApprox(t, "InfoPropagation(10,10,1.0)", score, 1.0)
+}
+
+func TestInfoPropagationLowAccuracy(t *testing.T) {
+	score := CalcInfoPropagation(10, 10, 0.0)
+	assertApprox(t, "InfoPropagation(10,10,0.0)", score, 0.0)
+}
+
+// --- GroupPolarization Tests ---
+
+func TestGroupPolarization(t *testing.T) {
+	// sentiments [0.6, 0.7, 0.65, 0.8, 0.55] -> low variance, <0.3
+	sentiments := []float64{0.6, 0.7, 0.65, 0.8, 0.55}
+	score := CalcGroupPolarization(sentiments)
+	if score >= 0.3 {
+		t.Errorf("GroupPolarization = %f, want < 0.3", score)
+	}
+}
+
+func TestGroupPolarizationHighVariance(t *testing.T) {
+	// Extreme sentiments -> high variance
+	sentiments := []float64{0.0, 1.0, 0.0, 1.0}
+	score := CalcGroupPolarization(sentiments)
+	if score < 0.2 {
+		t.Errorf("GroupPolarization = %f, want >= 0.2 for high polarization", score)
+	}
+}
+
+func TestGroupPolarizationEmpty(t *testing.T) {
+	score := CalcGroupPolarization(nil)
+	assertApprox(t, "GroupPolarization(nil)", score, 0.0)
+}
+
+func TestGroupPolarizationUniform(t *testing.T) {
+	// All same sentiment -> variance = 0
+	sentiments := []float64{0.5, 0.5, 0.5, 0.5}
+	score := CalcGroupPolarization(sentiments)
+	assertApprox(t, "GroupPolarization(uniform)", score, 0.0)
+}
+
+// --- PersonalityConsistency Tests ---
+
+func TestPersonalityConsistency(t *testing.T) {
+	detector := judge.NewDriftDetector()
+	// Extraversion 0.5 -> expectedVerbosity ~100 chars, expectedExclamations ~1.5
+	detector.RegisterProfile("Agent-01", judge.PersonalityProfile{
+		Role:         "Developer",
+		Extraversion: 0.5,
+		Neuroticism:  0.3,
+		KeyTraits:    []string{"analytical", "quiet"},
+	})
+
+	// Messages that match expected verbosity (~100 chars) and moderate exclamation use
+	windows := [][]string{
+		{
+			"Working on the API refactoring today, focusing on the endpoint structure and the error handling layer.",
+			"The database schema needs some adjustments! I will prepare the migration scripts for the new feature.",
+		},
+		{
+			"Code review completed for the authentication module. Found a few minor issues with input validation!",
+			"Deploying the staging build now. All integration tests passed with the updated configuration files.",
+		},
+	}
+
+	score := CalcPersonalityConsistency(detector, "Agent-01", windows)
+	// With messages matching the profile, consistency should be reasonable
+	if score < 0.3 {
+		t.Errorf("PersonalityConsistency = %f, want > 0.3 for profile-matching messages", score)
+	}
+
+	// Unknown agent should return high consistency (DriftDetector returns 0.0 drift)
+	scoreUnknown := CalcPersonalityConsistency(detector, "Unknown-Agent", windows)
+	assertApprox(t, "PersonalityConsistency(unknown)", scoreUnknown, 1.0)
+}
+
+func TestPersonalityConsistencyEmpty(t *testing.T) {
+	detector := judge.NewDriftDetector()
+	score := CalcPersonalityConsistency(detector, "Agent-01", nil)
+	assertApprox(t, "PersonalityConsistency(nil)", score, 1.0)
+}
+
+// --- ResponseCreativity Tests ---
+
+func TestResponseCreativity(t *testing.T) {
+	// Diverse texts -> higher creativity
+	diverse := []string{
+		"The quantum computing revolution transforms how we approach optimization problems.",
+		"Yesterday's rainfall created beautiful patterns across the garden stones.",
+		"Musical theory intersects with mathematical concepts in fascinating ways.",
+	}
+	diverseScore := CalcResponseCreativity(diverse)
+
+	// Repetitive texts -> lower creativity
+	repetitive := []string{
+		"I agree with the plan. The plan is good.",
+		"I agree with the plan. The plan is good.",
+		"I agree with the plan. The plan is good.",
+	}
+	repetitiveScore := CalcResponseCreativity(repetitive)
+
+	if diverseScore <= repetitiveScore {
+		t.Errorf("diverse creativity (%f) should be > repetitive creativity (%f)",
+			diverseScore, repetitiveScore)
+	}
+}
+
+func TestResponseCreativityEmpty(t *testing.T) {
+	score := CalcResponseCreativity(nil)
+	assertApprox(t, "ResponseCreativity(nil)", score, 0.0)
+}
+
+func TestResponseCreativitySingleWord(t *testing.T) {
+	score := CalcResponseCreativity([]string{"hello"})
+	// Single word: no bigrams possible, low entropy
+	assertApprox(t, "ResponseCreativity(single word)", score, 0.0)
+}
+
+// --- EmotionalRange Tests ---
+
+func TestEmotionalRange(t *testing.T) {
+	// 5 of 10 possible emotions -> 0.5
+	emotions := []string{"joy", "anger", "surprise", "fear", "sadness"}
+	score := CalcEmotionalRange(emotions, 10)
+	assertApprox(t, "EmotionalRange(5/10)", score, 0.5)
+}
+
+func TestEmotionalRangeWithDuplicates(t *testing.T) {
+	// Duplicates should be deduplicated: 3 unique of 10
+	emotions := []string{"joy", "joy", "anger", "anger", "surprise"}
+	score := CalcEmotionalRange(emotions, 10)
+	assertApprox(t, "EmotionalRange(3unique/10)", score, 0.3)
+}
+
+func TestEmotionalRangeEmpty(t *testing.T) {
+	score := CalcEmotionalRange(nil, 10)
+	assertApprox(t, "EmotionalRange(nil,10)", score, 0.0)
+}
+
+func TestEmotionalRangeZeroPossible(t *testing.T) {
+	score := CalcEmotionalRange([]string{"joy"}, 0)
+	assertApprox(t, "EmotionalRange(1,0)", score, 0.0)
+}
+
+func TestEmotionalRangeFull(t *testing.T) {
+	emotions := []string{"joy", "anger", "surprise", "fear", "sadness"}
+	score := CalcEmotionalRange(emotions, 5)
+	assertApprox(t, "EmotionalRange(5/5)", score, 1.0)
+}
+
+// --- CommunicationScore Tests ---
+
+func TestCommunicationScore(t *testing.T) {
+	detector := judge.NewDriftDetector()
+	detector.RegisterProfile("Agent-01", judge.PersonalityProfile{
+		Role:         "Developer",
+		Extraversion: 0.5,
+		Neuroticism:  0.3,
+		KeyTraits:    []string{"analytical"},
+	})
+	scorer := judge.NewQualityScorer(detector)
+
+	messages := []string{
+		"I reviewed the pull request for the authentication module and found 3 issues with error handling.",
+		"The CI pipeline needs updating: golangci-lint v2 changed the config format significantly.",
+	}
+
+	score := CalcCommunicationScore(scorer, "Agent-01", messages)
+	if score < 0.0 || score > 1.0 {
+		t.Errorf("CommunicationScore = %f, want in [0, 1]", score)
+	}
+	// These are reasonably specific messages, should score moderately well
+	if score < 0.2 {
+		t.Errorf("CommunicationScore = %f, want > 0.2 for specific messages", score)
+	}
+}
+
+func TestCommunicationScoreEmpty(t *testing.T) {
+	detector := judge.NewDriftDetector()
+	scorer := judge.NewQualityScorer(detector)
+	score := CalcCommunicationScore(scorer, "Agent-01", nil)
+	assertApprox(t, "CommunicationScore(nil)", score, 0.0)
+}
+
+// --- Helper function tests ---
+
+func TestShannonEntropy(t *testing.T) {
+	// All same tokens -> entropy 0
+	same := []string{"a", "a", "a", "a"}
+	e := shannonEntropy(same)
+	assertApprox(t, "shannonEntropy(same)", e, 0.0)
+
+	// All unique tokens -> entropy 1 (normalized)
+	unique := []string{"a", "b", "c", "d"}
+	e = shannonEntropy(unique)
+	assertApprox(t, "shannonEntropy(unique)", e, 1.0)
+}
+
+func TestUniqueNGramRatio(t *testing.T) {
+	// All unique bigrams
+	tokens := []string{"a", "b", "c", "d"}
+	ratio := uniqueNGramRatio(tokens, 2)
+	assertApprox(t, "uniqueNGramRatio(unique)", ratio, 1.0)
+
+	// Repeated bigrams: "a b a b" -> bigrams: "a b", "b a", "a b" -> 2/3
+	tokens = []string{"a", "b", "a", "b"}
+	ratio = uniqueNGramRatio(tokens, 2)
+	expected := 2.0 / 3.0
+	if math.Abs(ratio-expected) > floatTolerance {
+		t.Errorf("uniqueNGramRatio(repeated) = %f, want approx %f", ratio, expected)
+	}
+}
+
+func TestClamp01(t *testing.T) {
+	tests := []struct {
+		input, want float64
+	}{
+		{-0.5, 0.0},
+		{0.0, 0.0},
+		{0.5, 0.5},
+		{1.0, 1.0},
+		{1.5, 1.0},
+	}
+	for _, tc := range tests {
+		got := clamp01(tc.input)
+		if got != tc.want {
+			t.Errorf("clamp01(%f) = %f, want %f", tc.input, got, tc.want)
+		}
+	}
+}

--- a/cmd/cortex-gateway/internal/observatory/report.go
+++ b/cmd/cortex-gateway/internal/observatory/report.go
@@ -1,0 +1,234 @@
+package observatory
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ReportGenerator creates comparison reports from observatory data.
+type ReportGenerator struct {
+	store *ObservationStore
+}
+
+// NewReportGenerator creates a ReportGenerator backed by the given store.
+func NewReportGenerator(store *ObservationStore) *ReportGenerator {
+	return &ReportGenerator{store: store}
+}
+
+// ShiftSummary holds aggregated metrics for a single shift and model combination.
+type ShiftSummary struct {
+	Shift       int
+	Model       string
+	RecordCount int
+	AvgMetrics  MetricsSnapshot
+	MinMetrics  MetricsSnapshot
+	MaxMetrics  MetricsSnapshot
+}
+
+// GetShiftSummaries returns aggregated metrics per shift for the filtered records.
+func (r *ReportGenerator) GetShiftSummaries(filter QueryFilter) []ShiftSummary {
+	records := r.store.Query(filter)
+	if len(records) == 0 {
+		return nil
+	}
+
+	// Group records by shift
+	grouped := make(map[int][]ObservationRecord)
+	for _, rec := range records {
+		grouped[rec.Shift] = append(grouped[rec.Shift], rec)
+	}
+
+	var summaries []ShiftSummary
+	for shift := 1; shift <= requiredShifts; shift++ {
+		recs, ok := grouped[shift]
+		if !ok || len(recs) == 0 {
+			continue
+		}
+
+		summary := ShiftSummary{
+			Shift:       shift,
+			Model:       recs[0].Model,
+			RecordCount: len(recs),
+			MinMetrics:  recs[0].Metrics,
+			MaxMetrics:  recs[0].Metrics,
+		}
+
+		var sum MetricsSnapshot
+		for _, rec := range recs {
+			m := rec.Metrics
+			sum.InfoPropagation += m.InfoPropagation
+			sum.GroupPolarization += m.GroupPolarization
+			sum.CommunicationScore += m.CommunicationScore
+			sum.PersonalityConsistency += m.PersonalityConsistency
+			sum.ResponseCreativity += m.ResponseCreativity
+			sum.EmotionalRange += m.EmotionalRange
+
+			summary.MinMetrics = minSnapshot(summary.MinMetrics, m)
+			summary.MaxMetrics = maxSnapshot(summary.MaxMetrics, m)
+		}
+
+		n := float64(len(recs))
+		summary.AvgMetrics = MetricsSnapshot{
+			InfoPropagation:        sum.InfoPropagation / n,
+			GroupPolarization:      sum.GroupPolarization / n,
+			CommunicationScore:     sum.CommunicationScore / n,
+			PersonalityConsistency: sum.PersonalityConsistency / n,
+			ResponseCreativity:     sum.ResponseCreativity / n,
+			EmotionalRange:         sum.EmotionalRange / n,
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries
+}
+
+// GenerateMarkdown creates a comparison report in Markdown format.
+func (r *ReportGenerator) GenerateMarkdown(filter QueryFilter) string {
+	summaries := r.GetShiftSummaries(filter)
+	records := r.store.Query(filter)
+
+	var b strings.Builder
+
+	b.WriteString("# MARBLE Observatory Report\n\n")
+	b.WriteString(fmt.Sprintf("Generated: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("Records: %d\n\n", len(records)))
+
+	if len(summaries) == 0 {
+		b.WriteString("No data available.\n")
+		return b.String()
+	}
+
+	// Shift comparison table
+	b.WriteString("## Shift Comparison\n\n")
+	b.WriteString("| Metric |")
+	for _, s := range summaries {
+		b.WriteString(fmt.Sprintf(" %s (Shift %d) |", s.Model, s.Shift))
+	}
+	b.WriteString("\n|--------|")
+	for range summaries {
+		b.WriteString("-----------------|")
+	}
+	b.WriteString("\n")
+
+	type metricRow struct {
+		name string
+		get  func(MetricsSnapshot) float64
+	}
+	rows := []metricRow{
+		{"Info Propagation", func(m MetricsSnapshot) float64 { return m.InfoPropagation }},
+		{"Group Polarization", func(m MetricsSnapshot) float64 { return m.GroupPolarization }},
+		{"Communication Score", func(m MetricsSnapshot) float64 { return m.CommunicationScore }},
+		{"Personality Consistency", func(m MetricsSnapshot) float64 { return m.PersonalityConsistency }},
+		{"Response Creativity", func(m MetricsSnapshot) float64 { return m.ResponseCreativity }},
+		{"Emotional Range", func(m MetricsSnapshot) float64 { return m.EmotionalRange }},
+	}
+
+	for _, row := range rows {
+		b.WriteString(fmt.Sprintf("| %s |", row.name))
+		for _, s := range summaries {
+			b.WriteString(fmt.Sprintf(" %.2f |", row.get(s.AvgMetrics)))
+		}
+		b.WriteString("\n")
+	}
+
+	// Per-shift details
+	b.WriteString("\n## Per-Shift Details\n\n")
+	for _, s := range summaries {
+		b.WriteString(fmt.Sprintf("### Shift %d: %s (%d records)\n\n", s.Shift, s.Model, s.RecordCount))
+		b.WriteString("| Metric | Avg | Min | Max |\n")
+		b.WriteString("|--------|-----|-----|-----|\n")
+		for _, row := range rows {
+			b.WriteString(fmt.Sprintf("| %s | %.2f | %.2f | %.2f |\n",
+				row.name,
+				row.get(s.AvgMetrics),
+				row.get(s.MinMetrics),
+				row.get(s.MaxMetrics),
+			))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// jsonReport is the wire format for JSON export.
+type jsonReport struct {
+	Generated string        `json:"generated"`
+	Records   int           `json:"records"`
+	Summaries []jsonSummary `json:"summaries"`
+}
+
+// jsonSummary is the wire format for a single shift summary.
+type jsonSummary struct {
+	Shift       int             `json:"shift"`
+	Model       string          `json:"model"`
+	RecordCount int             `json:"record_count"`
+	AvgMetrics  MetricsSnapshot `json:"avg_metrics"`
+	MinMetrics  MetricsSnapshot `json:"min_metrics"`
+	MaxMetrics  MetricsSnapshot `json:"max_metrics"`
+}
+
+// GenerateJSON creates a structured JSON export of the comparison data.
+func (r *ReportGenerator) GenerateJSON(filter QueryFilter) ([]byte, error) {
+	summaries := r.GetShiftSummaries(filter)
+	records := r.store.Query(filter)
+
+	report := jsonReport{
+		Generated: time.Now().UTC().Format(time.RFC3339),
+		Records:   len(records),
+	}
+
+	for _, s := range summaries {
+		report.Summaries = append(report.Summaries, jsonSummary{
+			Shift:       s.Shift,
+			Model:       s.Model,
+			RecordCount: s.RecordCount,
+			AvgMetrics:  s.AvgMetrics,
+			MinMetrics:  s.MinMetrics,
+			MaxMetrics:  s.MaxMetrics,
+		})
+	}
+
+	return json.MarshalIndent(report, "", "  ")
+}
+
+// minSnapshot returns a MetricsSnapshot with the minimum of each field.
+func minSnapshot(a, b MetricsSnapshot) MetricsSnapshot {
+	return MetricsSnapshot{
+		InfoPropagation:        minF(a.InfoPropagation, b.InfoPropagation),
+		GroupPolarization:      minF(a.GroupPolarization, b.GroupPolarization),
+		CommunicationScore:     minF(a.CommunicationScore, b.CommunicationScore),
+		PersonalityConsistency: minF(a.PersonalityConsistency, b.PersonalityConsistency),
+		ResponseCreativity:     minF(a.ResponseCreativity, b.ResponseCreativity),
+		EmotionalRange:         minF(a.EmotionalRange, b.EmotionalRange),
+	}
+}
+
+// maxSnapshot returns a MetricsSnapshot with the maximum of each field.
+func maxSnapshot(a, b MetricsSnapshot) MetricsSnapshot {
+	return MetricsSnapshot{
+		InfoPropagation:        maxF(a.InfoPropagation, b.InfoPropagation),
+		GroupPolarization:      maxF(a.GroupPolarization, b.GroupPolarization),
+		CommunicationScore:     maxF(a.CommunicationScore, b.CommunicationScore),
+		PersonalityConsistency: maxF(a.PersonalityConsistency, b.PersonalityConsistency),
+		ResponseCreativity:     maxF(a.ResponseCreativity, b.ResponseCreativity),
+		EmotionalRange:         maxF(a.EmotionalRange, b.EmotionalRange),
+	}
+}
+
+func minF(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/cortex-gateway/internal/observatory/report_test.go
+++ b/cmd/cortex-gateway/internal/observatory/report_test.go
@@ -1,0 +1,339 @@
+package observatory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestStore() *ObservationStore {
+	store := NewObservationStore()
+	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+
+	// Shift 1: Claude
+	store.Add(ObservationRecord{
+		Timestamp: base,
+		Shift:     1,
+		Model:     "claude-sonnet",
+		Agent:     "AGENT-01",
+		Scenario:  "daily_routine",
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.85,
+			GroupPolarization:      0.15,
+			CommunicationScore:     0.82,
+			PersonalityConsistency: 0.91,
+			ResponseCreativity:     0.67,
+			EmotionalRange:         0.73,
+		},
+	})
+	store.Add(ObservationRecord{
+		Timestamp: base.Add(time.Hour),
+		Shift:     1,
+		Model:     "claude-sonnet",
+		Agent:     "AGENT-02",
+		Scenario:  "daily_routine",
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.89,
+			GroupPolarization:      0.11,
+			CommunicationScore:     0.78,
+			PersonalityConsistency: 0.93,
+			ResponseCreativity:     0.71,
+			EmotionalRange:         0.69,
+		},
+	})
+
+	// Shift 2: Llama
+	store.Add(ObservationRecord{
+		Timestamp: base,
+		Shift:     2,
+		Model:     "llama-3.1-70b",
+		Agent:     "AGENT-16",
+		Scenario:  "daily_routine",
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.72,
+			GroupPolarization:      0.22,
+			CommunicationScore:     0.65,
+			PersonalityConsistency: 0.78,
+			ResponseCreativity:     0.59,
+			EmotionalRange:         0.55,
+		},
+	})
+
+	// Shift 3: Qwen
+	store.Add(ObservationRecord{
+		Timestamp: base,
+		Shift:     3,
+		Model:     "qwen2.5-72b",
+		Agent:     "AGENT-31",
+		Scenario:  "daily_routine",
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.78,
+			GroupPolarization:      0.18,
+			CommunicationScore:     0.71,
+			PersonalityConsistency: 0.83,
+			ResponseCreativity:     0.63,
+			EmotionalRange:         0.61,
+		},
+	})
+
+	return store
+}
+
+func TestGenerateMarkdown(t *testing.T) {
+	store := newTestStore()
+	gen := NewReportGenerator(store)
+
+	md := gen.GenerateMarkdown(QueryFilter{})
+
+	// Header
+	if !strings.Contains(md, "# MARBLE Observatory Report") {
+		t.Error("markdown should contain report header")
+	}
+	if !strings.Contains(md, "Records: 4") {
+		t.Error("markdown should show 4 records")
+	}
+
+	// Shift comparison table
+	if !strings.Contains(md, "## Shift Comparison") {
+		t.Error("markdown should contain shift comparison section")
+	}
+	if !strings.Contains(md, "claude-sonnet (Shift 1)") {
+		t.Error("markdown should show claude-sonnet shift 1")
+	}
+	if !strings.Contains(md, "llama-3.1-70b (Shift 2)") {
+		t.Error("markdown should show llama shift 2")
+	}
+	if !strings.Contains(md, "qwen2.5-72b (Shift 3)") {
+		t.Error("markdown should show qwen shift 3")
+	}
+
+	// Metric rows
+	if !strings.Contains(md, "Info Propagation") {
+		t.Error("markdown should contain Info Propagation metric")
+	}
+	if !strings.Contains(md, "Group Polarization") {
+		t.Error("markdown should contain Group Polarization metric")
+	}
+	if !strings.Contains(md, "Communication Score") {
+		t.Error("markdown should contain Communication Score metric")
+	}
+	if !strings.Contains(md, "Personality Consistency") {
+		t.Error("markdown should contain Personality Consistency metric")
+	}
+	if !strings.Contains(md, "Response Creativity") {
+		t.Error("markdown should contain Response Creativity metric")
+	}
+	if !strings.Contains(md, "Emotional Range") {
+		t.Error("markdown should contain Emotional Range metric")
+	}
+
+	// Per-shift details
+	if !strings.Contains(md, "## Per-Shift Details") {
+		t.Error("markdown should contain per-shift details section")
+	}
+	if !strings.Contains(md, "| Avg | Min | Max |") {
+		t.Error("markdown should contain Avg/Min/Max columns")
+	}
+
+	// Table pipe character count check (basic structure validation)
+	lines := strings.Split(md, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "| Info Propagation") {
+			pipes := strings.Count(line, "|")
+			if pipes < 4 {
+				t.Errorf("metric row should have at least 4 pipe characters, got %d", pipes)
+			}
+		}
+	}
+}
+
+func TestGenerateJSON(t *testing.T) {
+	store := newTestStore()
+	gen := NewReportGenerator(store)
+
+	data, err := gen.GenerateJSON(QueryFilter{})
+	if err != nil {
+		t.Fatalf("GenerateJSON failed: %v", err)
+	}
+
+	// Must be valid JSON
+	var report struct {
+		Generated string `json:"generated"`
+		Records   int    `json:"records"`
+		Summaries []struct {
+			Shift       int             `json:"shift"`
+			Model       string          `json:"model"`
+			RecordCount int             `json:"record_count"`
+			AvgMetrics  MetricsSnapshot `json:"avg_metrics"`
+			MinMetrics  MetricsSnapshot `json:"min_metrics"`
+			MaxMetrics  MetricsSnapshot `json:"max_metrics"`
+		} `json:"summaries"`
+	}
+
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("JSON unmarshal failed: %v", err)
+	}
+
+	if report.Records != 4 {
+		t.Errorf("expected 4 records, got %d", report.Records)
+	}
+	if report.Generated == "" {
+		t.Error("generated timestamp should not be empty")
+	}
+	if len(report.Summaries) != 3 {
+		t.Fatalf("expected 3 summaries (one per shift), got %d", len(report.Summaries))
+	}
+
+	// Verify shift order
+	if report.Summaries[0].Shift != 1 {
+		t.Errorf("first summary shift = %d, want 1", report.Summaries[0].Shift)
+	}
+	if report.Summaries[1].Shift != 2 {
+		t.Errorf("second summary shift = %d, want 2", report.Summaries[1].Shift)
+	}
+	if report.Summaries[2].Shift != 3 {
+		t.Errorf("third summary shift = %d, want 3", report.Summaries[2].Shift)
+	}
+
+	// Verify models
+	if report.Summaries[0].Model != "claude-sonnet" {
+		t.Errorf("shift 1 model = %s, want claude-sonnet", report.Summaries[0].Model)
+	}
+
+	// Verify record counts
+	if report.Summaries[0].RecordCount != 2 {
+		t.Errorf("shift 1 record count = %d, want 2", report.Summaries[0].RecordCount)
+	}
+	if report.Summaries[1].RecordCount != 1 {
+		t.Errorf("shift 2 record count = %d, want 1", report.Summaries[1].RecordCount)
+	}
+
+	// Verify avg metrics for shift 1 (2 records: 0.85 and 0.89 -> avg 0.87)
+	avgIP := report.Summaries[0].AvgMetrics.InfoPropagation
+	if avgIP < 0.86 || avgIP > 0.88 {
+		t.Errorf("shift 1 avg InfoPropagation = %f, want ~0.87", avgIP)
+	}
+}
+
+func TestShiftSummaries(t *testing.T) {
+	store := newTestStore()
+	gen := NewReportGenerator(store)
+
+	summaries := gen.GetShiftSummaries(QueryFilter{})
+
+	if len(summaries) != 3 {
+		t.Fatalf("expected 3 summaries for 3 shifts, got %d", len(summaries))
+	}
+
+	// Shift 1 has 2 records
+	if summaries[0].RecordCount != 2 {
+		t.Errorf("shift 1 record count = %d, want 2", summaries[0].RecordCount)
+	}
+
+	// Verify min/max for shift 1 InfoPropagation (0.85, 0.89)
+	if summaries[0].MinMetrics.InfoPropagation != 0.85 {
+		t.Errorf("shift 1 min InfoPropagation = %f, want 0.85", summaries[0].MinMetrics.InfoPropagation)
+	}
+	if summaries[0].MaxMetrics.InfoPropagation != 0.89 {
+		t.Errorf("shift 1 max InfoPropagation = %f, want 0.89", summaries[0].MaxMetrics.InfoPropagation)
+	}
+
+	// Shift 2 has 1 record, so min/max/avg should be the same
+	if summaries[1].AvgMetrics.InfoPropagation != 0.72 {
+		t.Errorf("shift 2 avg InfoPropagation = %f, want 0.72", summaries[1].AvgMetrics.InfoPropagation)
+	}
+	if summaries[1].MinMetrics.InfoPropagation != 0.72 {
+		t.Errorf("shift 2 min InfoPropagation = %f, want 0.72", summaries[1].MinMetrics.InfoPropagation)
+	}
+	if summaries[1].MaxMetrics.InfoPropagation != 0.72 {
+		t.Errorf("shift 2 max InfoPropagation = %f, want 0.72", summaries[1].MaxMetrics.InfoPropagation)
+	}
+}
+
+func TestEmptyStore(t *testing.T) {
+	store := NewObservationStore()
+	gen := NewReportGenerator(store)
+
+	// Markdown should not panic on empty store
+	md := gen.GenerateMarkdown(QueryFilter{})
+	if !strings.Contains(md, "No data available") {
+		t.Error("empty markdown should contain 'No data available'")
+	}
+	if !strings.Contains(md, "Records: 0") {
+		t.Error("empty markdown should show 0 records")
+	}
+
+	// JSON should not panic on empty store
+	data, err := gen.GenerateJSON(QueryFilter{})
+	if err != nil {
+		t.Fatalf("GenerateJSON on empty store failed: %v", err)
+	}
+
+	var report struct {
+		Records   int           `json:"records"`
+		Summaries []interface{} `json:"summaries"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("empty JSON unmarshal failed: %v", err)
+	}
+	if report.Records != 0 {
+		t.Errorf("empty report records = %d, want 0", report.Records)
+	}
+
+	// Summaries should not panic on empty store
+	summaries := gen.GetShiftSummaries(QueryFilter{})
+	if len(summaries) != 0 {
+		t.Errorf("empty store summaries = %d, want 0", len(summaries))
+	}
+}
+
+func TestGenerateMarkdownWithFilter(t *testing.T) {
+	store := newTestStore()
+	gen := NewReportGenerator(store)
+
+	shift := 1
+	md := gen.GenerateMarkdown(QueryFilter{Shift: &shift})
+
+	if !strings.Contains(md, "Records: 2") {
+		t.Error("filtered markdown should show 2 records for shift 1")
+	}
+	// Only shift 1 model should appear in table
+	if !strings.Contains(md, "claude-sonnet (Shift 1)") {
+		t.Error("filtered markdown should show claude-sonnet")
+	}
+	if strings.Contains(md, "llama-3.1-70b (Shift 2)") {
+		t.Error("filtered markdown should not show llama (filtered out)")
+	}
+}
+
+func TestGenerateJSONWithFilter(t *testing.T) {
+	store := newTestStore()
+	gen := NewReportGenerator(store)
+
+	model := "qwen2.5-72b"
+	data, err := gen.GenerateJSON(QueryFilter{Model: &model})
+	if err != nil {
+		t.Fatalf("GenerateJSON with filter failed: %v", err)
+	}
+
+	var report struct {
+		Records   int `json:"records"`
+		Summaries []struct {
+			Model string `json:"model"`
+		} `json:"summaries"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("filtered JSON unmarshal failed: %v", err)
+	}
+
+	if report.Records != 1 {
+		t.Errorf("filtered report records = %d, want 1", report.Records)
+	}
+	if len(report.Summaries) != 1 {
+		t.Fatalf("filtered summaries = %d, want 1", len(report.Summaries))
+	}
+	if report.Summaries[0].Model != "qwen2.5-72b" {
+		t.Errorf("filtered summary model = %s, want qwen2.5-72b", report.Summaries[0].Model)
+	}
+}

--- a/cmd/cortex-gateway/internal/observatory/storage.go
+++ b/cmd/cortex-gateway/internal/observatory/storage.go
@@ -1,0 +1,110 @@
+package observatory
+
+import (
+	"sync"
+	"time"
+)
+
+// MetricsSnapshot holds a complete set of MARBLE metric values for one observation.
+type MetricsSnapshot struct {
+	InfoPropagation        float64
+	GroupPolarization      float64
+	CommunicationScore     float64
+	PersonalityConsistency float64
+	ResponseCreativity     float64
+	EmotionalRange         float64
+}
+
+// ObservationRecord represents a single observation data point.
+type ObservationRecord struct {
+	Timestamp time.Time
+	Shift     int    // 1, 2, 3
+	Model     string // "claude-sonnet", "llama-3.1-70b", "qwen2.5-72b"
+	Agent     string // Agent name
+	Scenario  string // "daily_routine", etc.
+	Metrics   MetricsSnapshot
+}
+
+// QueryFilter defines criteria for filtering observation records.
+type QueryFilter struct {
+	Shift    *int       // nil = no filter
+	Model    *string    // nil = no filter
+	Agent    *string    // nil = no filter
+	Scenario *string    // nil = no filter
+	From     *time.Time // nil = no lower bound
+	To       *time.Time // nil = no upper bound
+}
+
+// ObservationStore provides thread-safe in-memory storage for observation records.
+type ObservationStore struct {
+	mu      sync.RWMutex
+	records []ObservationRecord
+}
+
+// NewObservationStore creates an empty ObservationStore.
+func NewObservationStore() *ObservationStore {
+	return &ObservationStore{
+		records: make([]ObservationRecord, 0),
+	}
+}
+
+// Add appends an observation record to the store.
+func (s *ObservationStore) Add(record ObservationRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, record)
+}
+
+// Query returns all records matching the given filter criteria.
+func (s *ObservationStore) Query(filter QueryFilter) []ObservationRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []ObservationRecord
+	for _, r := range s.records {
+		if matchesFilter(r, filter) {
+			results = append(results, r)
+		}
+	}
+	return results
+}
+
+// AllRecords returns a copy of all stored observation records.
+func (s *ObservationStore) AllRecords() []ObservationRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]ObservationRecord, len(s.records))
+	copy(result, s.records)
+	return result
+}
+
+// Len returns the number of stored records.
+func (s *ObservationStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.records)
+}
+
+// matchesFilter checks if a record satisfies all filter criteria.
+func matchesFilter(r ObservationRecord, f QueryFilter) bool {
+	if f.Shift != nil && r.Shift != *f.Shift {
+		return false
+	}
+	if f.Model != nil && r.Model != *f.Model {
+		return false
+	}
+	if f.Agent != nil && r.Agent != *f.Agent {
+		return false
+	}
+	if f.Scenario != nil && r.Scenario != *f.Scenario {
+		return false
+	}
+	if f.From != nil && r.Timestamp.Before(*f.From) {
+		return false
+	}
+	if f.To != nil && r.Timestamp.After(*f.To) {
+		return false
+	}
+	return true
+}

--- a/cmd/cortex-gateway/internal/observatory/storage_test.go
+++ b/cmd/cortex-gateway/internal/observatory/storage_test.go
@@ -1,0 +1,211 @@
+package observatory
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func makeRecord(shift int, model, agent, scenario string, ts time.Time) ObservationRecord {
+	return ObservationRecord{
+		Timestamp: ts,
+		Shift:     shift,
+		Model:     model,
+		Agent:     agent,
+		Scenario:  scenario,
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.5,
+			GroupPolarization:      0.1,
+			CommunicationScore:     0.7,
+			PersonalityConsistency: 0.9,
+			ResponseCreativity:     0.6,
+			EmotionalRange:         0.5,
+		},
+	}
+}
+
+func TestNewObservationStore(t *testing.T) {
+	store := NewObservationStore()
+	if store.Len() != 0 {
+		t.Errorf("new store should be empty, got %d records", store.Len())
+	}
+}
+
+func TestStoreAddAndAllRecords(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(2, "llama-3.1-70b", "Agent-16", "meeting", now.Add(time.Hour)))
+
+	records := store.AllRecords()
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].Agent != "Agent-01" {
+		t.Errorf("first record agent = %s, want Agent-01", records[0].Agent)
+	}
+	if records[1].Agent != "Agent-16" {
+		t.Errorf("second record agent = %s, want Agent-16", records[1].Agent)
+	}
+}
+
+func TestStoreAllRecordsReturnsCopy(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+
+	records := store.AllRecords()
+	records[0].Agent = "MODIFIED"
+
+	original := store.AllRecords()
+	if original[0].Agent == "MODIFIED" {
+		t.Error("AllRecords should return a copy, not a reference to internal data")
+	}
+}
+
+func TestStoreQueryByShift(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(2, "claude-sonnet", "Agent-16", "daily_routine", now))
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-02", "meeting", now))
+
+	shift := 1
+	results := store.Query(QueryFilter{Shift: &shift})
+	if len(results) != 2 {
+		t.Errorf("expected 2 shift-1 records, got %d", len(results))
+	}
+}
+
+func TestStoreQueryByModel(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(1, "llama-3.1-70b", "Agent-02", "daily_routine", now))
+
+	model := "claude-sonnet"
+	results := store.Query(QueryFilter{Model: &model})
+	if len(results) != 1 {
+		t.Errorf("expected 1 claude-sonnet record, got %d", len(results))
+	}
+}
+
+func TestStoreQueryByAgent(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-02", "meeting", now))
+
+	agent := "Agent-01"
+	results := store.Query(QueryFilter{Agent: &agent})
+	if len(results) != 1 {
+		t.Errorf("expected 1 Agent-01 record, got %d", len(results))
+	}
+}
+
+func TestStoreQueryByScenario(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-02", "meeting", now))
+
+	scenario := "meeting"
+	results := store.Query(QueryFilter{Scenario: &scenario})
+	if len(results) != 1 {
+		t.Errorf("expected 1 meeting record, got %d", len(results))
+	}
+}
+
+func TestStoreQueryByTimeRange(t *testing.T) {
+	store := NewObservationStore()
+	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", base))
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-02", "daily_routine", base.Add(2*time.Hour)))
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-03", "daily_routine", base.Add(4*time.Hour)))
+
+	from := base.Add(1 * time.Hour)
+	to := base.Add(3 * time.Hour)
+	results := store.Query(QueryFilter{From: &from, To: &to})
+	if len(results) != 1 {
+		t.Errorf("expected 1 record in time range, got %d", len(results))
+	}
+}
+
+func TestStoreQueryCombinedFilters(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(1, "llama-3.1-70b", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(2, "claude-sonnet", "Agent-01", "daily_routine", now))
+
+	shift := 1
+	model := "claude-sonnet"
+	results := store.Query(QueryFilter{Shift: &shift, Model: &model})
+	if len(results) != 1 {
+		t.Errorf("expected 1 record matching shift+model, got %d", len(results))
+	}
+}
+
+func TestStoreQueryEmptyFilter(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+	store.Add(makeRecord(2, "llama-3.1-70b", "Agent-16", "meeting", now))
+
+	// Empty filter should return all
+	results := store.Query(QueryFilter{})
+	if len(results) != 2 {
+		t.Errorf("expected 2 records with empty filter, got %d", len(results))
+	}
+}
+
+func TestStoreQueryNoMatch(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+	store.Add(makeRecord(1, "claude-sonnet", "Agent-01", "daily_routine", now))
+
+	model := "nonexistent"
+	results := store.Query(QueryFilter{Model: &model})
+	if len(results) != 0 {
+		t.Errorf("expected 0 records for nonexistent model, got %d", len(results))
+	}
+}
+
+func TestStoreConcurrentAccess(t *testing.T) {
+	store := NewObservationStore()
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	// 10 concurrent writers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(shift int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				store.Add(makeRecord(shift%3+1, "claude-sonnet", "Agent-01", "daily_routine", now))
+			}
+		}(i)
+	}
+
+	// 5 concurrent readers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = store.AllRecords()
+				_ = store.Query(QueryFilter{})
+				_ = store.Len()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if store.Len() != 1000 {
+		t.Errorf("expected 1000 records after concurrent writes, got %d", store.Len())
+	}
+}

--- a/cmd/cortex-gateway/internal/proxy/provider.go
+++ b/cmd/cortex-gateway/internal/proxy/provider.go
@@ -38,12 +38,12 @@ type Provider interface {
 // ProviderConfig holds configuration for a provider.
 type ProviderConfig struct {
 	Name      string `toml:"name"`
-	Type      string `toml:"type"`      // "claude" or "ollama"
+	Type      string `toml:"type"` // "claude" or "ollama"
 	BaseURL   string `toml:"base_url"`
-	APIKey    string `toml:"api_key"`   // From env var, not config file
+	APIKey    string `toml:"api_key"` // From env var, not config file
 	Model     string `toml:"model"`
 	MaxTokens int    `toml:"max_tokens"`
-	Priority  int    `toml:"priority"`  // Lower = higher priority
+	Priority  int    `toml:"priority"` // Lower = higher priority
 }
 
 // Registry manages available LLM providers.

--- a/config/observatory.toml
+++ b/config/observatory.toml
@@ -1,0 +1,31 @@
+# MARBLE Observatory Configuration
+# Multi-Agent Runtime Behavioral Lab Environment
+# Compares LLM provider quality across identical scenarios
+
+[observatory]
+enabled = false  # Feature Flag: SENTINEL_OBSERVATORY=true zum Aktivieren
+
+# Schicht 1: Claude (Premium)
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15  # AGENT-01 bis AGENT-15
+
+# Schicht 2: Llama (Open Source)
+[observatory.shift_2]
+model = "llama-3.1-70b"
+provider = "ollama"
+agents = 15  # AGENT-16 bis AGENT-30
+
+# Schicht 3: Qwen (Alternative)
+[observatory.shift_3]
+model = "qwen2.5-72b"
+provider = "ollama"
+agents = 15  # AGENT-31 bis AGENT-45
+
+# Identische Szenarien pro Schicht
+[observatory.scenarios]
+daily_routine = true
+crisis_response = true
+creative_task = true
+conflict_resolution = true


### PR DESCRIPTION
## Summary

- Add `observatory` Go package with 6 MARBLE metrics for comparing LLM providers across identical simulation scenarios
- Integrate with existing `judge` package (DriftDetector, QualityScorer, FatigueDetector) for real metric computation
- Add `config/observatory.toml` with multi-model configuration (3 shifts: Claude, Llama, Qwen; 4 scenarios)
- Feature flag via `SENTINEL_OBSERVATORY` env var (default: disabled)

## New Files (8)

| File | Purpose |
|------|---------|
| `config/observatory.toml` | Multi-model observatory configuration |
| `internal/observatory/config.go` | TOML parser + validation |
| `internal/observatory/metrics.go` | 6 MARBLE metrics (real formulas, no stubs) |
| `internal/observatory/storage.go` | Thread-safe in-memory ObservationStore |
| `internal/observatory/report.go` | Markdown + JSON report generator |
| `*_test.go` (4 files) | 42 tests with race detector |

## MARBLE Metrics

1. **InfoPropagation**: `(reached/total) * accuracy`
2. **GroupPolarization**: Population variance of sentiment values
3. **CommunicationScore**: judge.QualityScorer integration (normalized 0-1)
4. **PersonalityConsistency**: `1.0 - avg(DriftScore)` via judge.DriftDetector
5. **ResponseCreativity**: `0.5 * shannonEntropy + 0.5 * uniqueBigramRatio`
6. **EmotionalRange**: `unique(emotions) / possible`

## Acceptance Criteria

- [x] AC1: Observatory Config parseable (3 shifts, 3 models)
- [x] AC2: All 6 MARBLE metrics computable
- [x] AC3: Data persistently stored (in-memory store)
- [x] AC4: Comparison report generatable (Markdown + JSON)
- [x] AC5: Feature flag SENTINEL_OBSERVATORY controls activation
- [x] AC6: Tests green (42 tests, -race)

## Test plan

- [x] `go test -race -count=1 ./internal/observatory/...` (42 PASS)
- [x] `go test -race ./...` (all packages green, 0 regressions)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `cargo fmt/clippy/deny` clean (Rust unchanged)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)