### PR TITLE
feat(limbo): complete EventStore scope (snapshots, compensation, monotonic offsets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sprint 6: `config/observatory.toml`: Multi-model observatory configuration (3 shifts: Claude, Llama, Qwen; 4 scenarios; feature flag via SENTINEL_OBSERVATORY)
 - `sentinel-zenoh` extended: SHM-Fallback (AC2), Scoped Queries with UUIDv7/deadline/min_tick (AC1/AC3), InFlightTracker with global=128/per-agent=8 Semaphore limits (AC4), BusConfig ENV parsing, query metrics (stale_drop, timeout, duration, inflight gauge)
 - `sentinel-telemetry`: Gauge metric type (AtomicI64) with set/increment/decrement/get, integrated into MetricsRegistry and snapshot_raw
+- `sentinel-limbo` EventStore: `snapshots` table with `save_snapshot()` and `get_latest_snapshot()` (auto-incrementing version)
+- `sentinel-limbo` EventStore: `compensation_type` field (Saga-Pattern, default "none") in events table and DomainEvent
+- `sentinel-limbo` EventStore: Monotonic offset enforcement in `update_offset()` (returns `MonotonicityError` on violation)
+- `sentinel-limbo` EventStore: `event_count()` and `get_all_events()` for rebuild/recovery
+- `sentinel-limbo` EventStore: Telemetry instrumentation (Counter + Histogram for append, query, snapshot, outbox)
+- `sentinel-limbo` EventStore: 7 acceptance tests (AC-1 through AC-7) and 4 new unit tests
+- `sentinel-common` DomainEvent: `compensation_type` field with `with_compensation_type()` builder
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +538,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +573,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "combine"
@@ -628,6 +698,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +794,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1187,6 +1299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1613,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1892,6 +2035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2258,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pnet_base"
@@ -2341,6 +2518,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redb"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2584,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2803,6 +3012,7 @@ name = "sentinel-limbo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "rusqlite",
  "sentinel-common",
  "sentinel-telemetry",
@@ -3374,6 +3584,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4456,7 +4676,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
- "itertools",
+ "itertools 0.14.0",
  "json5",
  "lazy_static",
  "nonempty-collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 anyhow = "1"
 toml = "1.0"
 approx = "0.5"
+criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -31,6 +31,8 @@ pub struct DomainEvent {
     pub timestamp_ms: u64,
     /// Schema-Version fuer Forward-Compatibility
     pub schema_version: u32,
+    /// Kompensations-Typ fuer Saga-Pattern (default: "none")
+    pub compensation_type: String,
 }
 
 impl DomainEvent {
@@ -58,6 +60,7 @@ impl DomainEvent {
             tick,
             timestamp_ms: now_ms,
             schema_version: 1,
+            compensation_type: "none".to_string(),
         }
     }
 
@@ -76,6 +79,12 @@ impl DomainEvent {
     /// Setzt eine explizite operation_id (Idempotenz).
     pub fn with_operation_id(mut self, operation_id: &str) -> Self {
         self.operation_id = operation_id.to_string();
+        self
+    }
+
+    /// Setzt den Kompensations-Typ (Saga-Pattern).
+    pub fn with_compensation_type(mut self, compensation_type: &str) -> Self {
+        self.compensation_type = compensation_type.to_string();
         self
     }
 }

--- a/crates/sentinel-limbo/Cargo.toml
+++ b/crates/sentinel-limbo/Cargo.toml
@@ -25,3 +25,8 @@ uuid = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
 rusqlite = { version = "0.38", features = ["bundled"] }
+criterion = { workspace = true }
+
+[[bench]]
+name = "event_store_bench"
+harness = false

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -290,10 +290,10 @@ fn bench_mixed_workload_tick(c: &mut Criterion) {
 
             // 3. Offset erhoehen
             offset += 1;
-            black_box(store.update_offset("bench-projection", offset).unwrap());
+            store.update_offset("bench-projection", offset).unwrap();
 
             // 4. Snapshot alle 10 Ticks
-            if tick % 10 == 0 {
+            if tick.is_multiple_of(10) {
                 black_box(
                     store
                         .save_snapshot(

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -1,0 +1,386 @@
+//! Benchmarks fuer EventStore Operationen.
+//!
+//! Misst IOPS-kritische Pfade auf SQLite (WAL mode).
+//! Wichtig fuer DRAM-lose NVMe Ziel-Hardware.
+//!
+//! WICHTIG: Diese Benchmarks MUESSEN auf der Deployment-VM ausgefuehrt werden
+//! (NICHT auf dem Build-Server/LXC). Siehe CLAUDE.md.
+//!
+//! Benchmark-Kategorien:
+//! 1. Einzeloperationen (Latenz pro Call)
+//! 2. Throughput-Szenario: 100 Ticks × 15 Agents (>100 ticks/s Schwellenwert)
+//! 3. Realistisches Mixed-Workload Szenario
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use sentinel_common::DomainEvent;
+use sentinel_limbo::EventStore;
+
+/// Anzahl Agents pro Schicht (SSOT: config/rooms.toml + sprint2-domain.md)
+const AGENTS_PER_SHIFT: u64 = 15;
+/// Tick-Rate Schwellenwert aus CLAUDE.md (>100 ticks/s)
+const MIN_TICKS_PER_SECOND: u64 = 100;
+
+fn make_event(i: u64) -> DomainEvent {
+    DomainEvent::new(
+        "transit_started",
+        &format!("AGENT-{:02}", (i % 15) + 1),
+        &format!(r#"{{"step":{i}}}"#),
+        "corr-bench",
+        i * 100,
+    )
+}
+
+fn bench_append_event(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_append.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut i = 0u64;
+    c.bench_function("append_event", |b| {
+        b.iter(|| {
+            let event = make_event(i);
+            black_box(store.append_event(&event).unwrap());
+            i += 1;
+        });
+    });
+}
+
+fn bench_append_with_outbox(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_outbox.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut i = 0u64;
+    c.bench_function("append_with_outbox", |b| {
+        b.iter(|| {
+            let event = make_event(i);
+            black_box(
+                store
+                    .append_with_outbox(&event, "sentinel/events/bench")
+                    .unwrap(),
+            );
+            i += 1;
+        });
+    });
+}
+
+fn bench_get_events_since(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_query.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 1000 Events vorbereiten
+    for i in 0..1000u64 {
+        let event = make_event(i);
+        store.append_event(&event).unwrap();
+    }
+
+    let mut group = c.benchmark_group("get_events_since");
+    for limit in [10, 50, 100, 500] {
+        group.bench_with_input(BenchmarkId::from_parameter(limit), &limit, |b, &limit| {
+            b.iter(|| {
+                black_box(store.get_events_since(0, limit).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_get_events_by_aggregate(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_aggregate.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 1000 Events verteilt auf 15 Agents
+    for i in 0..1000u64 {
+        let event = make_event(i);
+        store.append_event(&event).unwrap();
+    }
+
+    c.bench_function("get_events_by_aggregate", |b| {
+        b.iter(|| {
+            black_box(store.get_events_by_aggregate("AGENT-01", 100).unwrap());
+        });
+    });
+}
+
+fn bench_save_snapshot(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_snap.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut version = 0i64;
+    c.bench_function("save_snapshot", |b| {
+        b.iter(|| {
+            version += 1;
+            black_box(
+                store
+                    .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":42}"#, version)
+                    .unwrap(),
+            );
+        });
+    });
+}
+
+fn bench_get_latest_snapshot(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_snap_read.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 10 Snapshots anlegen
+    for i in 1..=10 {
+        store
+            .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":42}"#, i)
+            .unwrap();
+    }
+
+    c.bench_function("get_latest_snapshot", |b| {
+        b.iter(|| {
+            black_box(store.get_latest_snapshot("AGENT-01").unwrap());
+        });
+    });
+}
+
+fn bench_poll_outbox(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_poll.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 500 Events mit Outbox
+    for i in 0..500u64 {
+        let event = make_event(i);
+        store
+            .append_with_outbox(&event, "sentinel/events/bench")
+            .unwrap();
+    }
+
+    c.bench_function("poll_outbox_50", |b| {
+        b.iter(|| {
+            black_box(store.poll_outbox(50).unwrap());
+        });
+    });
+}
+
+fn bench_get_all_events(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_rebuild.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 1000 Events fuer Rebuild-Szenario
+    for i in 0..1000u64 {
+        let event = make_event(i);
+        store.append_event(&event).unwrap();
+    }
+
+    c.bench_function("get_all_events_1000", |b| {
+        b.iter(|| {
+            black_box(store.get_all_events().unwrap());
+        });
+    });
+}
+
+fn bench_event_count(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_count.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    for i in 0..1000u64 {
+        let event = make_event(i);
+        store.append_event(&event).unwrap();
+    }
+
+    c.bench_function("event_count", |b| {
+        b.iter(|| {
+            black_box(store.event_count().unwrap());
+        });
+    });
+}
+
+// ──────────────────────────────────────────────
+// Throughput: 100 Ticks mit 15 Agents
+// ──────────────────────────────────────────────
+
+/// Simuliert einen einzelnen Tick: Jeder der 15 Agents schreibt ein Event.
+/// Misst ob ein Tick unter 10ms bleibt (= >100 ticks/s moeglich).
+fn bench_single_tick_15_agents(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_tick.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut tick = 0u64;
+    c.bench_function("single_tick_15_agents", |b| {
+        b.iter(|| {
+            for agent in 1..=AGENTS_PER_SHIFT {
+                let event = DomainEvent::new(
+                    "agent_action_received",
+                    &format!("AGENT-{agent:02}"),
+                    &format!(r#"{{"tick":{tick},"action":"work"}}"#),
+                    &format!("corr-tick-{tick}"),
+                    tick * 100,
+                );
+                black_box(store.append_event(&event).unwrap());
+            }
+            tick += 1;
+        });
+    });
+}
+
+/// Throughput-Test: 100 Ticks × 15 Agents = 1500 Events.
+/// Validiert den >100 ticks/s Schwellenwert aus CLAUDE.md.
+fn bench_100_ticks_15_agents_throughput(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_throughput.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    c.bench_function("100_ticks_15_agents", |b| {
+        b.iter(|| {
+            for tick in 0..MIN_TICKS_PER_SECOND {
+                for agent in 1..=AGENTS_PER_SHIFT {
+                    let event = DomainEvent::new(
+                        "agent_action_received",
+                        &format!("AGENT-{agent:02}"),
+                        &format!(r#"{{"tick":{tick},"action":"work"}}"#),
+                        &format!("corr-tp-{tick}"),
+                        tick * 100,
+                    );
+                    black_box(store.append_event(&event).unwrap());
+                }
+            }
+        });
+    });
+}
+
+// ──────────────────────────────────────────────
+// Mixed Workload: Realistischer Tick-Zyklus
+// ──────────────────────────────────────────────
+
+/// Simuliert einen realistischen Tick-Zyklus:
+/// 1. 15 Agent-Events appenden (mit Outbox fuer Zenoh)
+/// 2. Outbox pollen (Publisher-Seite)
+/// 3. Offset aktualisieren (Projection Bookmark)
+/// 4. Alle 10 Ticks: Snapshot speichern
+fn bench_mixed_workload_tick(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_mixed.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut tick = 0u64;
+    let mut offset = 0i64;
+
+    c.bench_function("mixed_workload_tick", |b| {
+        b.iter(|| {
+            // 1. Agent-Events mit Outbox
+            for agent in 1..=AGENTS_PER_SHIFT {
+                let event = DomainEvent::new(
+                    "agent_action_received",
+                    &format!("AGENT-{agent:02}"),
+                    &format!(r#"{{"tick":{tick},"action":"work"}}"#),
+                    &format!("corr-mix-{tick}"),
+                    tick * 100,
+                );
+                black_box(
+                    store
+                        .append_with_outbox(&event, &format!("sentinel/events/AGENT-{agent:02}"))
+                        .unwrap(),
+                );
+            }
+
+            // 2. Outbox pollen
+            black_box(store.poll_outbox(20).unwrap());
+
+            // 3. Offset erhoehen
+            offset += 1;
+            black_box(store.update_offset("bench-projection", offset).unwrap());
+
+            // 4. Snapshot alle 10 Ticks
+            if tick % 10 == 0 {
+                black_box(
+                    store
+                        .save_snapshot(
+                            "AGENT-01",
+                            "bio_state",
+                            r#"{"hunger":42,"energy":75}"#,
+                            offset,
+                        )
+                        .unwrap(),
+                );
+            }
+
+            tick += 1;
+        });
+    });
+}
+
+// ──────────────────────────────────────────────
+// Skalierung: DB-Groesse Impact auf Reads
+// ──────────────────────────────────────────────
+
+/// Misst Read-Performance bei wachsender DB (100, 1K, 10K Events).
+/// Wichtig fuer IOPS-Budget auf DRAM-loser NVMe.
+fn bench_read_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_scaling");
+
+    for event_count in [100u64, 1_000, 10_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("bench_scale_{event_count}.db"));
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        for i in 0..event_count {
+            let event = make_event(i);
+            store.append_event(&event).unwrap();
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("get_events_since_50", event_count),
+            &event_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(store.get_events_since(0, 50).unwrap());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("get_events_by_aggregate", event_count),
+            &event_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(store.get_events_by_aggregate("AGENT-01", 50).unwrap());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("event_count", event_count),
+            &event_count,
+            |b, _| {
+                b.iter(|| {
+                    black_box(store.event_count().unwrap());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    // Einzeloperationen
+    bench_append_event,
+    bench_append_with_outbox,
+    bench_get_events_since,
+    bench_get_events_by_aggregate,
+    bench_save_snapshot,
+    bench_get_latest_snapshot,
+    bench_poll_outbox,
+    bench_get_all_events,
+    bench_event_count,
+    // Throughput (>100 ticks/s Schwellenwert)
+    bench_single_tick_15_agents,
+    bench_100_ticks_15_agents_throughput,
+    // Realistisches Szenario
+    bench_mixed_workload_tick,
+    // Skalierung (IOPS-Impact)
+    bench_read_scaling,
+);
+criterion_main!(benches);

--- a/crates/sentinel-limbo/src/event_store.rs
+++ b/crates/sentinel-limbo/src/event_store.rs
@@ -10,8 +10,13 @@
 
 use rusqlite::{params, Connection};
 use sentinel_common::DomainEvent;
+use std::fmt;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, info, instrument};
+
+/// Histogram-Buckets fuer EventStore Latenzen (Mikrosekunden).
+#[cfg(feature = "telemetry")]
+const LATENCY_BUCKETS: &[f64] = &[50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0];
 
 // ──────────────────────────────────────────────
 // SQL Schema
@@ -29,7 +34,8 @@ CREATE TABLE IF NOT EXISTS events (
     operation_id TEXT NOT NULL,
     tick INTEGER NOT NULL,
     timestamp_ms INTEGER NOT NULL,
-    schema_version INTEGER NOT NULL DEFAULT 1
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    compensation_type TEXT NOT NULL DEFAULT 'none'
 )";
 
 const CREATE_IDX_EVENTS_AGGREGATE: &str =
@@ -55,6 +61,20 @@ CREATE TABLE IF NOT EXISTS outbox (
 const CREATE_IDX_OUTBOX_PENDING: &str =
     "CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(status) WHERE status = 'pending'";
 
+const CREATE_SNAPSHOTS: &str = "
+CREATE TABLE IF NOT EXISTS snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    aggregate_id TEXT NOT NULL,
+    snapshot_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    last_event_id INTEGER NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL
+)";
+
+const CREATE_IDX_SNAPSHOTS_AGGREGATE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_snapshots_aggregate ON snapshots(aggregate_id, version DESC)";
+
 const CREATE_PROJECTION_OFFSETS: &str = "
 CREATE TABLE IF NOT EXISTS projection_offsets (
     projection_name TEXT PRIMARY KEY,
@@ -66,6 +86,26 @@ CREATE TABLE IF NOT EXISTS projection_offsets (
 // OutboxEntry
 // ──────────────────────────────────────────────
 
+/// Fehler bei Monotonie-Verletzung von projection_offsets.
+#[derive(Debug)]
+pub struct MonotonicityError {
+    pub projection: String,
+    pub current: i64,
+    pub attempted: i64,
+}
+
+impl fmt::Display for MonotonicityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "monotonicity violation for projection '{}': current={}, attempted={}",
+            self.projection, self.current, self.attempted
+        )
+    }
+}
+
+impl std::error::Error for MonotonicityError {}
+
 /// Zeile aus der Outbox-Tabelle fuer den Publisher.
 #[derive(Debug, Clone)]
 pub struct OutboxEntry {
@@ -74,6 +114,18 @@ pub struct OutboxEntry {
     pub topic: String,
     pub payload: String,
     pub status: String,
+    pub created_at: u64,
+}
+
+/// Zeile aus der Snapshots-Tabelle.
+#[derive(Debug, Clone)]
+pub struct SnapshotRow {
+    pub id: i64,
+    pub aggregate_id: String,
+    pub snapshot_type: String,
+    pub payload: String,
+    pub last_event_id: i64,
+    pub version: i32,
     pub created_at: u64,
 }
 
@@ -111,6 +163,8 @@ impl EventStore {
         conn.execute(CREATE_IDX_EVENTS_OPERATION, [])?;
         conn.execute_batch(CREATE_OUTBOX)?;
         conn.execute(CREATE_IDX_OUTBOX_PENDING, [])?;
+        conn.execute_batch(CREATE_SNAPSHOTS)?;
+        conn.execute(CREATE_IDX_SNAPSHOTS_AGGREGATE, [])?;
         conn.execute_batch(CREATE_PROJECTION_OFFSETS)?;
 
         info!("EventStore opened at {path}");
@@ -121,12 +175,13 @@ impl EventStore {
 
     /// Append-only: Fuegt ein Event ein. Gibt die interne Row-ID zurueck.
     pub fn append_event(&self, event: &DomainEvent) -> anyhow::Result<i64> {
+        let _telemetry_start = std::time::Instant::now();
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
         conn.execute(
-            "INSERT OR IGNORE INTO events (event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            "INSERT OR IGNORE INTO events (event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 event.event_id,
                 event.event_type,
@@ -138,9 +193,18 @@ impl EventStore {
                 event.tick as i64,
                 event.timestamp_ms as i64,
                 event.schema_version,
+                event.compensation_type,
             ],
         )?;
-        Ok(conn.last_insert_rowid())
+        let row_id = conn.last_insert_rowid();
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.event.append.count").increment();
+            reg.histogram("sentinel.limbo.event.append.duration_us", LATENCY_BUCKETS)
+                .observe(_telemetry_start.elapsed().as_micros() as f64);
+        }
+        Ok(row_id)
     }
 
     /// Atomar: Event + Outbox-Eintrag in einer Transaktion (AC1, AC3).
@@ -148,6 +212,7 @@ impl EventStore {
     /// Nutzt operation_id als Idempotenz-Key (UNIQUE INDEX).
     /// Bei Duplikat (gleiche operation_id) wird kein neuer Eintrag erstellt.
     pub fn append_with_outbox(&self, event: &DomainEvent, topic: &str) -> anyhow::Result<i64> {
+        let _telemetry_start = std::time::Instant::now();
         let mut conn = self
             .conn
             .lock()
@@ -156,7 +221,7 @@ impl EventStore {
 
         // INSERT OR IGNORE: Idempotenz via operation_id UNIQUE INDEX
         let inserted = tx.execute(
-            "INSERT OR IGNORE INTO events (event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            "INSERT OR IGNORE INTO events (event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 event.event_id,
                 event.event_type,
@@ -168,6 +233,7 @@ impl EventStore {
                 event.tick as i64,
                 event.timestamp_ms as i64,
                 event.schema_version,
+                event.compensation_type,
             ],
         )?;
 
@@ -188,6 +254,17 @@ impl EventStore {
         tx.commit()?;
 
         debug!(event_id = %event.event_id, event_type = %event.event_type, "event appended");
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.event.append_outbox.count")
+                .increment();
+            reg.histogram(
+                "sentinel.limbo.event.append_outbox.duration_us",
+                LATENCY_BUCKETS,
+            )
+            .observe(_telemetry_start.elapsed().as_micros() as f64);
+        }
         Ok(row_id)
     }
 
@@ -197,12 +274,13 @@ impl EventStore {
         after_id: i64,
         limit: usize,
     ) -> anyhow::Result<Vec<DomainEvent>> {
+        let _telemetry_start = std::time::Instant::now();
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
         let mut stmt = conn.prepare(
-            "SELECT event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version FROM events WHERE id > ?1 ORDER BY id ASC LIMIT ?2",
+            "SELECT event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type FROM events WHERE id > ?1 ORDER BY id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![after_id, limit as i64], |row| {
             Ok(DomainEvent {
@@ -216,11 +294,19 @@ impl EventStore {
                 tick: row.get::<_, i64>(7)? as u64,
                 timestamp_ms: row.get::<_, i64>(8)? as u64,
                 schema_version: row.get::<_, i32>(9)? as u32,
+                compensation_type: row.get(10)?,
             })
         })?;
         let mut results = Vec::new();
         for row in rows {
             results.push(row?);
+        }
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.event.query.count").increment();
+            reg.histogram("sentinel.limbo.event.query.duration_us", LATENCY_BUCKETS)
+                .observe(_telemetry_start.elapsed().as_micros() as f64);
         }
         Ok(results)
     }
@@ -236,7 +322,7 @@ impl EventStore {
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
         let mut stmt = conn.prepare(
-            "SELECT event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version FROM events WHERE aggregate_id = ?1 ORDER BY id ASC LIMIT ?2",
+            "SELECT event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type FROM events WHERE aggregate_id = ?1 ORDER BY id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![aggregate_id, limit as i64], |row| {
             Ok(DomainEvent {
@@ -250,6 +336,7 @@ impl EventStore {
                 tick: row.get::<_, i64>(7)? as u64,
                 timestamp_ms: row.get::<_, i64>(8)? as u64,
                 schema_version: row.get::<_, i32>(9)? as u32,
+                compensation_type: row.get(10)?,
             })
         })?;
         let mut results = Vec::new();
@@ -259,10 +346,92 @@ impl EventStore {
         Ok(results)
     }
 
+    // ── Snapshots ──────────────────────────────────
+
+    /// Speichert einen Snapshot fuer ein Aggregate. Version wird automatisch inkrementiert.
+    pub fn save_snapshot(
+        &self,
+        aggregate_id: &str,
+        snapshot_type: &str,
+        payload: &str,
+        last_event_id: i64,
+    ) -> anyhow::Result<i64> {
+        let _telemetry_start = std::time::Instant::now();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        // Aktuelle Version ermitteln
+        let current_version: i32 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(version), 0) FROM snapshots WHERE aggregate_id = ?1",
+                params![aggregate_id],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        conn.execute(
+            "INSERT INTO snapshots (aggregate_id, snapshot_type, payload, last_event_id, version, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                aggregate_id,
+                snapshot_type,
+                payload,
+                last_event_id,
+                current_version + 1,
+                now_ms,
+            ],
+        )?;
+        let row_id = conn.last_insert_rowid();
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.snapshot.save.count")
+                .increment();
+            reg.histogram("sentinel.limbo.snapshot.save.duration_us", LATENCY_BUCKETS)
+                .observe(_telemetry_start.elapsed().as_micros() as f64);
+        }
+        Ok(row_id)
+    }
+
+    /// Liest den neuesten Snapshot fuer ein Aggregate.
+    pub fn get_latest_snapshot(&self, aggregate_id: &str) -> anyhow::Result<Option<SnapshotRow>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let result = conn.query_row(
+            "SELECT id, aggregate_id, snapshot_type, payload, last_event_id, version, created_at FROM snapshots WHERE aggregate_id = ?1 ORDER BY version DESC LIMIT 1",
+            params![aggregate_id],
+            |row| {
+                Ok(SnapshotRow {
+                    id: row.get(0)?,
+                    aggregate_id: row.get(1)?,
+                    snapshot_type: row.get(2)?,
+                    payload: row.get(3)?,
+                    last_event_id: row.get(4)?,
+                    version: row.get(5)?,
+                    created_at: row.get::<_, i64>(6)? as u64,
+                })
+            },
+        );
+        match result {
+            Ok(snap) => Ok(Some(snap)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     // ── Outbox ──────────────────────────────────
 
     /// Pollt pending Outbox-Eintraege fuer den Zenoh-Publisher.
     pub fn poll_outbox(&self, limit: usize) -> anyhow::Result<Vec<OutboxEntry>> {
+        let _telemetry_start = std::time::Instant::now();
         let conn = self
             .conn
             .lock()
@@ -283,6 +452,13 @@ impl EventStore {
         let mut results = Vec::new();
         for row in rows {
             results.push(row?);
+        }
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.outbox.poll.count").increment();
+            reg.histogram("sentinel.limbo.outbox.poll.duration_us", LATENCY_BUCKETS)
+                .observe(_telemetry_start.elapsed().as_micros() as f64);
         }
         Ok(results)
     }
@@ -324,12 +500,35 @@ impl EventStore {
         }
     }
 
-    /// Setzt den Offset einer Projection (upsert).
+    /// Setzt den Offset einer Projection (upsert, monoton steigend).
+    ///
+    /// Gibt `MonotonicityError` zurueck wenn der neue Offset <= aktueller Offset ist.
     pub fn update_offset(&self, name: &str, offset: i64) -> anyhow::Result<()> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        // Aktuellen Offset pruefen
+        let current: Option<i64> = conn
+            .query_row(
+                "SELECT last_event_id FROM projection_offsets WHERE projection_name = ?1",
+                params![name],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if let Some(current_val) = current {
+            if offset <= current_val {
+                return Err(MonotonicityError {
+                    projection: name.to_string(),
+                    current: current_val,
+                    attempted: offset,
+                }
+                .into());
+            }
+        }
+
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -339,6 +538,51 @@ impl EventStore {
             params![name, offset, now_ms],
         )?;
         Ok(())
+    }
+
+    // ── Rebuild / Recovery ──────────────────────
+
+    /// Zaehlt alle Events im Store.
+    pub fn event_count(&self) -> anyhow::Result<i64> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let count: i64 = conn.query_row("SELECT count(*) FROM events", [], |row| row.get(0))?;
+        Ok(count)
+    }
+
+    /// Liest ALLE Events geordnet nach interner ID (fuer Rebuild/Recovery).
+    ///
+    /// Achtung: Nur fuer Rebuild/Recovery verwenden, nicht fuer normalen Betrieb.
+    pub fn get_all_events(&self) -> anyhow::Result<Vec<DomainEvent>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let mut stmt = conn.prepare(
+            "SELECT event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type FROM events ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(DomainEvent {
+                event_id: row.get(0)?,
+                event_type: row.get(1)?,
+                aggregate_id: row.get(2)?,
+                payload: row.get(3)?,
+                correlation_id: row.get(4)?,
+                causation_id: row.get(5)?,
+                operation_id: row.get(6)?,
+                tick: row.get::<_, i64>(7)? as u64,
+                timestamp_ms: row.get::<_, i64>(8)? as u64,
+                schema_version: row.get::<_, i32>(9)? as u32,
+                compensation_type: row.get(10)?,
+            })
+        })?;
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
     }
 
     /// Zugriff auf Connection fuer Tests.
@@ -375,6 +619,11 @@ mod tests {
 
         let count: i64 = conn
             .query_row("SELECT count(*) FROM outbox", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM snapshots", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
 
@@ -569,5 +818,131 @@ mod tests {
             .query_row("PRAGMA journal_mode", [], |row| row.get(0))
             .unwrap();
         assert_eq!(mode.to_lowercase(), "wal");
+    }
+
+    /// AC4: Monotonie-Enforcement fuer projection_offsets.
+    #[test]
+    fn test_monotonic_offset_enforcement() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-monotonic.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        // Offset setzen
+        store.update_offset("test-proj", 10).unwrap();
+        assert_eq!(store.get_offset("test-proj").unwrap(), Some(10));
+
+        // Gleicher Wert muss fehlschlagen (nicht strikt groesser)
+        let result = store.update_offset("test-proj", 10);
+        assert!(
+            result.is_err(),
+            "same offset should fail monotonicity check"
+        );
+
+        // Kleinerer Wert muss fehlschlagen
+        let result = store.update_offset("test-proj", 5);
+        assert!(
+            result.is_err(),
+            "smaller offset should fail monotonicity check"
+        );
+
+        // Groesserer Wert muss funktionieren
+        store.update_offset("test-proj", 20).unwrap();
+        assert_eq!(store.get_offset("test-proj").unwrap(), Some(20));
+    }
+
+    /// Snapshot save + get Roundtrip.
+    #[test]
+    fn test_save_and_get_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-snap.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        // Kein Snapshot vorhanden
+        assert!(store.get_latest_snapshot("AGENT-01").unwrap().is_none());
+
+        // Snapshot speichern
+        let id = store
+            .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":50}"#, 5)
+            .unwrap();
+        assert!(id > 0);
+
+        // Snapshot lesen
+        let snap = store.get_latest_snapshot("AGENT-01").unwrap().unwrap();
+        assert_eq!(snap.aggregate_id, "AGENT-01");
+        assert_eq!(snap.snapshot_type, "bio_state");
+        assert_eq!(snap.payload, r#"{"hunger":50}"#);
+        assert_eq!(snap.last_event_id, 5);
+        assert_eq!(snap.version, 1);
+
+        // Zweiter Snapshot = Version 2
+        store
+            .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":80}"#, 10)
+            .unwrap();
+        let snap2 = store.get_latest_snapshot("AGENT-01").unwrap().unwrap();
+        assert_eq!(snap2.version, 2);
+        assert_eq!(snap2.last_event_id, 10);
+        assert_eq!(snap2.payload, r#"{"hunger":80}"#);
+    }
+
+    /// AC5: Rebuild aus Events - Reihenfolge und Daten bleiben erhalten.
+    #[test]
+    fn test_get_all_events_ordered() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-rebuild.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        // 5 Events einfuegen
+        for i in 0..5u64 {
+            let event = DomainEvent::new(
+                "transit_started",
+                &format!("AGENT-{:02}", i + 1),
+                &format!(r#"{{"step":{i}}}"#),
+                "corr-rebuild",
+                i * 10,
+            );
+            store.append_event(&event).unwrap();
+        }
+
+        assert_eq!(store.event_count().unwrap(), 5);
+
+        // Alle Events lesen
+        let all = store.get_all_events().unwrap();
+        assert_eq!(all.len(), 5);
+
+        // Reihenfolge = Insertion Order (aufsteigende Ticks)
+        for (idx, event) in all.iter().enumerate() {
+            assert_eq!(event.tick, (idx as u64) * 10);
+            assert_eq!(event.aggregate_id, format!("AGENT-{:02}", idx + 1));
+        }
+
+        // Zweites Lesen = identisch (Reproduzierbarkeit)
+        let all2 = store.get_all_events().unwrap();
+        assert_eq!(all.len(), all2.len());
+        for (a, b) in all.iter().zip(all2.iter()) {
+            assert_eq!(a.event_id, b.event_id);
+            assert_eq!(a.tick, b.tick);
+            assert_eq!(a.payload, b.payload);
+        }
+    }
+
+    /// compensation_type Persistierung und Roundtrip.
+    #[test]
+    fn test_compensation_type_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-compensation.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        // Default compensation_type = "none"
+        let event1 = test_event("transit_started", "AGENT-01");
+        store.append_event(&event1).unwrap();
+
+        // Expliziter compensation_type
+        let event2 = test_event("transit_started", "AGENT-02").with_compensation_type("rollback");
+        store.append_event(&event2).unwrap();
+
+        let events = store.get_events_since(0, 10).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].compensation_type, "none");
+        assert_eq!(events[1].compensation_type, "rollback");
     }
 }

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -10,7 +10,7 @@
 
 pub mod event_store;
 
-pub use event_store::{EventStore, OutboxEntry};
+pub use event_store::{EventStore, MonotonicityError, OutboxEntry, SnapshotRow};
 
 use rusqlite::{params, Connection};
 use sentinel_common::{AgentId, Emotion, EventType, RoomId, Tick, Timestamp};

--- a/crates/sentinel-limbo/tests/acceptance.rs
+++ b/crates/sentinel-limbo/tests/acceptance.rs
@@ -1,17 +1,19 @@
 //! Acceptance tests for sentinel-limbo (Issue #8).
 
-use sentinel_common::{AgentId, Emotion, RoomId, Tick, Timestamp};
-use sentinel_limbo::ChatStore;
+use sentinel_common::{AgentId, DomainEvent, Emotion, RoomId, Tick, Timestamp};
+use sentinel_limbo::{ChatStore, EventStore};
 
-/// AC 8.2: All 4 tables are created on open
+// ──────────────────────────────────────────────
+// ChatStore Acceptance Tests
+// ──────────────────────────────────────────────
+
+/// ChatStore: Alle 4 Tabellen werden bei open erstellt.
 #[tokio::test]
-async fn ac_08_02_four_tables_created() {
-    // AC 8.2: DB open creates messages, meetings, observations, chaos_events tables
+async fn ac_08_chat_tables_created() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.db");
     let _store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
-    // Verify tables via direct SQLite query
     let conn = rusqlite::Connection::open(&path).unwrap();
     let mut stmt = conn
         .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
@@ -44,18 +46,14 @@ async fn ac_08_02_four_tables_created() {
     );
 }
 
-/// AC 8.3: Performance pragmas are set correctly
+/// ChatStore: Performance Pragmas aktiv.
 #[tokio::test]
-async fn ac_08_03_performance_pragmas() {
-    // AC 8.3: Verify journal_mode, synchronous, mmap_size, page_size
+async fn ac_08_chat_performance_pragmas() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.db");
     let _store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
 
-    // journal_mode=WAL ist persistent in der DB-Datei, daher verifizierbar
-    // ueber eine zweite Connection.
     let conn = rusqlite::Connection::open(&path).unwrap();
-
     let mode: String = conn
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();
@@ -66,11 +64,6 @@ async fn ac_08_03_performance_pragmas() {
         mode
     );
 
-    // synchronous ist connection-local (NICHT persistent in der DB-Datei).
-    // Eine neue Connection hat immer den Default (FULL=2).
-    // Wir verifizieren stattdessen, dass der PRAGMA-String im Source korrekt ist,
-    // und testen journal_mode=WAL als Proxy dafuer, dass PRAGMAs ausgefuehrt werden.
-    // Zusaetzlich: WAL-Datei existiert (Beweis dass WAL aktiv ist).
     let wal_path = dir.path().join("test.db-wal");
     assert!(
         wal_path.exists(),
@@ -79,10 +72,9 @@ async fn ac_08_03_performance_pragmas() {
     );
 }
 
-/// AC 8.4: Messages insert and query roundtrip
+/// ChatStore: Messages Insert + Query Roundtrip.
 #[tokio::test]
-async fn ac_08_04_messages_roundtrip() {
-    // AC 8.4: insert_message(), get_room_messages(), content matches
+async fn ac_08_chat_messages_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.db");
     let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
@@ -112,10 +104,9 @@ async fn ac_08_04_messages_roundtrip() {
     assert_eq!(messages[0].tick, Tick(42));
 }
 
-/// AC 8.5: Meeting lifecycle (create, end, status)
+/// ChatStore: Meeting Lifecycle (create, end, status).
 #[tokio::test]
-async fn ac_08_05_meeting_lifecycle() {
-    // AC 8.5: create_meeting(), end_meeting(), verify status
+async fn ac_08_chat_meeting_lifecycle() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.db");
     let store = ChatStore::open(path.to_str().unwrap()).await.unwrap();
@@ -123,7 +114,6 @@ async fn ac_08_05_meeting_lifecycle() {
     let room = RoomId::new(5).unwrap();
     let participants = vec![AgentId::new(1).unwrap(), AgentId::new(2).unwrap()];
 
-    // Create meeting
     let meeting_id = store
         .insert_meeting(room, "Sprint Review", &participants, Timestamp(9000))
         .await
@@ -133,7 +123,6 @@ async fn ac_08_05_meeting_lifecycle() {
         "Meeting insert should return positive rowid"
     );
 
-    // Verify meeting is open (ended_at is NULL)
     let conn = rusqlite::Connection::open(dir.path().join("test.db")).unwrap();
     let ended_at: Option<i64> = conn
         .query_row(
@@ -144,13 +133,11 @@ async fn ac_08_05_meeting_lifecycle() {
         .unwrap();
     assert!(ended_at.is_none(), "Meeting should be open (ended_at NULL)");
 
-    // End meeting
     store
         .end_meeting(meeting_id, Timestamp(10800), "Sprint goals achieved")
         .await
         .unwrap();
 
-    // Verify meeting is closed
     let (ended_at, summary): (i64, String) = conn
         .query_row(
             "SELECT ended_at, summary FROM meetings WHERE id = ?1",
@@ -160,4 +147,211 @@ async fn ac_08_05_meeting_lifecycle() {
         .unwrap();
     assert_eq!(ended_at, 10800);
     assert_eq!(summary, "Sprint goals achieved");
+}
+
+// ──────────────────────────────────────────────
+// EventStore Acceptance Tests
+// ──────────────────────────────────────────────
+
+fn test_event(event_type: &str, aggregate_id: &str) -> DomainEvent {
+    DomainEvent::new(event_type, aggregate_id, r#"{"test":true}"#, "corr-ac", 42)
+}
+
+/// AC-1: events hat keinen Update/Delete Pfad.
+#[test]
+fn ac_08_01_events_append_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac01.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let event = test_event("agent_action_received", "AGENT-01");
+    store.append_event(&event).unwrap();
+
+    // EventStore API bietet kein update/delete — Event bleibt unveraendert
+    let events = store.get_events_since(0, 10).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_id, event.event_id);
+    assert_eq!(events[0].event_type, "agent_action_received");
+    assert_eq!(events[0].aggregate_id, "AGENT-01");
+    assert_eq!(events[0].payload, r#"{"test":true}"#);
+}
+
+/// AC-2: Event + Outbox Write sind atomar.
+#[test]
+fn ac_08_02_event_outbox_atomic() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac02.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let event = test_event("transit_started", "AGENT-02");
+    store
+        .append_with_outbox(&event, "sentinel/events/AGENT-02")
+        .unwrap();
+
+    // Beide muessen existieren (atomar)
+    assert_eq!(store.event_count().unwrap(), 1);
+    let outbox = store.poll_outbox(10).unwrap();
+    assert_eq!(outbox.len(), 1);
+    assert_eq!(outbox[0].event_id, event.event_id);
+    assert_eq!(outbox[0].topic, "sentinel/events/AGENT-02");
+}
+
+/// AC-3: operation_id bleibt bei Retry identisch (kein Duplikat).
+#[test]
+fn ac_08_03_operation_id_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac03.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let event1 = test_event("agent_action_received", "AGENT-01").with_operation_id("op-retry-abc");
+    store
+        .append_with_outbox(&event1, "sentinel/events/AGENT-01")
+        .unwrap();
+
+    // Retry: gleiche operation_id, anderer event_id
+    let event2 = test_event("agent_action_received", "AGENT-01").with_operation_id("op-retry-abc");
+    store
+        .append_with_outbox(&event2, "sentinel/events/AGENT-01")
+        .unwrap();
+
+    // Nur 1 Event, nicht 2
+    assert_eq!(store.event_count().unwrap(), 1);
+    let outbox = store.poll_outbox(10).unwrap();
+    assert_eq!(outbox.len(), 1, "Duplicate should not create outbox entry");
+}
+
+/// AC-4: projection_offsets steigt monoton.
+#[test]
+fn ac_08_04_offsets_monotonic() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac04.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // Erster Offset
+    store.update_offset("ac-test", 5).unwrap();
+    assert_eq!(store.get_offset("ac-test").unwrap(), Some(5));
+
+    // Erhoehung: ok
+    store.update_offset("ac-test", 10).unwrap();
+    assert_eq!(store.get_offset("ac-test").unwrap(), Some(10));
+
+    // Verringerung: muss fehlschlagen
+    let result = store.update_offset("ac-test", 3);
+    assert!(result.is_err(), "decreasing offset must fail");
+
+    // Gleicher Wert: muss fehlschlagen
+    let result = store.update_offset("ac-test", 10);
+    assert!(result.is_err(), "same offset must fail");
+
+    // Offset ist unveraendert
+    assert_eq!(store.get_offset("ac-test").unwrap(), Some(10));
+}
+
+/// AC-5: Rebuild aus events ist reproduzierbar.
+#[test]
+fn ac_08_05_rebuild_reproducible() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac05.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // 10 Events mit deterministischen Daten einfuegen
+    for i in 0..10u64 {
+        let event = DomainEvent::new(
+            "transit_started",
+            &format!("AGENT-{:02}", (i % 5) + 1),
+            &format!(r#"{{"step":{i}}}"#),
+            "corr-rebuild",
+            i * 100,
+        );
+        store.append_event(&event).unwrap();
+    }
+
+    assert_eq!(store.event_count().unwrap(), 10);
+
+    // Erstes Lesen
+    let read1 = store.get_all_events().unwrap();
+    assert_eq!(read1.len(), 10);
+
+    // Zweites Lesen (Reproduzierbarkeit)
+    let read2 = store.get_all_events().unwrap();
+    assert_eq!(read2.len(), 10);
+
+    // Reihenfolge und Daten identisch
+    for (a, b) in read1.iter().zip(read2.iter()) {
+        assert_eq!(a.event_id, b.event_id);
+        assert_eq!(a.event_type, b.event_type);
+        assert_eq!(a.aggregate_id, b.aggregate_id);
+        assert_eq!(a.payload, b.payload);
+        assert_eq!(a.tick, b.tick);
+        assert_eq!(a.correlation_id, b.correlation_id);
+        assert_eq!(a.operation_id, b.operation_id);
+        assert_eq!(a.compensation_type, b.compensation_type);
+    }
+
+    // Reihenfolge = aufsteigend nach Tick (= Insertion Order)
+    for i in 1..read1.len() {
+        assert!(
+            read1[i].tick >= read1[i - 1].tick,
+            "Events should be in insertion order"
+        );
+    }
+}
+
+/// Scope: snapshots Tabelle mit save + get Roundtrip.
+#[test]
+fn ac_08_06_snapshots_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac06.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // Kein Snapshot vorhanden
+    assert!(store.get_latest_snapshot("AGENT-01").unwrap().is_none());
+
+    // Events einfuegen
+    for i in 0..3 {
+        let event = test_event("bio_action_performed", "AGENT-01")
+            .with_operation_id(&format!("op-snap-{i}"));
+        store.append_event(&event).unwrap();
+    }
+
+    // Snapshot speichern
+    store
+        .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":42}"#, 3)
+        .unwrap();
+
+    let snap = store.get_latest_snapshot("AGENT-01").unwrap().unwrap();
+    assert_eq!(snap.aggregate_id, "AGENT-01");
+    assert_eq!(snap.snapshot_type, "bio_state");
+    assert_eq!(snap.payload, r#"{"hunger":42}"#);
+    assert_eq!(snap.last_event_id, 3);
+    assert_eq!(snap.version, 1);
+
+    // Zweiter Snapshot = hoehere Version
+    store
+        .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":80}"#, 6)
+        .unwrap();
+    let snap2 = store.get_latest_snapshot("AGENT-01").unwrap().unwrap();
+    assert_eq!(snap2.version, 2);
+    assert_eq!(snap2.last_event_id, 6);
+}
+
+/// Scope: compensation_type Feld persistieren und lesen.
+#[test]
+fn ac_08_07_compensation_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac07.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    // Default compensation_type
+    let event1 = test_event("transit_started", "AGENT-01");
+    store.append_event(&event1).unwrap();
+
+    // Expliziter compensation_type
+    let event2 = test_event("transit_started", "AGENT-02").with_compensation_type("rollback");
+    store.append_event(&event2).unwrap();
+
+    let events = store.get_events_since(0, 10).unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].compensation_type, "none");
+    assert_eq!(events[1].compensation_type, "rollback");
 }


### PR DESCRIPTION
## Summary

Brings Issue #8 (`sentinel-limbo`) from PARTIAL to FULL scope by implementing all missing EventStore features.

### Changes

- **snapshots table**: `save_snapshot()` + `get_latest_snapshot()` with auto-incrementing version per aggregate
- **compensation_type**: New field in `DomainEvent` and `events` SQL table (Saga-Pattern, default `"none"`)
- **Monotonic offsets**: `update_offset()` now returns `MonotonicityError` on non-increasing values
- **Rebuild**: `event_count()` + `get_all_events()` for deterministic rebuild/recovery
- **Telemetry**: Counter + Histogram instrumentation for append, query, snapshot, outbox operations
- **Tests**: 7 acceptance tests (AC-1 through AC-7) + 4 new unit tests

### Acceptance Criteria

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | events hat keinen Update/Delete Pfad | PASS (`ac_08_01_events_append_only`) |
| AC-2 | Event + Outbox Write atomar | PASS (`ac_08_02_event_outbox_atomic`) |
| AC-3 | operation_id bei Retry identisch | PASS (`ac_08_03_operation_id_idempotent`) |
| AC-4 | projection_offsets steigt monoton | PASS (`ac_08_04_offsets_monotonic`) |
| AC-5 | Rebuild aus events reproduzierbar | PASS (`ac_08_05_rebuild_reproducible`) |

### Additional Scope (Issue Body)

| Feature | Status |
|---------|--------|
| snapshots table | PASS (`ac_08_06_snapshots_table`) |
| compensation_type field | PASS (`ac_08_07_compensation_type`) |
| EventStore telemetry | Implemented (Counter + Histogram) |

### Verification

```
cargo remote -- test -p sentinel-limbo -p sentinel-common
  → 29 tests passed (18 unit + 11 acceptance)
cargo remote -- clippy -p sentinel-limbo -p sentinel-common -- -D warnings
  → 0 warnings
cargo fmt --all -- --check
  → clean
typos .
  → clean
RUSTDOCFLAGS="-D warnings" cargo remote -- doc -p sentinel-limbo -p sentinel-common --no-deps
  → clean
```

## Test plan

- [x] All 29 tests pass (18 unit + 11 acceptance)
- [x] Clippy clean with `-D warnings`
- [x] Rustdoc clean with `-D warnings`
- [x] `cargo fmt` clean
- [x] `typos` clean
- [ ] VM deployment test (`ubuntu@10.0.0.240`)
- [ ] CI checks (blocked: GitHub Actions minutes exhausted)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)