### PR TITLE
fix(ci): skip PR quality gate for bot actors

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -21,6 +21,12 @@ jobs:
             const body = pr.body || "";
             const failures = [];
 
+            const botActors = ["dependabot[bot]", "github-actions[bot]", "renovate[bot]"];
+            if (botActors.includes(pr.user.login)) {
+              core.info(`Bot PR detected (${pr.user.login}). Skipping quality gate.`);
+              return;
+            }
+
             if (pr.draft) {
               core.info("Draft PR detected. Skipping strict quality gate until ready_for_review.");
               return;


### PR DESCRIPTION
## Summary
- Skip PR quality gate for bot PRs (dependabot, github-actions, renovate)

## Context
Bot-generated PRs cannot fill the PR template sections (Summary, Linked Issues, AC Evidence). This causes false `gate` failures on every Dependabot PR.

## Test plan
- [ ] Dependabot PR re-run: `gate` job should pass with skip message

🤖 Generated with [Claude Code](https://claude.com/claude-code)