### PR TITLE
feat(nightrun): implement sentinel-nightrun shift consolidation service

### DIFF
--- a/.github/workflows/issue-quality.yml
+++ b/.github/workflows/issue-quality.yml
@@ -27,6 +27,7 @@ jobs:
               { name: "Scope", variants: ["In Scope", "Scope"] },
               { name: "Out of Scope", variants: ["Out of Scope", "Nicht im Scope", "NICHT im Scope"] },
               { name: "Acceptance", variants: ["Acceptance Criteria", "Acceptance", "Akzeptanzkriterien"] },
+              { name: "Benchmarks", variants: ["Benchmarks", "Benchmark", "Performance"] },
             ];
             const sectionMissing = sectionGroups
               .filter((group) => {

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -37,6 +37,7 @@ jobs:
               "## Changes",
               "## Linked Issues",
               "## Test Plan",
+              "## Benchmarks",
               "## Evidence (AC Mapping)",
               "## Checklist",
             ];

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,10 +63,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -581,6 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -589,8 +634,22 @@ version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -598,6 +657,12 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1626,6 +1691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2103,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -3025,7 +3102,23 @@ dependencies = [
 name = "sentinel-nightrun"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap",
+ "criterion",
+ "libc",
+ "rusqlite",
  "sentinel-common",
+ "sentinel-hippocampus",
+ "sentinel-limbo",
+ "sentinel-telemetry",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3957,6 +4050,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1044,6 +1044,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d255a6b6ecd77bb93ce91de984d7039bff7503f500eb4851a1269732f22baf"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3162,6 +3193,8 @@ name = "sentinel-sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "criterion",
+ "landlock",
  "sentinel-common",
  "tracing",
 ]

--- a/config/nightrun.toml
+++ b/config/nightrun.toml
@@ -1,0 +1,26 @@
+# Sentinel Nightrun — Schichtwechsel-Konsolidierung
+#
+# Getriggert via systemd Timer bei 06:00, 14:00, 22:00.
+# Konsolidiert episodische Erinnerungen der abgehenden Schicht.
+
+[nightrun]
+# Pfad zur Hippocampus redb-Datenbank
+hippocampus_db = "data/hippocampus.redb"
+
+# Pfad zur Limbo Event-Store SQLite-Datenbank
+event_store_db = "data/events.db"
+
+# Verzeichnis mit Agent-TOML-Definitionen (fuer shift_set Filter)
+agent_config_dir = "config/agents"
+
+# Pfad zur Job-Queue SQLite-Datenbank (Crash-Recovery)
+job_queue_path = "data/nightrun-jobs.db"
+
+# Timeout pro Agent in Sekunden (default: 300)
+timeout_per_agent_secs = 300
+
+# Gesamt-Timeout in Sekunden (default: 7200 = 2h)
+timeout_total_secs = 7200
+
+# Max Episodes pro Agent bevor Skip (Backlog-Schutz)
+max_episodes_per_agent = 1000

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -143,6 +143,36 @@ pub enum DomainEventPayload {
         old_status: String,
         new_status: String,
     },
+    /// Nightrun-Konsolidierung gestartet
+    NightRunStarted {
+        run_id: String,
+        trigger_shift_set: u8,
+        agents_queued: u32,
+    },
+    /// Nightrun-Konsolidierung abgeschlossen
+    NightRunCompleted {
+        run_id: String,
+        trigger_shift_set: u8,
+        agents_consolidated: u32,
+        agents_failed: u32,
+        agents_skipped: u32,
+        total_episodes: u32,
+        duration_ms: u64,
+    },
+    /// Einzelner Agent konsolidiert
+    AgentConsolidated {
+        run_id: String,
+        agent_name: String,
+        episodes_processed: u32,
+        episodes_consolidated: u32,
+        duration_ms: u64,
+    },
+    /// Agent-Konsolidierung fehlgeschlagen
+    AgentConsolidationFailed {
+        run_id: String,
+        agent_name: String,
+        error: String,
+    },
 }
 
 impl DomainEventPayload {
@@ -164,6 +194,10 @@ impl DomainEventPayload {
             Self::AgentDespawned { .. } => "agent_despawned",
             Self::ShiftTransitionCompleted { .. } => "shift_transition_completed",
             Self::AgentStatusChanged { .. } => "agent_status_changed",
+            Self::NightRunStarted { .. } => "nightrun_started",
+            Self::NightRunCompleted { .. } => "nightrun_completed",
+            Self::AgentConsolidated { .. } => "agent_consolidated",
+            Self::AgentConsolidationFailed { .. } => "agent_consolidation_failed",
         }
     }
 }

--- a/crates/sentinel-sandbox/Cargo.toml
+++ b/crates/sentinel-sandbox/Cargo.toml
@@ -7,5 +7,13 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+landlock = "0.4"
 sentinel-common = { path = "../sentinel-common" }
 tracing = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "sandbox_bench"
+harness = false

--- a/crates/sentinel-sandbox/benches/sandbox_bench.rs
+++ b/crates/sentinel-sandbox/benches/sandbox_bench.rs
@@ -68,8 +68,8 @@ fn bench_cgroup_create_remove(c: &mut Criterion) {
 }
 
 fn bench_enforcer_setup_teardown(c: &mut Criterion) {
-    use std::sync::Arc;
     use sentinel_sandbox::{CgroupLimits, SandboxEnforcer};
+    use std::sync::Arc;
 
     let (enforcer, _) = SandboxEnforcer::detect();
 

--- a/crates/sentinel-sandbox/benches/sandbox_bench.rs
+++ b/crates/sentinel-sandbox/benches/sandbox_bench.rs
@@ -1,0 +1,104 @@
+//! Benchmarks fuer sentinel-sandbox Operationen (Issue #16).
+//!
+//! Misst Sandbox-Setup-Overhead:
+//! - BwrapConfig to_args() Generierung
+//! - Landlock Ruleset Erstellung
+//! - PSI String-Parsing
+//! - cgroup create + remove Zyklus (VM only)
+//! - SandboxEnforcer setup + teardown (VM only)
+//!
+//! WICHTIG: Die VM-only Benchmarks liefern nur auf der Deployment-VM
+//! (10.0.0.240) aussagekraeftige Ergebnisse. Auf anderen Systemen
+//! messen sie nur den Config-Overhead.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use sentinel_sandbox::BwrapConfig;
+
+fn bench_bwrap_config_to_args(c: &mut Criterion) {
+    c.bench_function("bwrap_config_to_args", |b| {
+        let config = BwrapConfig::for_agent("bench-agent");
+        b.iter(|| {
+            std::hint::black_box(config.to_args());
+        });
+    });
+}
+
+fn bench_landlock_ruleset_creation(c: &mut Criterion) {
+    use sentinel_sandbox::LandlockRuleset;
+
+    c.bench_function("landlock_ruleset_creation", |b| {
+        b.iter(|| {
+            std::hint::black_box(LandlockRuleset::for_agent("bench-agent"));
+        });
+    });
+}
+
+fn bench_psi_parse(c: &mut Criterion) {
+    let sample = "some avg10=1.50 avg60=2.30 avg300=0.10 total=12345\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0";
+
+    c.bench_function("psi_parse", |b| {
+        b.iter(|| {
+            std::hint::black_box(sentinel_sandbox::cgroups::parse_psi(sample).unwrap());
+        });
+    });
+}
+
+fn bench_cgroup_create_remove(c: &mut Criterion) {
+    use sentinel_sandbox::{CgroupLimits, SandboxEnforcer};
+
+    let (enforcer, _) = SandboxEnforcer::detect();
+
+    if !enforcer.has_cgroups() {
+        // On systems without cgroup access, benchmark the limits creation only
+        c.bench_function("cgroup_create_remove [no cgroup — limits only]", |b| {
+            b.iter(|| {
+                std::hint::black_box(CgroupLimits::default());
+            });
+        });
+        return;
+    }
+
+    let limits = CgroupLimits::default();
+    c.bench_function("cgroup_create_remove", |b| {
+        b.iter(|| {
+            sentinel_sandbox::cgroups::create_cgroup("bench-cgroup", &limits).unwrap();
+            sentinel_sandbox::cgroups::remove_cgroup("bench-cgroup").unwrap();
+        });
+    });
+}
+
+fn bench_enforcer_setup_teardown(c: &mut Criterion) {
+    use std::sync::Arc;
+    use sentinel_sandbox::{CgroupLimits, SandboxEnforcer};
+
+    let (enforcer, _) = SandboxEnforcer::detect();
+
+    if !enforcer.has_cgroups() {
+        c.bench_function("enforcer_setup_teardown [no cgroup — detect only]", |b| {
+            b.iter(|| {
+                std::hint::black_box(SandboxEnforcer::detect());
+            });
+        });
+        return;
+    }
+
+    let enforcer = Arc::new(enforcer);
+    let limits = CgroupLimits::default();
+
+    c.bench_function("enforcer_setup_teardown", |b| {
+        b.iter(|| {
+            let handle = enforcer.setup_agent("bench-enforcer", &limits).unwrap();
+            enforcer.teardown_agent(&handle).unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_bwrap_config_to_args,
+    bench_landlock_ruleset_creation,
+    bench_psi_parse,
+    bench_cgroup_create_remove,
+    bench_enforcer_setup_teardown,
+);
+criterion_main!(benches);

--- a/crates/sentinel-sandbox/src/bwrap.rs
+++ b/crates/sentinel-sandbox/src/bwrap.rs
@@ -51,7 +51,11 @@ impl BwrapConfig {
         let mut args = self.to_args();
         args.extend(command.iter().cloned());
 
-        info!("Spawning bwrap: {} args, command: {:?}", args.len(), command);
+        info!(
+            "Spawning bwrap: {} args, command: {:?}",
+            args.len(),
+            command
+        );
 
         Command::new("bwrap")
             .args(&args)

--- a/crates/sentinel-sandbox/src/bwrap.rs
+++ b/crates/sentinel-sandbox/src/bwrap.rs
@@ -1,5 +1,10 @@
 //! Bubblewrap sandbox configuration.
 
+use std::process::{Child, Command};
+
+use anyhow::{Context, Result};
+use tracing::info;
+
 /// Bubblewrap sandbox configuration fuer einen einzelnen Agenten.
 #[derive(Debug, Clone)]
 pub struct BwrapConfig {
@@ -22,6 +27,36 @@ impl BwrapConfig {
             share_net: true,
             die_with_parent: true,
         }
+    }
+
+    /// Tests whether bwrap user namespace creation works.
+    ///
+    /// Some systems (e.g. AppArmor) block unprivileged user namespaces.
+    /// Returns true if bwrap can create a minimal sandbox.
+    pub fn test_userns() -> bool {
+        Command::new("bwrap")
+            .args(["--unshare-user", "--ro-bind", "/", "/", "true"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Spawns a bwrap sandbox process with the configured isolation.
+    ///
+    /// Returns the Child handle. Caller is responsible for managing the child
+    /// (e.g. adding to cgroup, forgetting handle for --die-with-parent).
+    pub fn spawn(&self, command: &[String]) -> Result<Child> {
+        let mut args = self.to_args();
+        args.extend(command.iter().cloned());
+
+        info!("Spawning bwrap: {} args, command: {:?}", args.len(), command);
+
+        Command::new("bwrap")
+            .args(&args)
+            .spawn()
+            .context("Failed to spawn bwrap process")
     }
 
     /// Generiert bwrap CLI-Argumente.

--- a/crates/sentinel-sandbox/src/cgroups.rs
+++ b/crates/sentinel-sandbox/src/cgroups.rs
@@ -1,5 +1,8 @@
 //! cgroups v2 resource limits and PSI monitoring.
 
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+
 // PsiMetrics and parse_psi live in sentinel-common for cross-crate reuse.
 pub use sentinel_common::psi::{parse_psi, PsiMetrics};
 
@@ -25,9 +28,103 @@ impl Default for CgroupLimits {
     }
 }
 
+/// Result of creating a cgroup — tracks which controllers are available.
+#[derive(Debug)]
+pub struct CgroupSetup {
+    /// Whether the IO controller is delegated and io.max can be enforced.
+    pub io_available: bool,
+}
+
 /// Erzeugt den cgroup v2 Pfad fuer einen Agenten.
 pub fn cgroup_path(name: &str) -> String {
     format!("/sys/fs/cgroup/sentinel/{name}")
+}
+
+/// Creates a cgroup v2 for an agent with resource limits.
+///
+/// Creates the cgroup directory and writes cpu, memory, and io limits.
+/// IO limits are best-effort — if the IO controller is not delegated, they are skipped.
+pub fn create_cgroup(name: &str, limits: &CgroupLimits) -> Result<CgroupSetup> {
+    let path = cgroup_path(name);
+    std::fs::create_dir_all(&path)
+        .with_context(|| format!("Failed to create cgroup dir {path}"))?;
+
+    // CPU quota
+    let cpu_max = format!("{} {}", limits.cpu_quota_us, limits.cpu_period_us);
+    std::fs::write(format!("{path}/cpu.max"), &cpu_max)
+        .with_context(|| format!("Failed to write cpu.max for {name}"))?;
+    info!("cgroup {name}: cpu.max = {cpu_max}");
+
+    // Memory limit
+    std::fs::write(format!("{path}/memory.max"), limits.memory_bytes.to_string())
+        .with_context(|| format!("Failed to write memory.max for {name}"))?;
+
+    // IO limits (best-effort — controller may not be delegated)
+    let io_max_path = format!("{path}/io.max");
+    let io_available = if std::path::Path::new(&io_max_path).exists() {
+        // io.max format: "MAJ:MIN rbps=X wbps=X riops=Y wiops=Y"
+        // We apply symmetric read/write limits
+        let io_max = format!(
+            "rbps={bps} wbps={bps} riops={iops} wiops={iops}",
+            bps = limits.io_max_bps,
+            iops = limits.io_max_iops
+        );
+        match std::fs::write(&io_max_path, &io_max) {
+            Ok(_) => {
+                info!("cgroup {name}: io.max set");
+                true
+            }
+            Err(e) => {
+                warn!("cgroup {name}: io.max write failed (controller not delegated?): {e}");
+                false
+            }
+        }
+    } else {
+        warn!("cgroup {name}: io.max not available (IO controller not delegated)");
+        false
+    };
+
+    Ok(CgroupSetup { io_available })
+}
+
+/// Removes a cgroup for an agent.
+///
+/// Fails gracefully if the cgroup does not exist.
+pub fn remove_cgroup(name: &str) -> Result<()> {
+    let path = cgroup_path(name);
+    if std::path::Path::new(&path).exists() {
+        std::fs::remove_dir(&path)
+            .with_context(|| format!("Failed to remove cgroup {path}"))?;
+        info!("Removed cgroup for {name}");
+    }
+    Ok(())
+}
+
+/// Adds a process to an agent's cgroup.
+pub fn add_pid_to_cgroup(name: &str, pid: u32) -> Result<()> {
+    let path = format!("{}/cgroup.procs", cgroup_path(name));
+    std::fs::write(&path, pid.to_string())
+        .with_context(|| format!("Failed to add PID {pid} to cgroup {name}"))
+}
+
+/// Sets the OOM score adjustment for a process.
+///
+/// -1000 = immortal (ECS core), +1000 = first to kill.
+pub fn set_oom_score(pid: u32, score: i32) -> Result<()> {
+    let path = format!("/proc/{pid}/oom_score_adj");
+    std::fs::write(&path, score.to_string())
+        .with_context(|| format!("Failed to set oom_score_adj for PID {pid}"))
+}
+
+/// Reads PSI metrics from an agent's cgroup.
+///
+/// resource: "cpu", "memory", or "io"
+pub fn read_psi_from_cgroup(name: &str, resource: &str) -> Result<PsiMetrics> {
+    let path = format!("{}/{resource}.pressure", cgroup_path(name));
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read PSI {resource} for cgroup {name}"))?;
+    parse_psi(&content)
+        .with_context(|| format!("Failed to parse PSI {resource} for cgroup {name}"))
 }
 
 #[cfg(test)]
@@ -70,20 +167,31 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn cgroup_create_remove() {
-        // Echte cgroup erstellen/loeschen (braucht root)
+    fn cgroup_setup_fields() {
+        let setup = CgroupSetup { io_available: true };
+        assert!(setup.io_available);
     }
 
     #[test]
-    #[ignore]
+    #[ignore] // Needs cgroup v2 root access (VM only)
+    fn cgroup_create_remove() {
+        let limits = CgroupLimits::default();
+        let setup = create_cgroup("test-agent", &limits).unwrap();
+        assert!(std::path::Path::new("/sys/fs/cgroup/sentinel/test-agent").exists());
+        remove_cgroup("test-agent").unwrap();
+        assert!(!std::path::Path::new("/sys/fs/cgroup/sentinel/test-agent").exists());
+        let _ = setup;
+    }
+
+    #[test]
+    #[ignore] // Needs /proc access
     fn read_psi_real() {
         // Echte PSI-Datei lesen (/proc/pressure/cpu)
     }
 
     #[test]
-    #[ignore]
-    fn cgroup_remove_nonexistent_ok() {
-        // Nicht-existierende cgroup entfernen soll nicht paniken
+    fn remove_nonexistent_ok() {
+        // Removing a non-existent cgroup should succeed silently
+        assert!(remove_cgroup("does-not-exist-xyz").is_ok());
     }
 }

--- a/crates/sentinel-sandbox/src/cgroups.rs
+++ b/crates/sentinel-sandbox/src/cgroups.rs
@@ -56,8 +56,11 @@ pub fn create_cgroup(name: &str, limits: &CgroupLimits) -> Result<CgroupSetup> {
     info!("cgroup {name}: cpu.max = {cpu_max}");
 
     // Memory limit
-    std::fs::write(format!("{path}/memory.max"), limits.memory_bytes.to_string())
-        .with_context(|| format!("Failed to write memory.max for {name}"))?;
+    std::fs::write(
+        format!("{path}/memory.max"),
+        limits.memory_bytes.to_string(),
+    )
+    .with_context(|| format!("Failed to write memory.max for {name}"))?;
 
     // IO limits (best-effort — controller may not be delegated)
     let io_max_path = format!("{path}/io.max");
@@ -93,8 +96,7 @@ pub fn create_cgroup(name: &str, limits: &CgroupLimits) -> Result<CgroupSetup> {
 pub fn remove_cgroup(name: &str) -> Result<()> {
     let path = cgroup_path(name);
     if std::path::Path::new(&path).exists() {
-        std::fs::remove_dir(&path)
-            .with_context(|| format!("Failed to remove cgroup {path}"))?;
+        std::fs::remove_dir(&path).with_context(|| format!("Failed to remove cgroup {path}"))?;
         info!("Removed cgroup for {name}");
     }
     Ok(())
@@ -123,8 +125,7 @@ pub fn read_psi_from_cgroup(name: &str, resource: &str) -> Result<PsiMetrics> {
     let path = format!("{}/{resource}.pressure", cgroup_path(name));
     let content = std::fs::read_to_string(&path)
         .with_context(|| format!("Failed to read PSI {resource} for cgroup {name}"))?;
-    parse_psi(&content)
-        .with_context(|| format!("Failed to parse PSI {resource} for cgroup {name}"))
+    parse_psi(&content).with_context(|| format!("Failed to parse PSI {resource} for cgroup {name}"))
 }
 
 #[cfg(test)]

--- a/crates/sentinel-sandbox/src/enforcer.rs
+++ b/crates/sentinel-sandbox/src/enforcer.rs
@@ -191,11 +191,7 @@ impl SandboxEnforcer {
     /// The bwrap process runs in isolated namespaces.
     /// Landlock is applied inside the bwrap child (not yet implemented — TODO).
     /// Returns the bwrap PID on success.
-    pub fn start_agent_process(
-        &self,
-        name: &str,
-        command: &[String],
-    ) -> Result<u32> {
+    pub fn start_agent_process(&self, name: &str, command: &[String]) -> Result<u32> {
         if !self.bwrap_available {
             anyhow::bail!("bwrap not available — cannot start agent process");
         }
@@ -232,10 +228,7 @@ impl SandboxEnforcer {
         // Remove cgroup (may fail if processes still in it)
         if handle.cgroup_created {
             if let Err(e) = cgroups::remove_cgroup(&handle.agent_name) {
-                warn!(
-                    "Failed to remove cgroup for {}: {e}",
-                    handle.agent_name
-                );
+                warn!("Failed to remove cgroup for {}: {e}", handle.agent_name);
             }
         }
 

--- a/crates/sentinel-sandbox/src/enforcer.rs
+++ b/crates/sentinel-sandbox/src/enforcer.rs
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn sandbox_warning_variants() {
         // Verify all warning variants exist and are distinct
-        let warnings = vec![
+        let warnings = [
             SandboxWarning::LandlockNotAvailable,
             SandboxWarning::CgroupNotDelegated("io".into()),
             SandboxWarning::BwrapUsernsDenied,

--- a/crates/sentinel-sandbox/src/enforcer.rs
+++ b/crates/sentinel-sandbox/src/enforcer.rs
@@ -1,0 +1,321 @@
+//! SandboxEnforcer — zentrale Facade fuer Landlock + cgroups + bwrap.
+//!
+//! Orchestriert alle drei Isolationsmechanismen:
+//! - Landlock LSM (Kernel-Level Filesystem-Restriktion)
+//! - cgroups v2 (CPU, Memory, PID Limits)
+//! - bwrap (Namespace-Isolation: PID, Mount, UTS)
+//!
+//! Lifecycle:
+//! 1. `detect()` — prueft verfuegbare Kernel-Features, setzt OOM-Score
+//! 2. `setup_agent()` — erstellt cgroup + Agent-Home
+//! 3. `start_agent_process()` — startet bwrap (spaeter: mit Landlock im Child)
+//! 4. `teardown_agent()` — killt bwrap + entfernt cgroup
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+
+use crate::bwrap::BwrapConfig;
+use crate::cgroups::{self, CgroupLimits, PsiMetrics};
+use crate::landlock;
+
+/// Warnings about degraded sandbox capabilities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxWarning {
+    /// Landlock LSM not available on this kernel.
+    LandlockNotAvailable,
+    /// A cgroup controller is not delegated to the user.
+    CgroupNotDelegated(String),
+    /// bwrap can't create user namespaces (AppArmor blocks it).
+    BwrapUsernsDenied,
+    /// IO controller not delegated — io.max limits cannot be enforced.
+    IoNotDelegated,
+    /// Failed to set OOM score for ECS core process.
+    OomScoreFailed(String),
+}
+
+/// Handle returned by setup_agent() — tracks what was created.
+#[derive(Debug, Clone)]
+pub struct SandboxHandle {
+    pub agent_name: String,
+    pub cgroup_created: bool,
+    pub io_available: bool,
+    pub bwrap_pid: Option<u32>,
+    pub landlock_applied: bool,
+}
+
+/// Central sandbox enforcement facade.
+///
+/// Bundles Landlock + cgroups v2 + bwrap into a single interface.
+/// Created via `detect()` which probes kernel capabilities.
+pub struct SandboxEnforcer {
+    /// Detected Landlock ABI version (None = not available).
+    landlock_abi: Option<u8>,
+    /// cgroup v2 root for sentinel agents.
+    cgroup_root: PathBuf,
+    /// Whether cgroup root is writable by current user.
+    cgroup_available: bool,
+    /// Whether bwrap with user namespaces works.
+    bwrap_available: bool,
+    /// Whether OOM score has been set for ECS core.
+    oom_set: AtomicBool,
+}
+
+impl std::fmt::Debug for SandboxEnforcer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxEnforcer")
+            .field("landlock_abi", &self.landlock_abi)
+            .field("cgroup_root", &self.cgroup_root)
+            .field("cgroup_available", &self.cgroup_available)
+            .field("bwrap_available", &self.bwrap_available)
+            .finish()
+    }
+}
+
+impl SandboxEnforcer {
+    /// Detects available kernel sandbox features.
+    ///
+    /// Probes:
+    /// - Landlock ABI version
+    /// - cgroup v2 root writability
+    /// - IO controller delegation
+    /// - bwrap user namespace support
+    /// - Sets OOM score -1000 for ECS core process (immortal)
+    pub fn detect() -> (Self, Vec<SandboxWarning>) {
+        let mut warnings = Vec::new();
+
+        // 1. Landlock detection
+        let landlock_abi = landlock::detect_abi();
+        if let Some(abi) = landlock_abi {
+            info!("Landlock ABI v{abi} detected");
+        } else {
+            warnings.push(SandboxWarning::LandlockNotAvailable);
+        }
+
+        // 2. cgroup root
+        let cgroup_root = PathBuf::from("/sys/fs/cgroup/sentinel");
+        let cgroup_available = if cgroup_root.exists() {
+            true
+        } else {
+            match std::fs::create_dir_all(&cgroup_root) {
+                Ok(_) => {
+                    info!("Created cgroup root: {}", cgroup_root.display());
+                    true
+                }
+                Err(e) => {
+                    warnings.push(SandboxWarning::CgroupNotDelegated(format!(
+                        "Cannot create {}: {e}",
+                        cgroup_root.display()
+                    )));
+                    false
+                }
+            }
+        };
+
+        // 3. IO controller check
+        let io_delegated = std::fs::read_to_string("/sys/fs/cgroup/cgroup.subtree_control")
+            .map(|s| s.contains("io"))
+            .unwrap_or(false);
+        if !io_delegated {
+            warnings.push(SandboxWarning::IoNotDelegated);
+        }
+
+        // 4. bwrap userns check
+        let bwrap_available = BwrapConfig::test_userns();
+        if !bwrap_available {
+            warnings.push(SandboxWarning::BwrapUsernsDenied);
+        } else {
+            info!("bwrap user namespace support confirmed");
+        }
+
+        // 5. OOM score for ECS core (-1000 = immortal)
+        let oom_set = match cgroups::set_oom_score(std::process::id(), -1000) {
+            Ok(_) => {
+                info!("ECS core OOM score set to -1000 (immortal)");
+                AtomicBool::new(true)
+            }
+            Err(e) => {
+                warnings.push(SandboxWarning::OomScoreFailed(e.to_string()));
+                AtomicBool::new(false)
+            }
+        };
+
+        let enforcer = Self {
+            landlock_abi,
+            cgroup_root,
+            cgroup_available,
+            bwrap_available,
+            oom_set,
+        };
+
+        (enforcer, warnings)
+    }
+
+    /// Creates sandbox resources for an agent (cgroup + home directory).
+    ///
+    /// Does NOT start a process. Call `start_agent_process()` to launch bwrap.
+    /// Called by RuntimeOrchestrator::spawn_agent().
+    pub fn setup_agent(&self, name: &str, limits: &CgroupLimits) -> Result<SandboxHandle> {
+        let mut handle = SandboxHandle {
+            agent_name: name.to_string(),
+            cgroup_created: false,
+            io_available: false,
+            bwrap_pid: None,
+            landlock_applied: false,
+        };
+
+        // 1. Create cgroup with resource limits
+        if self.cgroup_available {
+            let setup = cgroups::create_cgroup(name, limits)
+                .with_context(|| format!("Failed to create cgroup for agent {name}"))?;
+            handle.cgroup_created = true;
+            handle.io_available = setup.io_available;
+        } else {
+            warn!("Skipping cgroup creation for {name} (cgroup root not available)");
+        }
+
+        // 2. Create agent home directory (sentinel-fs Integrationspunkt)
+        let home = format!("/ram/agents/{name}");
+        if let Err(e) = std::fs::create_dir_all(&home) {
+            warn!("Failed to create agent home {home}: {e}");
+            // Non-fatal: might be on a system without /ram/agents
+        }
+
+        Ok(handle)
+    }
+
+    /// Starts a bwrap process for the agent.
+    ///
+    /// The bwrap process runs in isolated namespaces.
+    /// Landlock is applied inside the bwrap child (not yet implemented — TODO).
+    /// Returns the bwrap PID on success.
+    pub fn start_agent_process(
+        &self,
+        name: &str,
+        command: &[String],
+    ) -> Result<u32> {
+        if !self.bwrap_available {
+            anyhow::bail!("bwrap not available — cannot start agent process");
+        }
+
+        let config = BwrapConfig::for_agent(name);
+        let child = config.spawn(command)?;
+        let pid = child.id();
+
+        // Add bwrap process to agent's cgroup
+        if self.cgroup_available {
+            if let Err(e) = cgroups::add_pid_to_cgroup(name, pid) {
+                warn!("Failed to add bwrap PID {pid} to cgroup {name}: {e}");
+            }
+        }
+
+        // Release child handle — bwrap has --die-with-parent
+        std::mem::forget(child);
+
+        Ok(pid)
+    }
+
+    /// Tears down sandbox resources for an agent.
+    ///
+    /// Kills the bwrap process (if running) and removes the cgroup.
+    /// Called by RuntimeOrchestrator::despawn_agent().
+    pub fn teardown_agent(&self, handle: &SandboxHandle) -> Result<()> {
+        // Kill bwrap process if running
+        if let Some(pid) = handle.bwrap_pid {
+            let _ = std::process::Command::new("kill")
+                .args(["-TERM", &pid.to_string()])
+                .status();
+        }
+
+        // Remove cgroup (may fail if processes still in it)
+        if handle.cgroup_created {
+            if let Err(e) = cgroups::remove_cgroup(&handle.agent_name) {
+                warn!(
+                    "Failed to remove cgroup for {}: {e}",
+                    handle.agent_name
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reads PSI metrics for an agent's cgroup.
+    ///
+    /// Used for Zenoh publish -> Bio-Engine pipeline.
+    /// resource: "cpu" or "memory"
+    pub fn read_agent_psi(&self, name: &str, resource: &str) -> Result<PsiMetrics> {
+        cgroups::read_psi_from_cgroup(name, resource)
+    }
+
+    /// Whether Landlock is available on this system.
+    pub fn has_landlock(&self) -> bool {
+        self.landlock_abi.is_some()
+    }
+
+    /// Detected Landlock ABI version.
+    pub fn landlock_abi(&self) -> Option<u8> {
+        self.landlock_abi
+    }
+
+    /// Whether cgroup v2 is available for agent isolation.
+    pub fn has_cgroups(&self) -> bool {
+        self.cgroup_available
+    }
+
+    /// Whether bwrap with user namespaces is available.
+    pub fn has_bwrap(&self) -> bool {
+        self.bwrap_available
+    }
+
+    /// Whether OOM score was set for the ECS core process.
+    pub fn oom_score_set(&self) -> bool {
+        self.oom_set.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_warning_variants() {
+        // Verify all warning variants exist and are distinct
+        let warnings = vec![
+            SandboxWarning::LandlockNotAvailable,
+            SandboxWarning::CgroupNotDelegated("io".into()),
+            SandboxWarning::BwrapUsernsDenied,
+            SandboxWarning::IoNotDelegated,
+            SandboxWarning::OomScoreFailed("test".into()),
+        ];
+        assert_eq!(warnings.len(), 5);
+        assert_ne!(warnings[0], warnings[1]);
+    }
+
+    #[test]
+    fn sandbox_handle_defaults() {
+        let handle = SandboxHandle {
+            agent_name: "test".into(),
+            cgroup_created: false,
+            io_available: false,
+            bwrap_pid: None,
+            landlock_applied: false,
+        };
+        assert_eq!(handle.agent_name, "test");
+        assert!(!handle.cgroup_created);
+        assert!(handle.bwrap_pid.is_none());
+    }
+
+    #[test]
+    #[ignore] // Needs real system capabilities (VM only)
+    fn enforcer_detect() {
+        let (enforcer, warnings) = SandboxEnforcer::detect();
+        // On the VM, we expect landlock + cgroups + bwrap to be available
+        println!("Landlock ABI: {:?}", enforcer.landlock_abi);
+        println!("cgroup available: {}", enforcer.cgroup_available);
+        println!("bwrap available: {}", enforcer.bwrap_available);
+        println!("Warnings: {:?}", warnings);
+    }
+}

--- a/crates/sentinel-sandbox/src/landlock.rs
+++ b/crates/sentinel-sandbox/src/landlock.rs
@@ -1,0 +1,160 @@
+//! Landlock LSM filesystem access control.
+//!
+//! Provides kernel-enforced filesystem restrictions for agent processes.
+//! Applied inside the bwrap namespace as Defense-in-Depth.
+//!
+//! Pfad-Policy (Masterplan-konform):
+//! - Read: /company (Firmendaten), /etc/resolv.conf (DNS)
+//! - Write: /home/{name} (Agent-Home), /tmp (Temp)
+//! - Execute: /usr (Binaries+Libs), /lib (Shared Libs)
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+
+/// Landlock filesystem ruleset for agent isolation.
+#[derive(Debug, Clone)]
+pub struct LandlockRuleset {
+    /// Paths with read-only access.
+    pub read_paths: Vec<PathBuf>,
+    /// Paths with read-write access (includes all FS operations except execute).
+    pub write_paths: Vec<PathBuf>,
+    /// Paths with read + execute access.
+    pub exec_paths: Vec<PathBuf>,
+}
+
+impl LandlockRuleset {
+    /// Creates a Masterplan-compliant ruleset for an agent.
+    ///
+    /// Paths are relative to the bwrap mount namespace:
+    /// - /company -> readonly Firmendaten
+    /// - /home/{name} -> writable Agent-Home (bwrap-mapped from /ram/agents/{name})
+    /// - /tmp -> writable temp (bwrap tmpfs)
+    /// - /usr, /lib -> readonly system + exec
+    /// - /etc/resolv.conf -> DNS resolution
+    pub fn for_agent(name: &str) -> Self {
+        Self {
+            read_paths: vec![
+                PathBuf::from("/company"),
+                PathBuf::from("/etc/resolv.conf"),
+            ],
+            write_paths: vec![
+                PathBuf::from(format!("/home/{name}")),
+                PathBuf::from("/tmp"),
+            ],
+            exec_paths: vec![PathBuf::from("/usr"), PathBuf::from("/lib")],
+        }
+    }
+
+    /// Applies the Landlock ruleset to the current process (irreversible).
+    ///
+    /// Must be called in the bwrap child process BEFORE exec'ing the agent.
+    /// Returns true if fully or partially enforced, false if not enforced.
+    pub fn apply(&self) -> Result<bool> {
+        use landlock::*;
+
+        let abi = ABI::V4;
+
+        // Handle all FS access types — restricts everything not explicitly allowed
+        let all_access = AccessFs::from_all(abi);
+        let read_access = AccessFs::ReadFile | AccessFs::ReadDir;
+        let exec_access = read_access | AccessFs::Execute;
+
+        let mut ruleset = Ruleset::default()
+            .handle_access(all_access)
+            .context("Failed to handle Landlock access")?
+            .create()
+            .context("Failed to create Landlock ruleset")?;
+
+        // Read-only paths
+        for path in &self.read_paths {
+            if path.exists() {
+                ruleset = ruleset
+                    .add_rule(PathBeneath::new(PathFd::new(path)?, read_access))
+                    .with_context(|| format!("Failed to add read rule for {}", path.display()))?;
+            }
+        }
+
+        // Writable paths — full access except execute
+        for path in &self.write_paths {
+            if path.exists() {
+                ruleset = ruleset
+                    .add_rule(PathBeneath::new(PathFd::new(path)?, all_access))
+                    .with_context(|| format!("Failed to add write rule for {}", path.display()))?;
+            }
+        }
+
+        // Executable paths — read + execute
+        for path in &self.exec_paths {
+            if path.exists() {
+                ruleset = ruleset
+                    .add_rule(PathBeneath::new(PathFd::new(path)?, exec_access))
+                    .with_context(|| format!("Failed to add exec rule for {}", path.display()))?;
+            }
+        }
+
+        let restriction = ruleset
+            .restrict_self()
+            .context("Failed to apply Landlock restriction")?;
+
+        match restriction.ruleset {
+            RulesetStatus::FullyEnforced => {
+                info!("Landlock fully enforced");
+                Ok(true)
+            }
+            RulesetStatus::PartiallyEnforced => {
+                warn!("Landlock partially enforced (kernel ABI may be older)");
+                Ok(true)
+            }
+            RulesetStatus::NotEnforced => {
+                warn!("Landlock not enforced");
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Detects whether Landlock is available on this kernel.
+/// Returns the ABI version (1-4) or None if not available.
+pub fn detect_abi() -> Option<u8> {
+    if !std::path::Path::new("/sys/kernel/security/landlock").exists() {
+        return None;
+    }
+    // VM kernel 6.8 supports ABI v4.
+    // The landlock crate handles ABI negotiation via BestEffort compat level.
+    Some(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ruleset_for_agent_paths() {
+        let rs = LandlockRuleset::for_agent("thomas");
+        assert!(rs.read_paths.contains(&PathBuf::from("/company")));
+        assert!(rs.read_paths.contains(&PathBuf::from("/etc/resolv.conf")));
+        assert!(rs.write_paths.contains(&PathBuf::from("/home/thomas")));
+        assert!(rs.write_paths.contains(&PathBuf::from("/tmp")));
+        assert!(rs.exec_paths.contains(&PathBuf::from("/usr")));
+        assert!(rs.exec_paths.contains(&PathBuf::from("/lib")));
+    }
+
+    #[test]
+    fn ruleset_no_root_write() {
+        let rs = LandlockRuleset::for_agent("thomas");
+        assert!(!rs.write_paths.contains(&PathBuf::from("/")));
+        assert!(!rs.write_paths.contains(&PathBuf::from("/etc")));
+        assert!(!rs.write_paths.contains(&PathBuf::from("/company")));
+    }
+
+    #[test]
+    fn different_agents_different_homes() {
+        let rs1 = LandlockRuleset::for_agent("thomas");
+        let rs2 = LandlockRuleset::for_agent("lisa");
+        assert!(rs1.write_paths.contains(&PathBuf::from("/home/thomas")));
+        assert!(rs2.write_paths.contains(&PathBuf::from("/home/lisa")));
+        assert!(!rs1.write_paths.contains(&PathBuf::from("/home/lisa")));
+    }
+}

--- a/crates/sentinel-sandbox/src/landlock.rs
+++ b/crates/sentinel-sandbox/src/landlock.rs
@@ -35,10 +35,7 @@ impl LandlockRuleset {
     /// - /etc/resolv.conf -> DNS resolution
     pub fn for_agent(name: &str) -> Self {
         Self {
-            read_paths: vec![
-                PathBuf::from("/company"),
-                PathBuf::from("/etc/resolv.conf"),
-            ],
+            read_paths: vec![PathBuf::from("/company"), PathBuf::from("/etc/resolv.conf")],
             write_paths: vec![
                 PathBuf::from(format!("/home/{name}")),
                 PathBuf::from("/tmp"),

--- a/crates/sentinel-sandbox/src/lib.rs
+++ b/crates/sentinel-sandbox/src/lib.rs
@@ -2,6 +2,10 @@
 
 pub mod bwrap;
 pub mod cgroups;
+pub mod enforcer;
+pub mod landlock;
 
 pub use bwrap::BwrapConfig;
 pub use cgroups::{CgroupLimits, PsiMetrics};
+pub use enforcer::{SandboxEnforcer, SandboxHandle, SandboxWarning};
+pub use landlock::LandlockRuleset;

--- a/deploy/systemd/sentinel-nightrun.service
+++ b/deploy/systemd/sentinel-nightrun.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Sentinel Nightrun — Schichtwechsel-Konsolidierung
+Documentation=https://github.com/obtFusi/project-sentinel/issues/17
+After=network.target
+Wants=sentinel-nightrun.timer
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/sentinel
+ExecStart=/opt/sentinel/bin/sentinel-nightrun --config /opt/sentinel/config/nightrun.toml
+TimeoutStartSec=7200
+MemoryMax=2G
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sentinel-nightrun
+
+# Security Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/opt/sentinel/data
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/sentinel-nightrun.timer
+++ b/deploy/systemd/sentinel-nightrun.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sentinel Nightrun Timer — Schichtwechsel 06:00/14:00/22:00
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+OnCalendar=*-*-* 14:00:00
+OnCalendar=*-*-* 22:00:00
+Persistent=true
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target

--- a/docs/codex-analyse.md
+++ b/docs/codex-analyse.md
@@ -125,12 +125,13 @@ Konkrete Beispiele:
    - erwarteter Output,
    - Artefakt-Pfad,
    - Datum.
-7. CI muss AC hart pruefen (Issue-Quality Gate + AC-Linter + Mindest-Evidence).
+7. CI muss AC hart pruefen (Issue-Quality Gate + AC-Linter + Mindest-Evidence). **[UMGESETZT: issue-quality.yml + pr-quality.yml]**
 8. Non-Functional AC verpflichtend bei Architektur-Issues:
    - Latenz,
    - Speicher,
    - I/O,
    - Isolation/Security.
+   **[UMGESETZT: `## Benchmarks` Pflicht-Sektion in allen 20 offenen Issues + CI Gate]**
 
 ## Offene Prioritaetsliste fuer Re-Audit/Repair
 1. ~~#13 Vollpipeline verdrahten~~ (erledigt: PR #71, FULL).
@@ -192,9 +193,9 @@ follow_up_issue: <id|null>
 
 ### 5) CI-Kopplung im Skill erzwingen
 Skill muss fuer neue Repos standardmaessig erzeugen/aktivieren:
-- `issue-quality.yml`: lintet neue/edierte Issues auf Pflichtsektionen
-- `pr-quality.yml`: verweigert Merge bei fehlender AC-Evidence
-- `main-push-guard.yml`: blockt direkte Pushes auf `main`
+- `issue-quality.yml`: lintet neue/edierte Issues auf Pflichtsektionen **[UMGESETZT 2026-02-16: Benchmarks-Sektion als Pflicht hinzugefuegt]**
+- `pr-quality.yml`: verweigert Merge bei fehlender AC-Evidence **[UMGESETZT 2026-02-16: ## Benchmarks als Pflicht-Sektion hinzugefuegt]**
+- `main-push-guard.yml`: blockt direkte Pushes auf `main` **[UMGESETZT]**
 
 ### 6) Placeholder-Policy
 Wenn Placeholder noetig:
@@ -436,7 +437,55 @@ Im Skill klarstellen:
 - Benchmark-Code: `crates/sentinel-hippocampus/benches/hippocampus_bench.rs`
 - VM-Verify: `ssh ubuntu@10.0.0.240 "cd /home/ubuntu/sentinel-target && ./release/deps/hippocampus_bench-* --bench"`
 
+### Benchmark-Governance (Two-Tier Architektur, Enterprise SOTA 2026)
+
+**Kontext:** Benchmark-Strategie fuer das Gesamtprojekt etabliert. Codex (gpt-5.3-codex) Session `019c655c-d997-70b1-a7f7-b9da63f47465` hat Option D (Criterion CI + Production Binary VM) als besten Enterprise-Ansatz bestaetigt.
+
+| Tier | Zweck | Wo | Tool |
+|------|-------|----|------|
+| **Tier 1** | Component-Level Regression | CI (Build-Server 10.0.0.155) | Criterion.rs, Go testing.B, Bun bench |
+| **Tier 2** | System-Level E2E | VM 10.0.0.240 (ext4 /data) | `deploy/bench/stack-harness` + Runner-Scripts |
+
+**Governance-Massnahmen (umgesetzt 2026-02-16):**
+- `issue-quality.yml`: Benchmarks-Sektion als Pflichtfeld (Varianten: Benchmarks, Benchmark, Performance)
+- `pr-quality.yml`: `## Benchmarks` als Pflicht-Sektion in PR-Body
+- Alle 20 offenen Feature-Issues (#17-#76) mit `## Benchmarks` Sektion versehen (Neue Metriken, Performance-Budget, Tier, Betroffene Sprachen, Bestehende Benchmarks betroffen)
+- Polyglot-Coverage: Rust, Go, TypeScript, C++, Bash beruecksichtigt
+
+**Erkenntnisse:**
+- Criterion.rs ist ein Microbenchmark-Tool — nicht geeignet fuer systemische Effekte (Storage, Scheduler, Kernel, I/O-Stack)
+- tmpfs-Benchmarks sind nicht vergleichbar mit ext4-Produktion (fsync-Kosten fehlen)
+- `deploy/bench/stack-harness` + `run-stack-suite-guest.sh` existieren bereits als Tier 2 Prototyp
+
+### Nightrun Benchmark (Issue #17, Criterion auf Build-Server)
+
+**Kontext:** Issue #17 implementiert sentinel-nightrun (Schichtwechsel-Konsolidierung). Benchmarks auf Build-Server 10.0.0.155 (tmpfs, Tier 1).
+**Binary:** `cargo bench -p sentinel-nightrun` (Release, Criterion).
+
+| Metrik | Wert | Einordnung | Status |
+|--------|------|------------|--------|
+| `nightrun.shift/shift_set_for_hour` | `7.06ns` | Pure Arithmetik (Hour -> Shift-Set) | **PASS** |
+| `nightrun.shift/outgoing_shift_set` | `882ps` | Lookup (New Shift -> Outgoing) | **PASS** |
+| `nightrun.job_queue/create_run_15` | `1.72ms` | SQLite: 15 Jobs anlegen | **PASS** |
+| `nightrun.job_queue/create_run_54` | `3.91ms` | SQLite: 54 Jobs anlegen | **PASS** |
+| `nightrun.job_queue/mark_transitions` | `596us` | Status-Updates (pending->completed) | **PASS** |
+| `nightrun.job_queue/get_pending_15` | `51.3us` | 15 pending Jobs abfragen | **PASS** |
+| `nightrun.pipeline/consolidate/1` | `12.4ms` | 1 Agent konsolidieren (E2E) | **PASS** |
+| `nightrun.pipeline/consolidate/5` | `43.9ms` | 5 Agents konsolidieren | **PASS** |
+| `nightrun.pipeline/consolidate/15` | `82.9ms` | 15 Agents konsolidieren | **PASS** |
+
+**Einordnung:**
+- Pipeline skaliert sublinear: 15 Agents in 82.9ms (nicht 15x 12.4ms = 186ms)
+- Job-Queue create_run skaliert linear: 54 Jobs in 3.91ms (~72us/Job)
+- Shift-Detection ist vernachlaessigbar (<10ns)
+- **Achtung:** Benchmarks auf tmpfs (Build-Server), nicht auf ext4 (Produktion). Tier 2 Benchmarks auf VM 10.0.0.240 stehen noch aus.
+
+**Artefakte:**
+- Benchmark-Code: `services/sentinel-nightrun/benches/nightrun_bench.rs`
+
 ### Update-Log
+- 2026-02-16: Benchmark-Governance etabliert (Two-Tier Architektur). 20 offene Issues mit ## Benchmarks Sektion versehen. CI Quality Gates (issue-quality.yml, pr-quality.yml) um Benchmarks-Pflichtsektion erweitert.
+- 2026-02-16: Nightrun Benchmark (Issue #17): 9 Benchmarks auf Build-Server. Pipeline 15 Agents 82.9ms, Job-Queue 54 Jobs 3.91ms, Shift-Detection 7ns.
 - 2026-02-15: Hippocampus Persistent Memory Benchmark (Issue #23): 40+ Benchmarks auf VM 10.0.0.240. Production 54-Agent Consolidate 586ms, Retrieve-Sweep 605us, DB-Size 532KB.
 - 2026-02-15: Issue #23 PARTIAL->FULL: redb-Persistence (4 Tables), HippocampusService Facade, Night-Run Konsolidierung, NMDA-priorisiertes Retrieval. 57 Unit-Tests + 4 Acceptance-Tests, 40+ Benchmarks.
 - 2026-02-15: Issue #15 Scope-Luecken geschlossen: pause_agent/resume_agent, State-Machine (AgentStatus::can_transition_to), RuntimeEventSink-Trait (ECS-Integration), Thread/Memory-Footprint dokumentiert. 29 Tests (21 unit + 8 acceptance), 13 Benchmarks auf VM.

--- a/services/sentinel-nightrun/Cargo.toml
+++ b/services/sentinel-nightrun/Cargo.toml
@@ -6,9 +6,35 @@ license = "MIT"
 publish = false
 description = "Schichtwechsel-Konsolidierung (Nightrun Service)"
 
+[lib]
+name = "sentinel_nightrun"
+path = "src/lib.rs"
+
 [[bin]]
 name = "sentinel-nightrun"
 path = "src/main.rs"
 
 [dependencies]
 sentinel-common = { path = "../../crates/sentinel-common" }
+sentinel-hippocampus = { path = "../../crates/sentinel-hippocampus" }
+sentinel-limbo = { path = "../../crates/sentinel-limbo" }
+sentinel-telemetry = { path = "../../crates/sentinel-telemetry" }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+uuid = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+rusqlite = { version = "0.38", features = ["bundled"] }
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"
+criterion = { workspace = true }
+
+[[bench]]
+name = "nightrun_bench"
+harness = false

--- a/services/sentinel-nightrun/benches/nightrun_bench.rs
+++ b/services/sentinel-nightrun/benches/nightrun_bench.rs
@@ -1,0 +1,186 @@
+//! Nightrun Benchmarks — Criterion-basiert.
+//!
+//! Misst die Kernoperationen des Nightrun-Service:
+//! - Job-Queue Operationen (SQLite)
+//! - Runner Pipeline (end-to-end Konsolidierung)
+//! - Shift-Detection
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use sentinel_hippocampus::{Episode, HippocampusService};
+use sentinel_limbo::EventStore;
+use sentinel_nightrun::config::NightrunSettings;
+use sentinel_nightrun::job_queue::JobQueue;
+use sentinel_nightrun::runner::NightrunRunner;
+use sentinel_nightrun::shift::{outgoing_shift_set, shift_set_for_hour};
+
+fn make_episode(id: u64, agent: &str, summary: &str) -> Episode {
+    Episode {
+        id,
+        agent_name: agent.to_string(),
+        summary: summary.to_string(),
+        relevance: 0.8,
+        emotion: 0.7,
+        repetitions: 1,
+        hours_ago: 1.0,
+        participants: vec![],
+        tags: vec![],
+    }
+}
+
+fn make_settings(dir: &std::path::Path) -> NightrunSettings {
+    NightrunSettings {
+        hippocampus_db: dir.join("hc.redb").to_str().unwrap().to_string(),
+        event_store_db: dir.join("ev.db").to_str().unwrap().to_string(),
+        agent_config_dir: dir.to_str().unwrap().to_string(),
+        job_queue_path: dir.join("jq.db").to_str().unwrap().to_string(),
+        timeout_per_agent_secs: 300,
+        timeout_total_secs: 7200,
+        max_episodes_per_agent: 1000,
+    }
+}
+
+// === Shift Detection ===
+
+fn bench_shift_detection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nightrun.shift");
+
+    group.bench_function("shift_set_for_hour", |b| {
+        b.iter(|| {
+            for hour in 0..24u8 {
+                std::hint::black_box(shift_set_for_hour(hour));
+            }
+        });
+    });
+
+    group.bench_function("outgoing_shift_set", |b| {
+        b.iter(|| {
+            for shift in 1..=3u8 {
+                std::hint::black_box(outgoing_shift_set(shift));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// === Job-Queue Operationen ===
+
+fn bench_job_queue(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nightrun.job_queue");
+
+    group.bench_function("create_run_15_agents", |b| {
+        b.iter_with_setup(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let jq = JobQueue::open(dir.path().join("jq.db").to_str().unwrap()).unwrap();
+                (jq, dir)
+            },
+            |(jq, _dir)| {
+                let agents: Vec<String> = (0..15).map(|i| format!("Agent-{i:02}")).collect();
+                jq.create_run("bench-run", &agents).unwrap();
+            },
+        );
+    });
+
+    group.bench_function("create_run_54_agents", |b| {
+        b.iter_with_setup(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let jq = JobQueue::open(dir.path().join("jq.db").to_str().unwrap()).unwrap();
+                (jq, dir)
+            },
+            |(jq, _dir)| {
+                let agents: Vec<String> = (0..54).map(|i| format!("Agent-{i:02}")).collect();
+                jq.create_run("bench-run", &agents).unwrap();
+            },
+        );
+    });
+
+    group.bench_function("mark_transitions", |b| {
+        b.iter_with_setup(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let jq = JobQueue::open(dir.path().join("jq.db").to_str().unwrap()).unwrap();
+                jq.create_run("bench-run", &["Agent-00".into()]).unwrap();
+                (jq, dir)
+            },
+            |(jq, _dir)| {
+                jq.mark_in_progress("bench-run", "Agent-00").unwrap();
+                jq.mark_completed("bench-run", "Agent-00", 10, 5).unwrap();
+            },
+        );
+    });
+
+    group.bench_function("get_pending_15", |b| {
+        let dir = tempfile::tempdir().unwrap();
+        let jq = JobQueue::open(dir.path().join("jq.db").to_str().unwrap()).unwrap();
+        let agents: Vec<String> = (0..15).map(|i| format!("Agent-{i:02}")).collect();
+        jq.create_run("bench-run", &agents).unwrap();
+
+        b.iter(|| {
+            std::hint::black_box(jq.get_pending("bench-run").unwrap());
+        });
+    });
+
+    group.finish();
+}
+
+// === Runner Pipeline ===
+
+fn bench_runner_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nightrun.pipeline");
+    group.sample_size(10); // Pipeline ist langsam (redb writes)
+
+    for &agent_count in &[1, 5, 15] {
+        group.bench_with_input(
+            BenchmarkId::new("consolidate", agent_count),
+            &agent_count,
+            |b, &count| {
+                b.iter_with_setup(
+                    || {
+                        let dir = tempfile::tempdir().unwrap();
+                        let settings = make_settings(dir.path());
+
+                        let hc = HippocampusService::open(&settings.hippocampus_db).unwrap();
+                        let es = EventStore::open(&settings.event_store_db).unwrap();
+                        let jq = JobQueue::open(&settings.job_queue_path).unwrap();
+
+                        // Seed episodes
+                        for i in 0..count {
+                            let name = format!("Agent-{i:02}");
+                            let episodes: Vec<Episode> = (0..8)
+                                .map(|j| {
+                                    make_episode(
+                                        (i * 10 + j) as u64,
+                                        &name,
+                                        &format!("Event {j}"),
+                                    )
+                                })
+                                .collect();
+                            hc.record_episodes(&name, &episodes).unwrap();
+                        }
+
+                        let run_id = format!("bench-{count}");
+                        let runner =
+                            NightrunRunner::new(hc, es, jq, settings, run_id, false);
+                        (runner, dir)
+                    },
+                    |(runner, _dir)| {
+                        std::hint::black_box(runner.run(1).unwrap());
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_shift_detection,
+    bench_job_queue,
+    bench_runner_pipeline,
+);
+criterion_main!(benches);

--- a/services/sentinel-nightrun/benches/nightrun_bench.rs
+++ b/services/sentinel-nightrun/benches/nightrun_bench.rs
@@ -151,19 +151,14 @@ fn bench_runner_pipeline(c: &mut Criterion) {
                             let name = format!("Agent-{i:02}");
                             let episodes: Vec<Episode> = (0..8)
                                 .map(|j| {
-                                    make_episode(
-                                        (i * 10 + j) as u64,
-                                        &name,
-                                        &format!("Event {j}"),
-                                    )
+                                    make_episode((i * 10 + j) as u64, &name, &format!("Event {j}"))
                                 })
                                 .collect();
                             hc.record_episodes(&name, &episodes).unwrap();
                         }
 
                         let run_id = format!("bench-{count}");
-                        let runner =
-                            NightrunRunner::new(hc, es, jq, settings, run_id, false);
+                        let runner = NightrunRunner::new(hc, es, jq, settings, run_id, false);
                         (runner, dir)
                     },
                     |(runner, _dir)| {

--- a/services/sentinel-nightrun/src/config.rs
+++ b/services/sentinel-nightrun/src/config.rs
@@ -1,0 +1,90 @@
+//! Nightrun-Konfiguration (TOML-basiert).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NightrunConfig {
+    pub nightrun: NightrunSettings,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NightrunSettings {
+    /// Pfad zur Hippocampus redb-Datenbank.
+    pub hippocampus_db: String,
+    /// Pfad zur Limbo Event-Store SQLite-Datenbank.
+    pub event_store_db: String,
+    /// Verzeichnis mit Agent-TOML-Definitionen.
+    pub agent_config_dir: String,
+    /// Pfad zur Job-Queue SQLite-Datenbank.
+    pub job_queue_path: String,
+    /// Timeout pro Agent in Sekunden (default: 300).
+    #[serde(default = "default_timeout_per_agent")]
+    pub timeout_per_agent_secs: u64,
+    /// Gesamt-Timeout in Sekunden (default: 7200).
+    #[serde(default = "default_timeout_total")]
+    pub timeout_total_secs: u64,
+    /// Max Episodes pro Agent bevor Skip (default: 1000).
+    #[serde(default = "default_max_episodes")]
+    pub max_episodes_per_agent: usize,
+}
+
+fn default_timeout_per_agent() -> u64 {
+    300
+}
+fn default_timeout_total() -> u64 {
+    7200
+}
+fn default_max_episodes() -> usize {
+    1000
+}
+
+impl NightrunConfig {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read config: {}", path.display()))?;
+        let config: NightrunConfig = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse config: {}", path.display()))?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_config() {
+        let toml_str = r#"
+[nightrun]
+hippocampus_db = "data/hippocampus.redb"
+event_store_db = "data/events.db"
+agent_config_dir = "config/agents"
+job_queue_path = "data/nightrun-jobs.db"
+timeout_per_agent_secs = 120
+timeout_total_secs = 3600
+max_episodes_per_agent = 500
+"#;
+        let config: NightrunConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.nightrun.hippocampus_db, "data/hippocampus.redb");
+        assert_eq!(config.nightrun.timeout_per_agent_secs, 120);
+        assert_eq!(config.nightrun.max_episodes_per_agent, 500);
+    }
+
+    #[test]
+    fn parse_config_with_defaults() {
+        let toml_str = r#"
+[nightrun]
+hippocampus_db = "data/hippocampus.redb"
+event_store_db = "data/events.db"
+agent_config_dir = "config/agents"
+job_queue_path = "data/nightrun-jobs.db"
+"#;
+        let config: NightrunConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.nightrun.timeout_per_agent_secs, 300);
+        assert_eq!(config.nightrun.timeout_total_secs, 7200);
+        assert_eq!(config.nightrun.max_episodes_per_agent, 1000);
+    }
+}

--- a/services/sentinel-nightrun/src/job_queue.rs
+++ b/services/sentinel-nightrun/src/job_queue.rs
@@ -1,0 +1,320 @@
+//! Persistente Job-Queue fuer Nightrun Crash-Recovery.
+//!
+//! Tracks welche Agents bereits konsolidiert wurden, damit nach einem
+//! Crash der Run fortgesetzt werden kann (--resume).
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+/// Status eines Konsolidierungs-Jobs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+    Skipped,
+}
+
+impl fmt::Display for JobStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::InProgress => write!(f, "in_progress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
+            Self::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+impl FromStr for JobStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "skipped" => Ok(Self::Skipped),
+            other => anyhow::bail!("Unknown JobStatus: {other}"),
+        }
+    }
+}
+
+/// Einzelner Job-Eintrag.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct JobEntry {
+    pub run_id: String,
+    pub agent_name: String,
+    pub status: JobStatus,
+    pub error: Option<String>,
+    pub episodes_processed: u32,
+    pub episodes_consolidated: u32,
+}
+
+/// Zusammenfassung eines Runs.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct RunSummary {
+    pub total: u32,
+    pub completed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub pending: u32,
+    pub total_episodes: u32,
+}
+
+/// Persistente Job-Queue backed by SQLite.
+pub struct JobQueue {
+    conn: Connection,
+}
+
+impl JobQueue {
+    pub fn open(path: &str) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("Failed to open job queue: {path}"))?;
+
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             CREATE TABLE IF NOT EXISTS nightrun_jobs (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 run_id TEXT NOT NULL,
+                 agent_name TEXT NOT NULL,
+                 status TEXT NOT NULL DEFAULT 'pending',
+                 error TEXT,
+                 episodes_processed INTEGER DEFAULT 0,
+                 episodes_consolidated INTEGER DEFAULT 0,
+                 started_at INTEGER,
+                 completed_at INTEGER,
+                 created_at INTEGER NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_nightrun_run_status
+                 ON nightrun_jobs(run_id, status);",
+        )
+        .context("Failed to initialize job queue schema")?;
+
+        Ok(Self { conn })
+    }
+
+    /// Erstellt einen neuen Run mit allen zu konsolidierenden Agents.
+    pub fn create_run(&self, run_id: &str, agents: &[String]) -> Result<()> {
+        let now = now_secs();
+        let mut stmt = self.conn.prepare(
+            "INSERT INTO nightrun_jobs (run_id, agent_name, status, created_at) VALUES (?1, ?2, 'pending', ?3)",
+        )?;
+        for agent in agents {
+            stmt.execute(params![run_id, agent, now])?;
+        }
+        Ok(())
+    }
+
+    /// Gibt alle ausstehenden Jobs fuer einen Run zurueck.
+    pub fn get_pending(&self, run_id: &str) -> Result<Vec<JobEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT run_id, agent_name, status, error, episodes_processed, episodes_consolidated
+             FROM nightrun_jobs WHERE run_id = ?1 AND status IN ('pending', 'in_progress')
+             ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(params![run_id], |row| {
+            let status_str: String = row.get(2)?;
+            Ok(JobEntry {
+                run_id: row.get(0)?,
+                agent_name: row.get(1)?,
+                status: status_str.parse::<JobStatus>().unwrap_or(JobStatus::Pending),
+                error: row.get(3)?,
+                episodes_processed: row.get(4)?,
+                episodes_consolidated: row.get(5)?,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// Sucht nach einem unvollstaendigen Run (fuer --resume).
+    pub fn get_incomplete_run(&self) -> Result<Option<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT run_id FROM nightrun_jobs
+             WHERE status IN ('pending', 'in_progress')
+             ORDER BY id DESC LIMIT 1",
+        )?;
+        let mut rows = stmt.query([])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Markiert einen Job als in_progress.
+    pub fn mark_in_progress(&self, run_id: &str, agent: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE nightrun_jobs SET status = 'in_progress', started_at = ?3
+             WHERE run_id = ?1 AND agent_name = ?2 AND status = 'pending'",
+            params![run_id, agent, now_secs()],
+        )?;
+        Ok(())
+    }
+
+    /// Markiert einen Job als completed.
+    pub fn mark_completed(
+        &self,
+        run_id: &str,
+        agent: &str,
+        episodes_processed: u32,
+        episodes_consolidated: u32,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE nightrun_jobs SET status = 'completed', completed_at = ?3,
+             episodes_processed = ?4, episodes_consolidated = ?5
+             WHERE run_id = ?1 AND agent_name = ?2",
+            params![run_id, agent, now_secs(), episodes_processed, episodes_consolidated],
+        )?;
+        Ok(())
+    }
+
+    /// Markiert einen Job als failed.
+    pub fn mark_failed(&self, run_id: &str, agent: &str, error: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE nightrun_jobs SET status = 'failed', error = ?3, completed_at = ?4
+             WHERE run_id = ?1 AND agent_name = ?2",
+            params![run_id, agent, error, now_secs()],
+        )?;
+        Ok(())
+    }
+
+    /// Markiert einen Job als skipped.
+    pub fn mark_skipped(&self, run_id: &str, agent: &str, reason: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE nightrun_jobs SET status = 'skipped', error = ?3, completed_at = ?4
+             WHERE run_id = ?1 AND agent_name = ?2",
+            params![run_id, agent, reason, now_secs()],
+        )?;
+        Ok(())
+    }
+
+    /// Zusammenfassung eines Runs.
+    #[allow(dead_code)]
+    pub fn get_summary(&self, run_id: &str) -> Result<RunSummary> {
+        let mut summary = RunSummary::default();
+        let mut stmt = self.conn.prepare(
+            "SELECT status, COUNT(*), COALESCE(SUM(episodes_processed), 0)
+             FROM nightrun_jobs WHERE run_id = ?1 GROUP BY status",
+        )?;
+        let rows = stmt.query_map(params![run_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, u32>(1)?,
+                row.get::<_, u32>(2)?,
+            ))
+        })?;
+        for row in rows {
+            let (status, count, episodes) = row?;
+            summary.total += count;
+            summary.total_episodes += episodes;
+            match status.as_str() {
+                "completed" => summary.completed = count,
+                "failed" => summary.failed = count,
+                "skipped" => summary.skipped = count,
+                "pending" | "in_progress" => summary.pending += count,
+                _ => {}
+            }
+        }
+        Ok(summary)
+    }
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_queue() -> JobQueue {
+        JobQueue::open(":memory:").unwrap()
+    }
+
+    #[test]
+    fn create_and_list_pending() {
+        let q = temp_queue();
+        let agents = vec!["Thomas".into(), "Lisa".into(), "Max".into()];
+        q.create_run("run-1", &agents).unwrap();
+        let pending = q.get_pending("run-1").unwrap();
+        assert_eq!(pending.len(), 3);
+        assert_eq!(pending[0].agent_name, "Thomas");
+        assert_eq!(pending[0].status, JobStatus::Pending);
+    }
+
+    #[test]
+    fn mark_progress_transitions() {
+        let q = temp_queue();
+        q.create_run("run-1", &["Thomas".into()]).unwrap();
+
+        q.mark_in_progress("run-1", "Thomas").unwrap();
+        let pending = q.get_pending("run-1").unwrap();
+        assert_eq!(pending[0].status, JobStatus::InProgress);
+
+        q.mark_completed("run-1", "Thomas", 10, 5).unwrap();
+        let pending = q.get_pending("run-1").unwrap();
+        assert!(pending.is_empty()); // completed is not pending
+    }
+
+    #[test]
+    fn resume_finds_incomplete() {
+        let q = temp_queue();
+        q.create_run("run-1", &["Thomas".into(), "Lisa".into()])
+            .unwrap();
+        q.mark_completed("run-1", "Thomas", 5, 3).unwrap();
+
+        let incomplete = q.get_incomplete_run().unwrap();
+        assert_eq!(incomplete.as_deref(), Some("run-1"));
+
+        // Complete all
+        q.mark_completed("run-1", "Lisa", 8, 4).unwrap();
+        let incomplete = q.get_incomplete_run().unwrap();
+        assert!(incomplete.is_none());
+    }
+
+    #[test]
+    fn summary_counts() {
+        let q = temp_queue();
+        let agents: Vec<String> = vec!["A".into(), "B".into(), "C".into(), "D".into()];
+        q.create_run("run-1", &agents).unwrap();
+        q.mark_completed("run-1", "A", 10, 5).unwrap();
+        q.mark_completed("run-1", "B", 8, 4).unwrap();
+        q.mark_failed("run-1", "C", "timeout").unwrap();
+        q.mark_skipped("run-1", "D", "backlog").unwrap();
+
+        let s = q.get_summary("run-1").unwrap();
+        assert_eq!(s.total, 4);
+        assert_eq!(s.completed, 2);
+        assert_eq!(s.failed, 1);
+        assert_eq!(s.skipped, 1);
+        assert_eq!(s.pending, 0);
+        assert_eq!(s.total_episodes, 18);
+    }
+
+    #[test]
+    fn mark_failed_stores_error() {
+        let q = temp_queue();
+        q.create_run("run-1", &["Thomas".into()]).unwrap();
+        q.mark_in_progress("run-1", "Thomas").unwrap();
+        q.mark_failed("run-1", "Thomas", "redb write error").unwrap();
+
+        let mut stmt = q
+            .conn
+            .prepare("SELECT error FROM nightrun_jobs WHERE agent_name = 'Thomas'")
+            .unwrap();
+        let error: String = stmt.query_row([], |r| r.get(0)).unwrap();
+        assert_eq!(error, "redb write error");
+    }
+}

--- a/services/sentinel-nightrun/src/job_queue.rs
+++ b/services/sentinel-nightrun/src/job_queue.rs
@@ -77,8 +77,8 @@ pub struct JobQueue {
 
 impl JobQueue {
     pub fn open(path: &str) -> Result<Self> {
-        let conn = Connection::open(path)
-            .with_context(|| format!("Failed to open job queue: {path}"))?;
+        let conn =
+            Connection::open(path).with_context(|| format!("Failed to open job queue: {path}"))?;
 
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
@@ -127,7 +127,9 @@ impl JobQueue {
             Ok(JobEntry {
                 run_id: row.get(0)?,
                 agent_name: row.get(1)?,
-                status: status_str.parse::<JobStatus>().unwrap_or(JobStatus::Pending),
+                status: status_str
+                    .parse::<JobStatus>()
+                    .unwrap_or(JobStatus::Pending),
                 error: row.get(3)?,
                 episodes_processed: row.get(4)?,
                 episodes_consolidated: row.get(5)?,
@@ -172,7 +174,13 @@ impl JobQueue {
             "UPDATE nightrun_jobs SET status = 'completed', completed_at = ?3,
              episodes_processed = ?4, episodes_consolidated = ?5
              WHERE run_id = ?1 AND agent_name = ?2",
-            params![run_id, agent, now_secs(), episodes_processed, episodes_consolidated],
+            params![
+                run_id,
+                agent,
+                now_secs(),
+                episodes_processed,
+                episodes_consolidated
+            ],
         )?;
         Ok(())
     }
@@ -308,7 +316,8 @@ mod tests {
         let q = temp_queue();
         q.create_run("run-1", &["Thomas".into()]).unwrap();
         q.mark_in_progress("run-1", "Thomas").unwrap();
-        q.mark_failed("run-1", "Thomas", "redb write error").unwrap();
+        q.mark_failed("run-1", "Thomas", "redb write error")
+            .unwrap();
 
         let mut stmt = q
             .conn

--- a/services/sentinel-nightrun/src/lib.rs
+++ b/services/sentinel-nightrun/src/lib.rs
@@ -1,0 +1,8 @@
+//! Sentinel Nightrun — Schichtwechsel-Konsolidierung.
+//!
+//! Library-Target fuer Integration-Tests und Benchmarks.
+
+pub mod config;
+pub mod job_queue;
+pub mod runner;
+pub mod shift;

--- a/services/sentinel-nightrun/src/main.rs
+++ b/services/sentinel-nightrun/src/main.rs
@@ -100,11 +100,10 @@ fn run(cli: Cli) -> Result<sentinel_nightrun::runner::NightrunResult> {
     let hippocampus = HippocampusService::open(&settings.hippocampus_db)
         .context("Failed to open HippocampusService")?;
 
-    let event_store = EventStore::open(&settings.event_store_db)
-        .context("Failed to open EventStore")?;
+    let event_store =
+        EventStore::open(&settings.event_store_db).context("Failed to open EventStore")?;
 
-    let job_queue = JobQueue::open(&settings.job_queue_path)
-        .context("Failed to open JobQueue")?;
+    let job_queue = JobQueue::open(&settings.job_queue_path).context("Failed to open JobQueue")?;
 
     // Run-ID bestimmen (resume oder neu)
     let run_id = if cli.resume {

--- a/services/sentinel-nightrun/src/main.rs
+++ b/services/sentinel-nightrun/src/main.rs
@@ -1,6 +1,138 @@
-// Sentinel Nightrun - Schichtwechsel-Konsolidierung
-// Stub: wird in Issue #17 (sentinel-nightrun) implementiert.
+//! Sentinel Nightrun — Schichtwechsel-Konsolidierung.
+//!
+//! Run-to-completion Service, getriggert via systemd Timer bei Schichtwechsel.
+//! Konsolidiert episodische Erinnerungen der abgehenden Agents per NMDA-Scoring.
 
-fn main() {
-    println!("sentinel-nightrun: not yet implemented (see issue #17)");
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tracing::{error, info};
+
+use sentinel_nightrun::config::NightrunConfig;
+use sentinel_nightrun::job_queue::JobQueue;
+use sentinel_nightrun::runner::NightrunRunner;
+use sentinel_nightrun::shift::{current_shift_set, outgoing_shift_set};
+
+use sentinel_hippocampus::HippocampusService;
+use sentinel_limbo::EventStore;
+
+/// Sentinel Nightrun — Schichtwechsel-Konsolidierung.
+#[derive(Parser, Debug)]
+#[command(name = "sentinel-nightrun", version, about)]
+struct Cli {
+    /// Pfad zur Konfigurations-Datei.
+    #[arg(long, default_value = "config/nightrun.toml")]
+    config: String,
+
+    /// Expliziter Shift-Set (1=Frueh, 2=Mittel, 3=Spaet). Auto-detect wenn nicht gesetzt.
+    #[arg(long)]
+    shift: Option<u8>,
+
+    /// Dry-Run: Agents auflisten aber nicht konsolidieren.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Unvollstaendigen Run fortsetzen statt neuen zu starten.
+    #[arg(long)]
+    resume: bool,
+}
+
+fn main() -> ExitCode {
+    // Logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    match run(cli) {
+        Ok(result) => {
+            if result.agents_failed > 0 {
+                error!(
+                    run_id = %result.run_id,
+                    failed = result.agents_failed,
+                    consolidated = result.agents_consolidated,
+                    "Nightrun mit Fehlern abgeschlossen"
+                );
+                ExitCode::from(1)
+            } else {
+                info!(
+                    run_id = %result.run_id,
+                    consolidated = result.agents_consolidated,
+                    skipped = result.agents_skipped,
+                    total_episodes = result.total_episodes,
+                    duration_ms = result.duration_ms,
+                    "Nightrun erfolgreich abgeschlossen"
+                );
+                ExitCode::SUCCESS
+            }
+        }
+        Err(e) => {
+            error!(error = %e, "Nightrun fehlgeschlagen");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<sentinel_nightrun::runner::NightrunResult> {
+    // Config
+    let config = NightrunConfig::load(Path::new(&cli.config))
+        .with_context(|| format!("Config laden fehlgeschlagen: {}", cli.config))?;
+    let settings = config.nightrun;
+
+    // Shift-Set bestimmen
+    let current = current_shift_set();
+    let trigger_shift_set = cli.shift.unwrap_or_else(|| outgoing_shift_set(current));
+
+    info!(
+        current_shift = current,
+        trigger_shift = trigger_shift_set,
+        explicit = cli.shift.is_some(),
+        "Schicht-Erkennung"
+    );
+
+    // Services oeffnen
+    let hippocampus = HippocampusService::open(&settings.hippocampus_db)
+        .context("Failed to open HippocampusService")?;
+
+    let event_store = EventStore::open(&settings.event_store_db)
+        .context("Failed to open EventStore")?;
+
+    let job_queue = JobQueue::open(&settings.job_queue_path)
+        .context("Failed to open JobQueue")?;
+
+    // Run-ID bestimmen (resume oder neu)
+    let run_id = if cli.resume {
+        match job_queue.get_incomplete_run()? {
+            Some(id) => {
+                info!(run_id = %id, "Fortsetze unvollstaendigen Run");
+                id
+            }
+            None => {
+                info!("Kein unvollstaendiger Run gefunden, starte neuen");
+                uuid::Uuid::new_v4().to_string()
+            }
+        }
+    } else {
+        uuid::Uuid::new_v4().to_string()
+    };
+
+    info!(run_id = %run_id, dry_run = cli.dry_run, "Nightrun initialisiert");
+
+    // Runner ausfuehren
+    let runner = NightrunRunner::new(
+        hippocampus,
+        event_store,
+        job_queue,
+        settings,
+        run_id,
+        cli.dry_run,
+    );
+
+    runner.run(trigger_shift_set)
 }

--- a/services/sentinel-nightrun/src/runner.rs
+++ b/services/sentinel-nightrun/src/runner.rs
@@ -136,7 +136,12 @@ impl NightrunRunner {
                     "Backlog zu gross: {episode_count} > {}",
                     self.config.max_episodes_per_agent
                 );
-                warn!(agent, episode_count, max = self.config.max_episodes_per_agent, "Agent uebersprungen");
+                warn!(
+                    agent,
+                    episode_count,
+                    max = self.config.max_episodes_per_agent,
+                    "Agent uebersprungen"
+                );
                 self.job_queue.mark_skipped(&self.run_id, agent, &reason)?;
                 self.emit_failed(&self.run_id.clone(), agent, &reason)?;
                 skipped += 1;
@@ -145,14 +150,14 @@ impl NightrunRunner {
 
             if self.dry_run {
                 info!(agent, episode_count, "DRY-RUN: wuerde konsolidieren");
-                self.job_queue.mark_skipped(&self.run_id, agent, "dry-run")?;
+                self.job_queue
+                    .mark_skipped(&self.run_id, agent, "dry-run")?;
                 skipped += 1;
                 continue;
             }
 
             // Konsolidierung
-            self.job_queue
-                .mark_in_progress(&self.run_id, agent)?;
+            self.job_queue.mark_in_progress(&self.run_id, agent)?;
 
             let agent_start = Instant::now();
             match self.consolidate_single_agent(agent) {
@@ -228,8 +233,8 @@ impl NightrunRunner {
     ///
     /// Agents ohne TOML-Definition werden IMMER inkludiert (konservativ).
     fn filter_by_shift(&self, agents: &[String], trigger_shift_set: u8) -> Vec<String> {
-        let agent_configs = load_all_agents(Path::new(&self.config.agent_config_dir))
-            .unwrap_or_default();
+        let agent_configs =
+            load_all_agents(Path::new(&self.config.agent_config_dir)).unwrap_or_default();
 
         // Shift-Set Lookup: name → shift_set
         let shift_map: std::collections::HashMap<String, u8> = agent_configs

--- a/services/sentinel-nightrun/src/runner.rs
+++ b/services/sentinel-nightrun/src/runner.rs
@@ -1,0 +1,375 @@
+//! Nightrun Runner — Kern-Pipeline fuer Schichtwechsel-Konsolidierung.
+//!
+//! Sequentielle Verarbeitung: redb ist single-writer, Parallelitaet bringt nichts.
+//! Pro Agent wird `HippocampusService::consolidate_agent()` aufgerufen.
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use tracing::{error, info, warn};
+
+use sentinel_common::agent_config::load_all_agents;
+use sentinel_common::{DomainEvent, DomainEventPayload};
+use sentinel_hippocampus::HippocampusService;
+use sentinel_limbo::EventStore;
+
+use crate::config::NightrunSettings;
+use crate::job_queue::JobQueue;
+
+/// Ergebnis eines Nightrun-Durchlaufs.
+#[derive(Debug)]
+pub struct NightrunResult {
+    pub run_id: String,
+    pub agents_consolidated: u32,
+    pub agents_failed: u32,
+    pub agents_skipped: u32,
+    pub total_episodes: u32,
+    pub duration_ms: u64,
+}
+
+/// Kern-Pipeline fuer Schichtwechsel-Konsolidierung.
+pub struct NightrunRunner {
+    hippocampus: HippocampusService,
+    event_store: EventStore,
+    job_queue: JobQueue,
+    config: NightrunSettings,
+    run_id: String,
+    dry_run: bool,
+}
+
+impl NightrunRunner {
+    pub fn new(
+        hippocampus: HippocampusService,
+        event_store: EventStore,
+        job_queue: JobQueue,
+        config: NightrunSettings,
+        run_id: String,
+        dry_run: bool,
+    ) -> Self {
+        Self {
+            hippocampus,
+            event_store,
+            job_queue,
+            config,
+            run_id,
+            dry_run,
+        }
+    }
+
+    /// Fuehrt den kompletten Nightrun-Durchlauf aus.
+    ///
+    /// 1. Agents mit pending Episodes ermitteln
+    /// 2. Optional shift_set Filter
+    /// 3. Job-Queue befuellen
+    /// 4. Pro Agent sequentiell konsolidieren
+    /// 5. Events emittieren
+    pub fn run(&self, trigger_shift_set: u8) -> Result<NightrunResult> {
+        let start = Instant::now();
+        info!(run_id = %self.run_id, shift = trigger_shift_set, "Nightrun gestartet");
+
+        // 1. Agents mit pending Episodes
+        let all_agents = self
+            .hippocampus
+            .store()
+            .list_agents_with_episodes()
+            .context("Failed to list agents with episodes")?;
+
+        if all_agents.is_empty() {
+            info!("Keine Agents mit pending Episodes gefunden");
+            return Ok(NightrunResult {
+                run_id: self.run_id.clone(),
+                agents_consolidated: 0,
+                agents_failed: 0,
+                agents_skipped: 0,
+                total_episodes: 0,
+                duration_ms: start.elapsed().as_millis() as u64,
+            });
+        }
+
+        // 2. Optional shift_set Filter (best-effort, TOML nicht fuer alle vorhanden)
+        let agents = self.filter_by_shift(&all_agents, trigger_shift_set);
+        let agent_count = agents.len() as u32;
+
+        info!(
+            total = all_agents.len(),
+            filtered = agents.len(),
+            shift = trigger_shift_set,
+            "Agent-Selektion abgeschlossen"
+        );
+
+        // 3. NightRunStarted Event
+        self.emit_started(trigger_shift_set, agent_count)?;
+
+        // 4. Job-Queue befuellen (nur bei neuem Run, nicht bei Resume)
+        if self.job_queue.get_pending(&self.run_id)?.is_empty() {
+            self.job_queue
+                .create_run(&self.run_id, &agents)
+                .context("Failed to create job queue run")?;
+        }
+
+        // 5. Sequentielle Verarbeitung
+        let mut consolidated = 0u32;
+        let mut failed = 0u32;
+        let mut skipped = 0u32;
+        let mut total_episodes = 0u32;
+
+        let pending_jobs = self.job_queue.get_pending(&self.run_id)?;
+        for job in &pending_jobs {
+            // Total-Timeout Check
+            if start.elapsed().as_secs() >= self.config.timeout_total_secs {
+                warn!(
+                    run_id = %self.run_id,
+                    elapsed_secs = start.elapsed().as_secs(),
+                    "Total-Timeout erreicht, breche ab"
+                );
+                // Remaining jobs bleiben pending fuer --resume
+                break;
+            }
+
+            let agent = &job.agent_name;
+
+            // Episode-Count pruefen (Backlog-Limit)
+            let episode_count = self.get_episode_count(agent)?;
+            if episode_count > self.config.max_episodes_per_agent {
+                let reason = format!(
+                    "Backlog zu gross: {episode_count} > {}",
+                    self.config.max_episodes_per_agent
+                );
+                warn!(agent, episode_count, max = self.config.max_episodes_per_agent, "Agent uebersprungen");
+                self.job_queue.mark_skipped(&self.run_id, agent, &reason)?;
+                self.emit_failed(&self.run_id.clone(), agent, &reason)?;
+                skipped += 1;
+                continue;
+            }
+
+            if self.dry_run {
+                info!(agent, episode_count, "DRY-RUN: wuerde konsolidieren");
+                self.job_queue.mark_skipped(&self.run_id, agent, "dry-run")?;
+                skipped += 1;
+                continue;
+            }
+
+            // Konsolidierung
+            self.job_queue
+                .mark_in_progress(&self.run_id, agent)?;
+
+            let agent_start = Instant::now();
+            match self.consolidate_single_agent(agent) {
+                Ok((processed, cons)) => {
+                    let duration_ms = agent_start.elapsed().as_millis() as u64;
+                    info!(
+                        agent,
+                        episodes_processed = processed,
+                        episodes_consolidated = cons,
+                        duration_ms,
+                        "Agent konsolidiert"
+                    );
+                    self.job_queue
+                        .mark_completed(&self.run_id, agent, processed, cons)?;
+                    self.emit_consolidated(agent, processed, cons, duration_ms)?;
+                    consolidated += 1;
+                    total_episodes += processed;
+                }
+                Err(e) => {
+                    let err_msg = format!("{e:#}");
+                    error!(agent, error = %err_msg, "Konsolidierung fehlgeschlagen");
+                    self.job_queue.mark_failed(&self.run_id, agent, &err_msg)?;
+                    self.emit_failed(&self.run_id.clone(), agent, &err_msg)?;
+                    failed += 1;
+                }
+            }
+
+            // Per-Agent Timeout Check (warnung, kein Abbruch)
+            if agent_start.elapsed().as_secs() >= self.config.timeout_per_agent_secs {
+                warn!(
+                    agent,
+                    elapsed_secs = agent_start.elapsed().as_secs(),
+                    "Agent-Timeout ueberschritten"
+                );
+            }
+        }
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        // 6. NightRunCompleted Event
+        self.emit_completed(
+            trigger_shift_set,
+            consolidated,
+            failed,
+            skipped,
+            total_episodes,
+            duration_ms,
+        )?;
+
+        let result = NightrunResult {
+            run_id: self.run_id.clone(),
+            agents_consolidated: consolidated,
+            agents_failed: failed,
+            agents_skipped: skipped,
+            total_episodes,
+            duration_ms,
+        };
+
+        info!(
+            run_id = %self.run_id,
+            consolidated,
+            failed,
+            skipped,
+            total_episodes,
+            duration_ms,
+            "Nightrun abgeschlossen"
+        );
+
+        Ok(result)
+    }
+
+    /// Filtert Agents nach shift_set (best-effort via Agent-TOMLs).
+    ///
+    /// Agents ohne TOML-Definition werden IMMER inkludiert (konservativ).
+    fn filter_by_shift(&self, agents: &[String], trigger_shift_set: u8) -> Vec<String> {
+        let agent_configs = load_all_agents(Path::new(&self.config.agent_config_dir))
+            .unwrap_or_default();
+
+        // Shift-Set Lookup: name → shift_set
+        let shift_map: std::collections::HashMap<String, u8> = agent_configs
+            .into_iter()
+            .map(|c| (c.identity.name.clone(), c.identity.shift_set))
+            .collect();
+
+        agents
+            .iter()
+            .filter(|name| {
+                match shift_map.get(*name) {
+                    Some(&0) => {
+                        // Schicht 0 (Sonder) wird NIE konsolidiert
+                        false
+                    }
+                    Some(&shift) => shift == trigger_shift_set,
+                    None => {
+                        // Kein TOML vorhanden → konservativ inkludieren
+                        true
+                    }
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Konsolidiert einen einzelnen Agent ueber HippocampusService.
+    fn consolidate_single_agent(&self, agent: &str) -> Result<(u32, u32)> {
+        let result = self
+            .hippocampus
+            .consolidate_agent(agent)
+            .with_context(|| format!("Consolidation failed for agent: {agent}"))?;
+
+        Ok((
+            result.episodes_processed as u32,
+            result.episodes_consolidated as u32,
+        ))
+    }
+
+    /// Ermittelt die Episode-Anzahl fuer einen Agent.
+    fn get_episode_count(&self, agent: &str) -> Result<usize> {
+        let episodes = self.hippocampus.store().load_episodes(agent)?;
+        Ok(episodes.len())
+    }
+
+    // === Event Emission ===
+
+    fn emit_started(&self, trigger_shift_set: u8, agents_queued: u32) -> Result<()> {
+        let payload = DomainEventPayload::NightRunStarted {
+            run_id: self.run_id.clone(),
+            trigger_shift_set,
+            agents_queued,
+        };
+        let event = DomainEvent::new(
+            payload.event_type_str(),
+            "nightrun",
+            &payload.to_json(),
+            &self.run_id,
+            0,
+        );
+        self.event_store
+            .append_with_outbox(&event, "nightrun")
+            .context("Failed to emit NightRunStarted")?;
+        Ok(())
+    }
+
+    fn emit_completed(
+        &self,
+        trigger_shift_set: u8,
+        agents_consolidated: u32,
+        agents_failed: u32,
+        agents_skipped: u32,
+        total_episodes: u32,
+        duration_ms: u64,
+    ) -> Result<()> {
+        let payload = DomainEventPayload::NightRunCompleted {
+            run_id: self.run_id.clone(),
+            trigger_shift_set,
+            agents_consolidated,
+            agents_failed,
+            agents_skipped,
+            total_episodes,
+            duration_ms,
+        };
+        let event = DomainEvent::new(
+            payload.event_type_str(),
+            "nightrun",
+            &payload.to_json(),
+            &self.run_id,
+            0,
+        );
+        self.event_store
+            .append_with_outbox(&event, "nightrun")
+            .context("Failed to emit NightRunCompleted")?;
+        Ok(())
+    }
+
+    fn emit_consolidated(
+        &self,
+        agent_name: &str,
+        episodes_processed: u32,
+        episodes_consolidated: u32,
+        duration_ms: u64,
+    ) -> Result<()> {
+        let payload = DomainEventPayload::AgentConsolidated {
+            run_id: self.run_id.clone(),
+            agent_name: agent_name.to_string(),
+            episodes_processed,
+            episodes_consolidated,
+            duration_ms,
+        };
+        let event = DomainEvent::new(
+            payload.event_type_str(),
+            agent_name,
+            &payload.to_json(),
+            &self.run_id,
+            0,
+        );
+        self.event_store
+            .append_with_outbox(&event, "nightrun")
+            .context("Failed to emit AgentConsolidated")?;
+        Ok(())
+    }
+
+    fn emit_failed(&self, run_id: &str, agent_name: &str, error: &str) -> Result<()> {
+        let payload = DomainEventPayload::AgentConsolidationFailed {
+            run_id: run_id.to_string(),
+            agent_name: agent_name.to_string(),
+            error: error.to_string(),
+        };
+        let event = DomainEvent::new(
+            payload.event_type_str(),
+            agent_name,
+            &payload.to_json(),
+            &self.run_id,
+            0,
+        );
+        self.event_store
+            .append_with_outbox(&event, "nightrun")
+            .context("Failed to emit AgentConsolidationFailed")?;
+        Ok(())
+    }
+}

--- a/services/sentinel-nightrun/src/shift.rs
+++ b/services/sentinel-nightrun/src/shift.rs
@@ -1,0 +1,100 @@
+//! Schicht-Erkennung und Mapping.
+//!
+//! Shift-Sets:
+//! - 0: Sonder (always-on, wird NIE konsolidiert)
+//! - 1: Frueh (06:00-14:00)
+//! - 2: Mittel (14:00-22:00)
+//! - 3: Spaet (22:00-06:00)
+
+/// Bestimmt die aktuelle Schicht anhand der Wall-Clock-Stunde.
+pub fn current_shift_set() -> u8 {
+    shift_set_for_hour(current_local_hour())
+}
+
+/// Mapping: Stunde → Schicht-Set.
+pub fn shift_set_for_hour(hour: u8) -> u8 {
+    match hour {
+        6..=13 => 1,
+        14..=21 => 2,
+        _ => 3, // 22-05
+    }
+}
+
+/// Bestimmt welche Schicht abgeht (= konsolidiert werden soll).
+///
+/// Bei Schichtwechsel zu `new_shift` geht die vorherige Schicht ab:
+/// - Frueh (1) startet → Spaet (3) geht ab
+/// - Mittel (2) startet → Frueh (1) geht ab
+/// - Spaet (3) startet → Mittel (2) geht ab
+pub fn outgoing_shift_set(new_shift: u8) -> u8 {
+    match new_shift {
+        1 => 3,
+        2 => 1,
+        3 => 2,
+        _ => 0, // Sonder: nie konsolidiert
+    }
+}
+
+/// Gibt die aktuelle lokale Stunde zurueck (0-23).
+fn current_local_hour() -> u8 {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // SAFETY: libc::localtime_r ist thread-safe
+    let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    let time_t = secs as libc::time_t;
+    unsafe { libc::localtime_r(&time_t, &mut tm) };
+    tm.tm_hour as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shift_mapping_frueh() {
+        for hour in 6..=13 {
+            assert_eq!(shift_set_for_hour(hour), 1, "hour {hour} should be Frueh");
+        }
+    }
+
+    #[test]
+    fn shift_mapping_mittel() {
+        for hour in 14..=21 {
+            assert_eq!(shift_set_for_hour(hour), 2, "hour {hour} should be Mittel");
+        }
+    }
+
+    #[test]
+    fn shift_mapping_spaet() {
+        for hour in [22, 23, 0, 1, 2, 3, 4, 5] {
+            assert_eq!(shift_set_for_hour(hour), 3, "hour {hour} should be Spaet");
+        }
+    }
+
+    #[test]
+    fn outgoing_mapping() {
+        assert_eq!(outgoing_shift_set(1), 3); // Frueh startet → Spaet geht
+        assert_eq!(outgoing_shift_set(2), 1); // Mittel startet → Frueh geht
+        assert_eq!(outgoing_shift_set(3), 2); // Spaet startet → Mittel geht
+        assert_eq!(outgoing_shift_set(0), 0); // Sonder → nix
+    }
+
+    #[test]
+    fn boundary_hours() {
+        assert_eq!(shift_set_for_hour(5), 3);  // 05:59 → Spaet
+        assert_eq!(shift_set_for_hour(6), 1);  // 06:00 → Frueh
+        assert_eq!(shift_set_for_hour(13), 1); // 13:59 → Frueh
+        assert_eq!(shift_set_for_hour(14), 2); // 14:00 → Mittel
+        assert_eq!(shift_set_for_hour(21), 2); // 21:59 → Mittel
+        assert_eq!(shift_set_for_hour(22), 3); // 22:00 → Spaet
+    }
+
+    #[test]
+    fn current_shift_set_returns_valid() {
+        let shift = current_shift_set();
+        assert!((1..=3).contains(&shift));
+    }
+}

--- a/services/sentinel-nightrun/src/shift.rs
+++ b/services/sentinel-nightrun/src/shift.rs
@@ -84,8 +84,8 @@ mod tests {
 
     #[test]
     fn boundary_hours() {
-        assert_eq!(shift_set_for_hour(5), 3);  // 05:59 → Spaet
-        assert_eq!(shift_set_for_hour(6), 1);  // 06:00 → Frueh
+        assert_eq!(shift_set_for_hour(5), 3); // 05:59 → Spaet
+        assert_eq!(shift_set_for_hour(6), 1); // 06:00 → Frueh
         assert_eq!(shift_set_for_hour(13), 1); // 13:59 → Frueh
         assert_eq!(shift_set_for_hour(14), 2); // 14:00 → Mittel
         assert_eq!(shift_set_for_hour(21), 2); // 21:59 → Mittel

--- a/services/sentinel-nightrun/tests/integration.rs
+++ b/services/sentinel-nightrun/tests/integration.rs
@@ -1,0 +1,320 @@
+//! Integration-Tests fuer den Nightrun-Runner.
+//!
+//! Testet die gesamte Pipeline end-to-end:
+//! HippocampusService + EventStore + JobQueue + Runner
+
+use sentinel_hippocampus::{Episode, HippocampusService};
+use sentinel_limbo::EventStore;
+use sentinel_nightrun::config::NightrunSettings;
+use sentinel_nightrun::job_queue::JobQueue;
+use sentinel_nightrun::runner::NightrunRunner;
+
+fn make_episode(id: u64, agent: &str, summary: &str, relevance: f64, emotion: f64) -> Episode {
+    Episode {
+        id,
+        agent_name: agent.to_string(),
+        summary: summary.to_string(),
+        relevance,
+        emotion,
+        repetitions: 1,
+        hours_ago: 1.0,
+        participants: vec![],
+        tags: vec![],
+    }
+}
+
+struct TestHarness {
+    hippocampus: HippocampusService,
+    event_store: EventStore,
+    job_queue: JobQueue,
+    settings: NightrunSettings,
+    _dir: tempfile::TempDir,
+}
+
+impl TestHarness {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+
+        let hc_path = dir.path().join("hippocampus.redb");
+        let es_path = dir.path().join("events.db");
+        let jq_path = dir.path().join("nightrun-jobs.db");
+
+        let hippocampus = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+        let event_store = EventStore::open(es_path.to_str().unwrap()).unwrap();
+        let job_queue = JobQueue::open(jq_path.to_str().unwrap()).unwrap();
+
+        let settings = NightrunSettings {
+            hippocampus_db: hc_path.to_str().unwrap().to_string(),
+            event_store_db: es_path.to_str().unwrap().to_string(),
+            agent_config_dir: dir.path().to_str().unwrap().to_string(),
+            job_queue_path: jq_path.to_str().unwrap().to_string(),
+            timeout_per_agent_secs: 300,
+            timeout_total_secs: 7200,
+            max_episodes_per_agent: 1000,
+        };
+
+        Self {
+            hippocampus,
+            event_store,
+            job_queue,
+            settings,
+            _dir: dir,
+        }
+    }
+
+    fn seed_agent(&self, name: &str, episode_count: usize) {
+        let episodes: Vec<Episode> = (0..episode_count)
+            .map(|i| make_episode(i as u64, name, &format!("Event {i} von {name}"), 0.8, 0.7))
+            .collect();
+        self.hippocampus.record_episodes(name, &episodes).unwrap();
+    }
+
+    fn runner(self, run_id: &str, dry_run: bool) -> (NightrunRunner, EventStore, tempfile::TempDir) {
+        let event_store_check = EventStore::open(&self.settings.event_store_db).unwrap();
+        let runner = NightrunRunner::new(
+            self.hippocampus,
+            self.event_store,
+            self.job_queue,
+            self.settings,
+            run_id.to_string(),
+            dry_run,
+        );
+        (runner, event_store_check, self._dir)
+    }
+}
+
+// === AC-1: Service startet robust bei Schichtwechsel ===
+
+#[test]
+fn ac1_consolidation_completes_for_all_agents() {
+    let h = TestHarness::new();
+    h.seed_agent("Thomas", 5);
+    h.seed_agent("Lisa", 3);
+    h.seed_agent("Max", 8);
+
+    let (runner, _es, _dir) = h.runner("run-ac1", false);
+    let result = runner.run(1).unwrap();
+
+    assert_eq!(result.agents_consolidated, 3);
+    assert_eq!(result.agents_failed, 0);
+    assert_eq!(result.agents_skipped, 0);
+    assert!(result.total_episodes > 0);
+}
+
+// === AC-2: Konsolidierte Daten persistent ===
+
+#[test]
+fn ac2_narratives_persist_after_consolidation() {
+    let dir = tempfile::tempdir().unwrap();
+    let hc_path = dir.path().join("hc.redb");
+
+    // Phase 1: Consolidate
+    {
+        let hc = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+        let es = EventStore::open(dir.path().join("ev.db").to_str().unwrap()).unwrap();
+        let jq = JobQueue::open(dir.path().join("jq.db").to_str().unwrap()).unwrap();
+        let settings = NightrunSettings {
+            hippocampus_db: hc_path.to_str().unwrap().to_string(),
+            event_store_db: dir.path().join("ev.db").to_str().unwrap().to_string(),
+            agent_config_dir: dir.path().to_str().unwrap().to_string(),
+            job_queue_path: dir.path().join("jq.db").to_str().unwrap().to_string(),
+            timeout_per_agent_secs: 300,
+            timeout_total_secs: 7200,
+            max_episodes_per_agent: 1000,
+        };
+
+        let eps = vec![
+            make_episode(1, "Thomas", "Wichtiges Meeting", 0.9, 0.8),
+            make_episode(2, "Thomas", "Konflikt geloest", 0.95, 0.9),
+        ];
+        hc.record_episodes("Thomas", &eps).unwrap();
+
+        let runner = NightrunRunner::new(hc, es, jq, settings, "run-ac2".into(), false);
+        runner.run(1).unwrap();
+    }
+
+    // Phase 2: Reopen und pruefen
+    {
+        let hc = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+        let narrative = hc.get_narrative("Thomas").unwrap();
+        assert!(narrative.is_some(), "Narrative muss persistent sein");
+        assert!(!narrative.unwrap().is_empty());
+
+        // Episodes muessen geloescht sein
+        let remaining = hc.store().load_episodes("Thomas").unwrap();
+        assert!(remaining.is_empty(), "Episodes muessen nach Konsolidierung geloescht sein");
+    }
+}
+
+// === AC-3: Keine Gewichtsdateien erzeugt (architekturbedingt) ===
+
+#[test]
+fn ac3_no_weight_files_created() {
+    let h = TestHarness::new();
+
+    h.seed_agent("Thomas", 5);
+    let (runner, _es, dir) = h.runner("run-ac3", false);
+    let dir_path = dir.path().to_path_buf();
+    runner.run(1).unwrap();
+
+    // Keine .bin, .safetensors, .pt, .gguf Dateien
+    let weight_extensions = ["bin", "safetensors", "pt", "gguf", "onnx"];
+    for entry in std::fs::read_dir(&dir_path).unwrap() {
+        let path = entry.unwrap().path();
+        if let Some(ext) = path.extension() {
+            assert!(
+                !weight_extensions.contains(&ext.to_str().unwrap_or("")),
+                "Gewichtsdatei gefunden: {}", path.display()
+            );
+        }
+    }
+}
+
+// === AC-4: Laufzeit-Guardrails (Timeout-Enforcement) ===
+
+#[test]
+fn ac4_backlog_skip_enforced() {
+    let h = TestHarness::new();
+    // Seed Agent mit mehr Episodes als max_episodes_per_agent
+    let mut settings = h.settings.clone();
+    settings.max_episodes_per_agent = 3; // Niedrig setzen
+
+    let dir = tempfile::tempdir().unwrap();
+    let hc_path = dir.path().join("hc.redb");
+    let es_path = dir.path().join("ev.db");
+    let jq_path = dir.path().join("jq.db");
+
+    let hc = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+    let es = EventStore::open(es_path.to_str().unwrap()).unwrap();
+    let jq = JobQueue::open(jq_path.to_str().unwrap()).unwrap();
+
+    // 10 Episodes > max 3
+    let episodes: Vec<Episode> = (0..10)
+        .map(|i| make_episode(i, "Backlog-Agent", &format!("Event {i}"), 0.5, 0.5))
+        .collect();
+    hc.record_episodes("Backlog-Agent", &episodes).unwrap();
+
+    settings.hippocampus_db = hc_path.to_str().unwrap().to_string();
+    settings.event_store_db = es_path.to_str().unwrap().to_string();
+    settings.agent_config_dir = dir.path().to_str().unwrap().to_string();
+    settings.job_queue_path = jq_path.to_str().unwrap().to_string();
+
+    let runner = NightrunRunner::new(hc, es, jq, settings, "run-ac4".into(), false);
+    let result = runner.run(1).unwrap();
+
+    assert_eq!(result.agents_skipped, 1, "Agent mit zu grossem Backlog muss uebersprungen werden");
+    assert_eq!(result.agents_consolidated, 0);
+}
+
+// === Resume nach Crash ===
+
+#[test]
+fn resume_continues_partial_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let hc_path = dir.path().join("hc.redb");
+    let es_path = dir.path().join("ev.db");
+    let jq_path = dir.path().join("jq.db");
+
+    // Phase 1: Starte Run, konsolidiere nur einen Agent
+    {
+        let hc = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+        hc.record_episodes("A", &[make_episode(1, "A", "Event A", 0.8, 0.7)])
+            .unwrap();
+        hc.record_episodes("B", &[make_episode(2, "B", "Event B", 0.8, 0.7)])
+            .unwrap();
+
+        let jq = JobQueue::open(jq_path.to_str().unwrap()).unwrap();
+        jq.create_run("run-resume", &["A".into(), "B".into()])
+            .unwrap();
+        // Simuliere: A wurde konsolidiert, B ist noch pending
+        jq.mark_in_progress("run-resume", "A").unwrap();
+        jq.mark_completed("run-resume", "A", 1, 1).unwrap();
+    }
+
+    // Phase 2: Resume — B sollte jetzt konsolidiert werden
+    {
+        let hc = HippocampusService::open(hc_path.to_str().unwrap()).unwrap();
+        let es = EventStore::open(es_path.to_str().unwrap()).unwrap();
+        let jq = JobQueue::open(jq_path.to_str().unwrap()).unwrap();
+
+        // Prüfe dass incomplete run gefunden wird
+        let incomplete = jq.get_incomplete_run().unwrap();
+        assert_eq!(incomplete.as_deref(), Some("run-resume"));
+
+        let settings = NightrunSettings {
+            hippocampus_db: hc_path.to_str().unwrap().to_string(),
+            event_store_db: es_path.to_str().unwrap().to_string(),
+            agent_config_dir: dir.path().to_str().unwrap().to_string(),
+            job_queue_path: jq_path.to_str().unwrap().to_string(),
+            timeout_per_agent_secs: 300,
+            timeout_total_secs: 7200,
+            max_episodes_per_agent: 1000,
+        };
+
+        let runner = NightrunRunner::new(hc, es, jq, settings, "run-resume".into(), false);
+        let result = runner.run(1).unwrap();
+
+        // Nur B sollte konsolidiert worden sein (A war schon done)
+        assert_eq!(result.agents_consolidated, 1);
+        assert_eq!(result.agents_failed, 0);
+    }
+}
+
+// === Dry-Run ===
+
+#[test]
+fn dry_run_skips_all_agents() {
+    let h = TestHarness::new();
+    h.seed_agent("Thomas", 5);
+    h.seed_agent("Lisa", 3);
+
+    let (runner, _es, _dir) = h.runner("run-dry", true);
+    let result = runner.run(1).unwrap();
+
+    assert_eq!(result.agents_consolidated, 0);
+    assert_eq!(result.agents_skipped, 2);
+
+    // Episodes muessen noch vorhanden sein
+    // (Hippocampus wurde an den Runner uebergeben, also koennen wir hier nicht pruefen.
+    // Aber dry_run soll nicht konsolidieren — das prueft der skipped count.)
+}
+
+// === Leerer Run (keine Episodes) ===
+
+#[test]
+fn empty_run_completes_gracefully() {
+    let h = TestHarness::new();
+    // Keine Episodes seeden
+    let (runner, _es, _dir) = h.runner("run-empty", false);
+    let result = runner.run(1).unwrap();
+
+    assert_eq!(result.agents_consolidated, 0);
+    assert_eq!(result.agents_failed, 0);
+    assert_eq!(result.agents_skipped, 0);
+    assert_eq!(result.total_episodes, 0);
+}
+
+// === Events werden emittiert ===
+
+#[test]
+fn events_emitted_to_event_store() {
+    let h = TestHarness::new();
+    h.seed_agent("Thomas", 5);
+
+    let es_path = h.settings.event_store_db.clone();
+    let (runner, _, _dir) = h.runner("run-events", false);
+    runner.run(1).unwrap();
+
+    // EventStore oeffnen und Events zaehlen
+    let conn = rusqlite::Connection::open(&es_path).unwrap();
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM events WHERE event_type LIKE 'nightrun_%' OR event_type LIKE 'agent_consol%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+
+    // Mindestens: NightRunStarted + AgentConsolidated + NightRunCompleted = 3
+    assert!(count >= 3, "Mindestens 3 Nightrun-Events erwartet, gefunden: {count}");
+}

--- a/services/sentinel-nightrun/tests/integration.rs
+++ b/services/sentinel-nightrun/tests/integration.rs
@@ -69,7 +69,11 @@ impl TestHarness {
         self.hippocampus.record_episodes(name, &episodes).unwrap();
     }
 
-    fn runner(self, run_id: &str, dry_run: bool) -> (NightrunRunner, EventStore, tempfile::TempDir) {
+    fn runner(
+        self,
+        run_id: &str,
+        dry_run: bool,
+    ) -> (NightrunRunner, EventStore, tempfile::TempDir) {
         let event_store_check = EventStore::open(&self.settings.event_store_db).unwrap();
         let runner = NightrunRunner::new(
             self.hippocampus,
@@ -142,7 +146,10 @@ fn ac2_narratives_persist_after_consolidation() {
 
         // Episodes muessen geloescht sein
         let remaining = hc.store().load_episodes("Thomas").unwrap();
-        assert!(remaining.is_empty(), "Episodes muessen nach Konsolidierung geloescht sein");
+        assert!(
+            remaining.is_empty(),
+            "Episodes muessen nach Konsolidierung geloescht sein"
+        );
     }
 }
 
@@ -164,7 +171,8 @@ fn ac3_no_weight_files_created() {
         if let Some(ext) = path.extension() {
             assert!(
                 !weight_extensions.contains(&ext.to_str().unwrap_or("")),
-                "Gewichtsdatei gefunden: {}", path.display()
+                "Gewichtsdatei gefunden: {}",
+                path.display()
             );
         }
     }
@@ -202,7 +210,10 @@ fn ac4_backlog_skip_enforced() {
     let runner = NightrunRunner::new(hc, es, jq, settings, "run-ac4".into(), false);
     let result = runner.run(1).unwrap();
 
-    assert_eq!(result.agents_skipped, 1, "Agent mit zu grossem Backlog muss uebersprungen werden");
+    assert_eq!(
+        result.agents_skipped, 1,
+        "Agent mit zu grossem Backlog muss uebersprungen werden"
+    );
     assert_eq!(result.agents_consolidated, 0);
 }
 
@@ -316,5 +327,8 @@ fn events_emitted_to_event_store() {
         .unwrap();
 
     // Mindestens: NightRunStarted + AgentConsolidated + NightRunCompleted = 3
-    assert!(count >= 3, "Mindestens 3 Nightrun-Events erwartet, gefunden: {count}");
+    assert!(
+        count >= 3,
+        "Mindestens 3 Nightrun-Events erwartet, gefunden: {count}"
+    );
 }

--- a/typos.toml
+++ b/typos.toml
@@ -243,6 +243,13 @@ manuell = "manuell"
 zusaetzlich = "zusaetzlich"
 ausfuehrbar = "ausfuehrbar"
 
+# Nightrun / Sandbox words (Issue #16, #17 - German in doc comments + SQL patterns)
+consol = "consol"             # SQL LIKE pattern: agent_consol% (matches agent_consolidated)
+Produktion = "Produktion"     # German: production
+lokale = "lokale"             # German: local
+Restriktion = "Restriktion"   # German: restriction
+Selektion = "Selektion"       # German: selection
+
 # Hippocampus Memory words (Issue #23 - Persistent Memory)
 Tage = "Tage"
 Tages = "Tages"


### PR DESCRIPTION
## Summary
- Implementiert den sentinel-nightrun run-to-completion Service fuer Schichtwechsel-Konsolidierung (Issue #17)
- Etabliert projekt-weite Benchmark-Governance (Two-Tier Architektur)
- Aktualisiert CI Quality Gates fuer Benchmark-Pflicht in Issues und PRs

## Changes
### sentinel-nightrun Service (neu)
- `src/shift.rs`: Shift-Detection (Wall-Clock Hour -> Shift-Set, outgoing shift mapping)
- `src/job_queue.rs`: SQLite Job-Queue mit Crash-Recovery (pending/in_progress/completed/failed/skipped)
- `src/runner.rs`: Kern-Pipeline (Agent-Selektion, sequentielle Konsolidierung, Timeout-Enforcement)
- `src/config.rs`: NightrunConfig aus nightrun.toml
- `src/main.rs`: CLI Entry Point (--config, --shift, --dry-run, --resume)
- `config/nightrun.toml`: Default-Konfiguration
- `deploy/systemd/sentinel-nightrun.service` + `.timer`: systemd Units (06:00/14:00/22:00)

### Events (erweitert)
- `crates/sentinel-common/src/events.rs`: 4 neue DomainEventPayload Varianten (NightRunStarted, NightRunCompleted, AgentConsolidated, AgentConsolidationFailed)

### Benchmark-Governance
- `.github/workflows/issue-quality.yml`: Benchmarks als Pflicht-Sektion
- `.github/workflows/pr-quality.yml`: ## Benchmarks als Pflicht-Sektion
- `docs/codex-analyse.md`: Two-Tier Benchmark-Strategie + Nightrun-Benchmarks dokumentiert

## Linked Issues
Closes #17

## Test Plan
- 13 Unit-Tests (shift, job_queue, config, runner)
- 8 Acceptance-Tests (AC-1 bis AC-4, resume, dry-run, empty-run, events)
- 9 Criterion-Benchmarks (shift, job_queue, pipeline)
- `cargo remote -- build -p sentinel-nightrun` -> OK
- `cargo remote -- test -p sentinel-nightrun` -> 21/21 pass
- `cargo remote -- clippy -p sentinel-nightrun -- -D warnings` -> 0 warnings

## Benchmarks

| Metrik | Wert | Status |
|--------|------|--------|
| `nightrun.shift/shift_set_for_hour` | 7.06ns | PASS |
| `nightrun.shift/outgoing_shift_set` | 882ps | PASS |
| `nightrun.job_queue/create_run_54` | 3.91ms | PASS |
| `nightrun.job_queue/mark_transitions` | 596us | PASS |
| `nightrun.pipeline/consolidate/15` | 82.9ms | PASS |

Tier 1 (Criterion/CI) auf Build-Server. Tier 2 (VM ext4) steht noch aus.

## Evidence (AC Mapping)

| AC | Kriterium | Evidence |
|----|-----------|----------|
| AC-1 | Service startet robust bei Schichtwechsel | `ac1_consolidation_completes_for_all_agents` test pass |
| AC-2 | Konsolidierte Daten in naechster Schicht sichtbar | `ac2_narratives_persist_after_consolidation` test pass |
| AC-3 | Keine Gewichtsdatei erzeugt | `ac3_no_weight_files_created` test pass |
| AC-4 | Laufzeit innerhalb Guardrails | `ac4_backlog_skip_enforced` test pass |

## Checklist
- [x] `cargo remote -- build` erfolgreich
- [x] `cargo remote -- test` 21/21 pass
- [x] `cargo remote -- clippy -- -D warnings` 0 warnings
- [x] Benchmarks dokumentiert
- [x] systemd Units erstellt
- [x] Conventional Commit Titel

🤖 Generated with [Claude Code](https://claude.com/claude-code)