### PR TITLE
fix(ci): add contents:read permission to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
     - cron: '0 4 * * 3'  # Mittwoch 04:00 UTC
 
 permissions:
+  contents: read
   security-events: write
 
 jobs:


### PR DESCRIPTION
## Summary
- CodeQL workflow has been failing on every single run since repo creation (9 consecutive failures)
- Root cause: `permissions` block only had `security-events: write` but lacked `contents: read`
- Self-hosted runners with private repos require explicit `contents: read` for `actions/checkout` to clone the repository
- Fix: Add `contents: read` to the workflow permissions block

## Test plan
- [ ] **Static**: N/A (YAML-only change)
- [ ] **CI**: Merge to main triggers CodeQL workflow — verify it passes for the first time
- [ ] **Regression**: Verify other workflows (CI, Main Push Guard) still pass

### NOT Tested
- Ebene: CodeQL analysis results
- Grund: Can only verify after merge to main (workflow triggers on push to main)
- Risiko: Low — only adding a permission, not changing analysis config
- Folge-Issue: None needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)