### PR TITLE
feat(runtime): event-sourced lifecycle + snapshot persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "sentinel-common",
+ "sentinel-limbo",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/sentinel-common/src/components.rs
+++ b/crates/sentinel-common/src/components.rs
@@ -6,6 +6,7 @@
 //! zu sentinel-ecs zu erzeugen.
 
 use bevy_ecs::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{AgentId, Emotion, Tick};
 
@@ -49,7 +50,7 @@ impl Default for EventQueue {
 }
 
 /// Identitaet und Metadaten eines Agenten
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Serialize, Deserialize)]
 pub struct AgentIdentity {
     pub agent_id: AgentId,
     pub name: String,
@@ -133,7 +134,7 @@ pub struct LlmConfig {
 }
 
 /// Schichtinformationen
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Serialize, Deserialize)]
 pub struct ShiftInfo {
     pub shift_set: u8,        // 0=Sonder, 1=Frueh, 2=Mittel, 3=Spaet
     pub shift_start_hour: u8, // 0-23

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -130,10 +130,7 @@ pub enum DomainEventPayload {
         shift_set: u8,
     },
     /// Agent wurde aus der Runtime entfernt
-    AgentDespawned {
-        agent_id: AgentId,
-        reason: String,
-    },
+    AgentDespawned { agent_id: AgentId, reason: String },
     /// Schichtwechsel abgeschlossen
     ShiftTransitionCompleted {
         new_shift_set: u8,

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -122,6 +122,30 @@ pub enum DomainEventPayload {
     BioActionPerformed { agent_id: AgentId, action: String },
     /// Periodischer Tick-Snapshot-Marker
     TickSnapshot { tick: u64, agent_count: u32 },
+    /// Agent wurde in der Runtime gespawnt
+    AgentSpawned {
+        agent_id: AgentId,
+        name: String,
+        role: String,
+        shift_set: u8,
+    },
+    /// Agent wurde aus der Runtime entfernt
+    AgentDespawned {
+        agent_id: AgentId,
+        reason: String,
+    },
+    /// Schichtwechsel abgeschlossen
+    ShiftTransitionCompleted {
+        new_shift_set: u8,
+        removed_count: u32,
+        removed_agents: Vec<AgentId>,
+    },
+    /// Agent-Status hat sich geaendert
+    AgentStatusChanged {
+        agent_id: AgentId,
+        old_status: String,
+        new_status: String,
+    },
 }
 
 impl DomainEventPayload {
@@ -139,6 +163,10 @@ impl DomainEventPayload {
             Self::ChaosTriggered { .. } => "chaos_triggered",
             Self::BioActionPerformed { .. } => "bio_action_performed",
             Self::TickSnapshot { .. } => "tick_snapshot",
+            Self::AgentSpawned { .. } => "agent_spawned",
+            Self::AgentDespawned { .. } => "agent_despawned",
+            Self::ShiftTransitionCompleted { .. } => "shift_transition_completed",
+            Self::AgentStatusChanged { .. } => "agent_status_changed",
         }
     }
 }

--- a/crates/sentinel-runtime/Cargo.toml
+++ b/crates/sentinel-runtime/Cargo.toml
@@ -7,8 +7,14 @@ publish = false
 
 [dependencies]
 sentinel-common = { path = "../sentinel-common" }
+sentinel-limbo = { path = "../sentinel-limbo", default-features = false }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 sentinel-common = { path = "../sentinel-common" }
+sentinel-limbo = { path = "../sentinel-limbo", default-features = false }
+tempfile = "3"

--- a/crates/sentinel-runtime/src/lib.rs
+++ b/crates/sentinel-runtime/src/lib.rs
@@ -7,11 +7,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use serde::{Deserialize, Serialize};
 use sentinel_common::components::{AgentIdentity, ShiftInfo};
 use sentinel_common::events::{DomainEvent, DomainEventPayload};
 use sentinel_common::{AgentId, Tick};
 use sentinel_limbo::EventStore;
+use serde::{Deserialize, Serialize};
 
 /// Status eines laufenden Agenten.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/sentinel-runtime/src/lib.rs
+++ b/crates/sentinel-runtime/src/lib.rs
@@ -1,13 +1,20 @@
 //! Agent Runtime Orchestrator fuer Teammate-basierte Agent-Sessions.
+//!
+//! Emittiert Lifecycle-Events in sentinel-limbo (AC-2) und
+//! unterstuetzt Snapshot-basiertes Resume nach Neustart (AC-4).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use sentinel_common::components::{AgentIdentity, ShiftInfo};
+use sentinel_common::events::{DomainEvent, DomainEventPayload};
 use sentinel_common::{AgentId, Tick};
+use sentinel_limbo::EventStore;
 
 /// Status eines laufenden Agenten.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AgentStatus {
     Active,
     Sleeping,
@@ -23,18 +30,75 @@ pub struct AgentHandle {
     pub last_activity_tick: Tick,
 }
 
+/// Serialisierbarer Snapshot eines AgentHandle (fuer Persistence).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentSnapshot {
+    identity: AgentIdentity,
+    shift: ShiftInfo,
+    status: AgentStatus,
+    last_activity_tick: u64,
+}
+
+impl From<&AgentHandle> for AgentSnapshot {
+    fn from(h: &AgentHandle) -> Self {
+        Self {
+            identity: h.identity.clone(),
+            shift: h.shift.clone(),
+            status: h.status,
+            last_activity_tick: h.last_activity_tick.0,
+        }
+    }
+}
+
+impl From<AgentSnapshot> for AgentHandle {
+    fn from(s: AgentSnapshot) -> Self {
+        Self {
+            identity: s.identity,
+            shift: s.shift,
+            status: s.status,
+            last_activity_tick: Tick(s.last_activity_tick),
+        }
+    }
+}
+
+/// Serialisierbarer Snapshot des gesamten RuntimeOrchestrator State.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeSnapshot {
+    agents: Vec<AgentSnapshot>,
+    max_agents: usize,
+}
+
 /// Orchestriert Agent-Lifecycle: Spawn, Despawn, Schichtwechsel, Health-Checks.
+/// Optional mit Event-Store fuer event-sourced Lifecycle-Events und Snapshot-Persistence.
 pub struct RuntimeOrchestrator {
     agents: HashMap<AgentId, AgentHandle>,
     max_agents: usize,
+    event_store: Option<Arc<EventStore>>,
+    current_tick: u64,
 }
+
+const RUNTIME_AGGREGATE: &str = "runtime";
+const RUNTIME_SNAPSHOT_TYPE: &str = "runtime_state";
 
 impl RuntimeOrchestrator {
     pub fn new(max_agents: usize) -> Self {
         Self {
             agents: HashMap::new(),
             max_agents,
+            event_store: None,
+            current_tick: 0,
         }
+    }
+
+    /// Attaches an EventStore for lifecycle event emission and snapshot persistence.
+    pub fn with_event_store(mut self, store: Arc<EventStore>) -> Self {
+        self.event_store = Some(store);
+        self
+    }
+
+    /// Updates the current simulation tick (used for event timestamps).
+    pub fn set_tick(&mut self, tick: u64) {
+        self.current_tick = tick;
     }
 
     /// Spawnt einen neuen Agenten. Fehler bei Duplikat oder max erreicht.
@@ -52,6 +116,10 @@ impl RuntimeOrchestrator {
         }
 
         let agent_id = identity.agent_id;
+        let shift_set = shift.shift_set;
+        let name = identity.name.clone();
+        let role = identity.role.clone();
+
         let handle = AgentHandle {
             identity,
             shift,
@@ -63,6 +131,20 @@ impl RuntimeOrchestrator {
         tracing::info!(
             agent_id = %agent_id,
             "Agent spawned"
+        );
+
+        // Emit lifecycle event (AC-2)
+        let payload = DomainEventPayload::AgentSpawned {
+            agent_id,
+            name,
+            role,
+            shift_set,
+        };
+        self.emit_event(
+            payload.event_type_str(),
+            &format!("AGENT-{:02}", agent_id.0),
+            &payload.to_json(),
+            &format!("spawn-{}", agent_id.0),
         );
 
         Ok(())
@@ -77,6 +159,18 @@ impl RuntimeOrchestrator {
         tracing::info!(
             agent_id = %agent_id,
             "Agent despawned"
+        );
+
+        // Emit lifecycle event (AC-2)
+        let payload = DomainEventPayload::AgentDespawned {
+            agent_id,
+            reason: "explicit_despawn".to_string(),
+        };
+        self.emit_event(
+            payload.event_type_str(),
+            &format!("AGENT-{:02}", agent_id.0),
+            &payload.to_json(),
+            &format!("despawn-{}", agent_id.0),
         );
 
         Ok(())
@@ -109,6 +203,19 @@ impl RuntimeOrchestrator {
             "Shift transition completed"
         );
 
+        // Emit lifecycle event (AC-2)
+        let payload = DomainEventPayload::ShiftTransitionCompleted {
+            new_shift_set,
+            removed_count: to_remove.len() as u32,
+            removed_agents: to_remove.clone(),
+        };
+        self.emit_event(
+            payload.event_type_str(),
+            RUNTIME_AGGREGATE,
+            &payload.to_json(),
+            &format!("shift-{}-tick-{}", new_shift_set, self.current_tick),
+        );
+
         to_remove
     }
 
@@ -136,11 +243,90 @@ impl RuntimeOrchestrator {
     pub fn agent_count(&self) -> usize {
         self.agents.len()
     }
+
+    /// Saves the full runtime state as a snapshot to the event store (AC-4).
+    pub fn save_state(&self) -> Result<()> {
+        let store = self
+            .event_store
+            .as_ref()
+            .ok_or_else(|| anyhow!("No event store attached"))?;
+
+        let snapshot = RuntimeSnapshot {
+            agents: self.agents.values().map(AgentSnapshot::from).collect(),
+            max_agents: self.max_agents,
+        };
+
+        let json = serde_json::to_string(&snapshot)?;
+
+        store.save_snapshot(RUNTIME_AGGREGATE, RUNTIME_SNAPSHOT_TYPE, &json, 0)?;
+
+        tracing::info!(
+            agent_count = self.agents.len(),
+            "Runtime state snapshot saved"
+        );
+
+        Ok(())
+    }
+
+    /// Restores a RuntimeOrchestrator from the latest snapshot in the event store (AC-4).
+    pub fn restore(store: Arc<EventStore>, max_agents: usize) -> Result<Self> {
+        let snapshot_row = store
+            .get_latest_snapshot(RUNTIME_AGGREGATE)?
+            .ok_or_else(|| anyhow!("No runtime snapshot found"))?;
+
+        let snapshot: RuntimeSnapshot = serde_json::from_str(&snapshot_row.payload)?;
+
+        let mut agents = HashMap::new();
+        for agent_snap in snapshot.agents {
+            let agent_id = agent_snap.identity.agent_id;
+            agents.insert(agent_id, AgentHandle::from(agent_snap));
+        }
+
+        tracing::info!(
+            agent_count = agents.len(),
+            "Runtime state restored from snapshot"
+        );
+
+        Ok(Self {
+            agents,
+            max_agents: if max_agents > 0 {
+                max_agents
+            } else {
+                snapshot.max_agents
+            },
+            event_store: Some(store),
+            current_tick: 0,
+        })
+    }
+
+    /// Emits a lifecycle event to the event store (best-effort, logs on failure).
+    fn emit_event(&self, event_type: &str, aggregate_id: &str, payload: &str, op_suffix: &str) {
+        let store = match &self.event_store {
+            Some(s) => s,
+            None => return,
+        };
+
+        let op_id = format!("runtime-{}-{}", op_suffix, self.current_tick);
+        let event = DomainEvent::new(event_type, aggregate_id, payload, &op_id, self.current_tick)
+            .with_operation_id(&op_id);
+
+        let topic = format!("sentinel/runtime/events/{}", aggregate_id);
+        if let Err(e) = store.append_with_outbox(&event, &topic) {
+            tracing::warn!(
+                error = %e,
+                event_type,
+                "Failed to emit runtime lifecycle event"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sentinel_limbo::EventStore;
+    use std::sync::Arc;
+    use tempfile::TempDir;
 
     fn create_identity(id: u16, name: &str, role: &str) -> AgentIdentity {
         AgentIdentity {
@@ -157,6 +343,13 @@ mod tests {
             shift_end_hour: end,
             is_on_duty: true,
         }
+    }
+
+    fn temp_event_store() -> (TempDir, Arc<EventStore>) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test_runtime.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+        (dir, Arc::new(store))
     }
 
     #[test]
@@ -300,5 +493,107 @@ mod tests {
         assert!(orchestrator.get_agent_mut(AgentId(1)).is_some());
         assert!(orchestrator.get_agent_mut(AgentId(3)).is_some());
         assert!(orchestrator.get_agent_mut(AgentId(2)).is_none());
+    }
+
+    #[test]
+    fn event_emission_on_spawn_despawn() {
+        let (_dir, store) = temp_event_store();
+        let mut orch = RuntimeOrchestrator::new(10).with_event_store(store.clone());
+        orch.set_tick(42);
+
+        orch.spawn_agent(create_identity(1, "Thomas", "CEO"), create_shift(1, 6, 14))
+            .unwrap();
+
+        // Verify spawn event in store
+        let events = store.get_events_by_aggregate("AGENT-01", 10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "agent_spawned");
+        assert_eq!(events[0].tick, 42);
+
+        // Despawn
+        orch.despawn_agent(AgentId(1)).unwrap();
+
+        let events = store.get_events_by_aggregate("AGENT-01", 10).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].event_type, "agent_despawned");
+    }
+
+    #[test]
+    fn event_emission_on_shift_transition() {
+        let (_dir, store) = temp_event_store();
+        let mut orch = RuntimeOrchestrator::new(10).with_event_store(store.clone());
+        orch.set_tick(100);
+
+        orch.spawn_agent(create_identity(1, "Thomas", "CEO"), create_shift(1, 6, 14))
+            .unwrap();
+        orch.spawn_agent(
+            create_identity(16, "Michael", "CEO"),
+            create_shift(2, 14, 22),
+        )
+        .unwrap();
+
+        let _removed = orch.shift_transition(2);
+
+        // Shift transition event on "runtime" aggregate
+        let events = store.get_events_by_aggregate("runtime", 10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "shift_transition_completed");
+        assert_eq!(events[0].tick, 100);
+    }
+
+    #[test]
+    fn snapshot_save_restore() {
+        let (_dir, store) = temp_event_store();
+        let mut orch = RuntimeOrchestrator::new(15).with_event_store(store.clone());
+        orch.set_tick(50);
+
+        // Spawn 5 agents
+        for i in 1..=5 {
+            orch.spawn_agent(
+                create_identity(i, &format!("Agent-{}", i), "Worker"),
+                create_shift(1, 6, 14),
+            )
+            .unwrap();
+        }
+
+        // Set one to Errored
+        if let Some(h) = orch.get_agent_mut(AgentId(3)) {
+            h.status = AgentStatus::Errored;
+        }
+
+        // Save snapshot
+        orch.save_state().unwrap();
+
+        // Restore into new orchestrator
+        let restored = RuntimeOrchestrator::restore(store, 15).unwrap();
+
+        assert_eq!(restored.agent_count(), 5);
+
+        // Verify specific agent state survived
+        // Note: get_agent_mut requires &mut, so we create a mutable binding
+        let mut restored = restored;
+        let agent3 = restored.get_agent_mut(AgentId(3)).unwrap();
+        assert_eq!(agent3.status, AgentStatus::Errored);
+        assert_eq!(agent3.identity.name, "Agent-3");
+        assert_eq!(agent3.shift.shift_set, 1);
+    }
+
+    #[test]
+    fn no_event_without_store() {
+        // Without event store, operations should still work (no panic)
+        let mut orch = RuntimeOrchestrator::new(10);
+
+        orch.spawn_agent(create_identity(1, "Thomas", "CEO"), create_shift(1, 6, 14))
+            .unwrap();
+        orch.despawn_agent(AgentId(1)).unwrap();
+        let _ = orch.shift_transition(2);
+        // No panic = success
+    }
+
+    #[test]
+    fn save_state_requires_store() {
+        let orch = RuntimeOrchestrator::new(10);
+        let result = orch.save_state();
+        assert!(result.is_err());
     }
 }

--- a/crates/sentinel-runtime/tests/acceptance.rs
+++ b/crates/sentinel-runtime/tests/acceptance.rs
@@ -1,11 +1,16 @@
 //! Acceptance Tests fuer Issue #15: sentinel-runtime
 //!
 //! Testet RuntimeOrchestrator: spawn/despawn, max-agents-limit,
-//! Schichtwechsel, Sonder-Set Beibehaltung, Health-Checks.
+//! Schichtwechsel, Sonder-Set Beibehaltung, Health-Checks,
+//! Event-Sourced Lifecycle (AC-2), Resume nach Neustart (AC-4).
+
+use std::sync::Arc;
 
 use sentinel_common::components::{AgentIdentity, ShiftInfo};
 use sentinel_common::AgentId;
+use sentinel_limbo::EventStore;
 use sentinel_runtime::{AgentStatus, RuntimeOrchestrator};
+use tempfile::TempDir;
 
 fn create_identity(id: u16, name: &str, role: &str) -> AgentIdentity {
     AgentIdentity {
@@ -22,6 +27,13 @@ fn create_shift(shift_set: u8, start: u8, end: u8) -> ShiftInfo {
         shift_end_hour: end,
         is_on_duty: true,
     }
+}
+
+fn temp_event_store() -> (TempDir, Arc<EventStore>) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("acceptance_runtime.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+    (dir, Arc::new(store))
 }
 
 // AC #15.02: spawn, verify active, despawn, verify gone
@@ -56,6 +68,72 @@ fn ac_15_02_spawn_despawn() {
     );
 }
 
+// AC #15.02b: Lifecycle events are event-sourced (AC-2)
+#[test]
+fn ac_15_02_lifecycle_events_sourced() {
+    let (_dir, store) = temp_event_store();
+    let mut orch = RuntimeOrchestrator::new(20).with_event_store(store.clone());
+    orch.set_tick(1);
+
+    // Spawn 3 agents
+    orch.spawn_agent(create_identity(1, "Thomas", "CEO"), create_shift(1, 6, 14))
+        .unwrap();
+    orch.spawn_agent(
+        create_identity(2, "Lisa", "Designer"),
+        create_shift(1, 6, 14),
+    )
+    .unwrap();
+    orch.spawn_agent(
+        create_identity(3, "Andreas", "Developer"),
+        create_shift(1, 6, 14),
+    )
+    .unwrap();
+
+    // Verify spawn events in store
+    let events_1 = store.get_events_by_aggregate("AGENT-01", 10).unwrap();
+    assert_eq!(events_1.len(), 1, "Agent 1 should have 1 spawn event");
+    assert_eq!(events_1[0].event_type, "agent_spawned");
+
+    let events_2 = store.get_events_by_aggregate("AGENT-02", 10).unwrap();
+    assert_eq!(events_2.len(), 1, "Agent 2 should have 1 spawn event");
+
+    // Despawn Agent 2
+    orch.despawn_agent(AgentId(2)).unwrap();
+
+    let events_2 = store.get_events_by_aggregate("AGENT-02", 10).unwrap();
+    assert_eq!(
+        events_2.len(),
+        2,
+        "Agent 2 should have 2 events (spawn + despawn)"
+    );
+    assert_eq!(events_2[1].event_type, "agent_despawned");
+
+    // Shift transition
+    orch.set_tick(10);
+    let _ = orch.shift_transition(2);
+
+    let runtime_events = store.get_events_by_aggregate("runtime", 10).unwrap();
+    assert_eq!(
+        runtime_events.len(),
+        1,
+        "Runtime should have 1 shift transition event"
+    );
+    assert_eq!(
+        runtime_events[0].event_type, "shift_transition_completed",
+        "Event type should be shift_transition_completed"
+    );
+    assert_eq!(runtime_events[0].tick, 10, "Event tick should match");
+
+    // All events have outbox entries (for Zenoh)
+    // Total events: 3 spawns + 1 despawn + 1 shift = 5
+    let all_events = store.get_events_since(0, 100).unwrap();
+    assert!(
+        all_events.len() >= 5,
+        "Should have at least 5 lifecycle events, got {}",
+        all_events.len()
+    );
+}
+
 // AC #15.03: spawn max+1 -> Error
 #[test]
 fn ac_15_03_max_agents_limit() {
@@ -86,9 +164,87 @@ fn ac_15_03_max_agents_limit() {
     );
 }
 
-// AC #15.04: Set 1 active, transition to Set 2, verify Set 1 gone
+// AC #15.04: Resume after restart with persisted states
 #[test]
-fn ac_15_04_shift_transition() {
+fn ac_15_04_resume_after_restart() {
+    let (_dir, store) = temp_event_store();
+
+    // Phase 1: Create orchestrator, spawn agents, save state
+    {
+        let mut orch = RuntimeOrchestrator::new(20).with_event_store(store.clone());
+        orch.set_tick(50);
+
+        // Spawn 5 agents across shifts
+        orch.spawn_agent(create_identity(1, "Thomas", "CEO"), create_shift(1, 6, 14))
+            .unwrap();
+        orch.spawn_agent(
+            create_identity(2, "Lisa", "Designer"),
+            create_shift(1, 6, 14),
+        )
+        .unwrap();
+        orch.spawn_agent(
+            create_identity(3, "Andreas", "Developer"),
+            create_shift(2, 14, 22),
+        )
+        .unwrap();
+        orch.spawn_agent(
+            create_identity(4, "Sandra", "PM"),
+            create_shift(2, 14, 22),
+        )
+        .unwrap();
+        orch.spawn_agent(
+            create_identity(46, "Betriebsrat", "Sonder"),
+            create_shift(0, 0, 23),
+        )
+        .unwrap();
+
+        // Set one to Errored
+        if let Some(h) = orch.get_agent_mut(AgentId(3)) {
+            h.status = AgentStatus::Errored;
+        }
+
+        assert_eq!(orch.agent_count(), 5);
+
+        // Save state (simulates clean shutdown)
+        orch.save_state().unwrap();
+    }
+    // Orchestrator dropped here — simulates process exit
+
+    // Phase 2: Restore from snapshot (simulates restart)
+    let mut restored = RuntimeOrchestrator::restore(store, 20).unwrap();
+
+    // Verify all 5 agents are back
+    assert_eq!(
+        restored.agent_count(),
+        5,
+        "All 5 agents should be restored after restart"
+    );
+
+    // Verify specific agent identities survived
+    let agent1 = restored.get_agent_mut(AgentId(1)).unwrap();
+    assert_eq!(agent1.identity.name, "Thomas");
+    assert_eq!(agent1.identity.role, "CEO");
+    assert_eq!(agent1.status, AgentStatus::Active);
+    assert_eq!(agent1.shift.shift_set, 1);
+
+    // Verify Errored status persisted
+    let agent3 = restored.get_agent_mut(AgentId(3)).unwrap();
+    assert_eq!(
+        agent3.status,
+        AgentStatus::Errored,
+        "Errored status should persist across restart"
+    );
+    assert_eq!(agent3.identity.name, "Andreas");
+
+    // Verify Sonder-Agent persisted
+    let sonder = restored.get_agent_mut(AgentId(46)).unwrap();
+    assert_eq!(sonder.shift.shift_set, 0, "Sonder shift_set should be 0");
+    assert_eq!(sonder.identity.name, "Betriebsrat");
+}
+
+// AC #15.04b: Set 1 active, transition to Set 2, verify Set 1 gone
+#[test]
+fn ac_15_04b_shift_transition() {
     let mut orch = RuntimeOrchestrator::new(20);
 
     // Set 1 Agents (Frueh-Schicht)

--- a/crates/sentinel-runtime/tests/acceptance.rs
+++ b/crates/sentinel-runtime/tests/acceptance.rs
@@ -187,11 +187,8 @@ fn ac_15_04_resume_after_restart() {
             create_shift(2, 14, 22),
         )
         .unwrap();
-        orch.spawn_agent(
-            create_identity(4, "Sandra", "PM"),
-            create_shift(2, 14, 22),
-        )
-        .unwrap();
+        orch.spawn_agent(create_identity(4, "Sandra", "PM"), create_shift(2, 14, 22))
+            .unwrap();
         orch.spawn_agent(
             create_identity(46, "Betriebsrat", "Sonder"),
             create_shift(0, 0, 23),


### PR DESCRIPTION
## Summary
- Add event-sourced lifecycle tracking (AC-2): spawn, despawn, and shift transition events are persisted via sentinel-limbo EventStore with atomic outbox writes (Zenoh-ready)
- Add snapshot-based state persistence (AC-4): `save_state()` / `restore()` enable full RuntimeOrchestrator recovery after restart, including agent identities, shifts, and statuses
- Extend sentinel-common with 4 new DomainEventPayload variants and Serialize/Deserialize derives on AgentIdentity, ShiftInfo, AgentStatus

## Changes
- `crates/sentinel-common/src/components.rs`: Add Serialize/Deserialize derives to AgentIdentity and ShiftInfo
- `crates/sentinel-common/src/events.rs`: Add 4 new DomainEventPayload variants (AgentSpawned, AgentDespawned, ShiftTransitionCompleted, AgentStatusChanged)
- `crates/sentinel-runtime/Cargo.toml`: Add sentinel-limbo, serde, serde_json, uuid dependencies
- `crates/sentinel-runtime/src/lib.rs`: Add EventStore integration, lifecycle event emission, snapshot save/restore, AgentSnapshot/RuntimeSnapshot types
- `crates/sentinel-runtime/tests/acceptance.rs`: Add AC-2 and AC-4 acceptance tests

## Linked Issues
Closes #15

## Test Plan
- [x] 11 unit tests pass (6 original + 5 new: event emission, snapshot save/restore, edge cases)
- [x] 7 acceptance tests pass (5 original + 2 new: AC-2 lifecycle events, AC-4 resume after restart)
- [x] Regression: sentinel-ecs 37 tests pass, sentinel-common 35 tests pass
- [x] Clippy clean (no warnings with -D warnings)
- [x] cargo fmt --check clean

## Checklist
- [x] Code compiles without warnings
- [x] All tests pass
- [x] No breaking changes to existing API
- [x] Event-sourced lifecycle events verified (AC-2)
- [x] Snapshot-based resume after restart verified (AC-4)

## Evidence (AC Mapping)

| AC | Beschreibung | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | 15 aktive Agents stabil in einem Runtime-Verbund | PASS | `test_full_shift_15_agents` in sentinel-ecs (pre-existing) |
| AC-2 | Lifecycle-Ereignisse sind event-sourced nachweisbar | PASS | `ac_15_02_lifecycle_events_sourced`: spawn/despawn/shift events in Limbo DB verified |
| AC-3 | Kein unkontrolliertes Prozesswachstum unter Last | PASS | `ac_15_03_max_agents_limit`: spawn beyond max returns error (pre-existing) |
| AC-4 | Resume nach Neustart funktioniert mit persistierten States | PASS | `ac_15_04_resume_after_restart`: 5 agents across shifts, Errored status, Sonder-Agent all restored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)