### PR TITLE
fix(ci): self-hosted runner compatibility for security audit + bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: latest
 
       - name: Install
         working-directory: dashboard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,6 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: latest
       - name: Install dependencies
         working-directory: dashboard
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Add `dtolnay/rust-toolchain` step before `rustsec/audit-check` (cargo not pre-installed on self-hosted)
- Add `bun-version: latest` to all `setup-bun` steps (version detection fails on self-hosted)

## Test plan
- [ ] `rust-audit` job passes (cargo available)
- [ ] `npm-audit` job passes (bun installs correctly)
- [ ] `dashboard` CI job passes (bun setup works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)