### PR TITLE
deps(deps): bump criterion from 0.5.1 to 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,25 +773,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -790,12 +798,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1700,17 +1708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,9 +1715,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2158,6 +2155,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 anyhow = "1"
 toml = "1.0"
 approx = "0.5"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/sentinel-hippocampus/benches/hippocampus_bench.rs
+++ b/crates/sentinel-hippocampus/benches/hippocampus_bench.rs
@@ -11,7 +11,9 @@
 //! WICHTIG: Diese Benchmarks MUESSEN auf der Deployment-VM ausgefuehrt werden
 //! (NICHT auf dem Build-Server/LXC). Siehe CLAUDE.md.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use redb::ReadableDatabase;
 use sentinel_hippocampus::{nmda_score, Episode, HippocampusService, HippocampusStore};
 

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -11,7 +11,9 @@
 //! 2. Throughput-Szenario: 100 Ticks × 15 Agents (>100 ticks/s Schwellenwert)
 //! 3. Realistisches Mixed-Workload Szenario
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use sentinel_common::DomainEvent;
 use sentinel_limbo::EventStore;
 

--- a/crates/sentinel-runtime/benches/runtime_bench.rs
+++ b/crates/sentinel-runtime/benches/runtime_bench.rs
@@ -11,7 +11,9 @@
 
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use sentinel_common::components::{AgentIdentity, ShiftInfo};
 use sentinel_common::AgentId;
 use sentinel_limbo::EventStore;


### PR DESCRIPTION
## Summary
- Bump criterion benchmark framework from 0.5.1 to 0.8.2
- Migrate deprecated `criterion::black_box` to `std::hint::black_box` across all benchmark files
- Replaces Dependabot PR #78 which failed CI due to the deprecation

## Linked Issues
Closes #83

## Changes
- `Cargo.toml`: workspace criterion version `0.5` → `0.8`
- `Cargo.lock`: updated transitive dependencies
- `hippocampus_bench.rs`: `use std::hint::black_box` instead of `criterion::black_box`
- `event_store_bench.rs`: `use std::hint::black_box` instead of `criterion::black_box`
- `runtime_bench.rs`: `use std::hint::black_box` instead of `criterion::black_box`

## Test Plan
- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test` — all pass

## Benchmarks
No benchmark regressions expected — this is a dependency version bump with API migration only.

## Evidence (AC Mapping)
| AC-1 | criterion 0.8.2 compiles and all benchmark targets build | `cargo build` pass |

## Checklist
- [x] Code compiles without warnings
- [x] Clippy passes with `-D warnings`
- [x] All tests pass
- [x] Formatting checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)