### PR TITLE
feat: add MARBLE Observatory persistence and HTTP API

### DIFF
--- a/cmd/cortex-gateway/internal/observatory/handler.go
+++ b/cmd/cortex-gateway/internal/observatory/handler.go
@@ -1,0 +1,229 @@
+package observatory
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const maxBodySize = 4 * 1024 * 1024 // 4 MB
+
+// Handler serves HTTP endpoints for the MARBLE Observatory.
+type Handler struct {
+	store  *SqliteStore
+	config *ObservatoryConfig
+	logger *slog.Logger
+}
+
+// NewHandler creates an observatory HTTP handler.
+// If logger is nil, a no-op logger is used.
+func NewHandler(store *SqliteStore, config *ObservatoryConfig, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Handler{store: store, config: config, logger: logger}
+}
+
+// RegisterRoutes adds observatory endpoints to the given ServeMux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /observatory/runs", h.handleSubmitRun)
+	mux.HandleFunc("GET /observatory/runs", h.handleListRuns)
+	mux.HandleFunc("GET /observatory/runs/{run_id}", h.handleGetRun)
+	mux.HandleFunc("GET /observatory/report", h.handleReport)
+}
+
+// submitRunRequest is the JSON body for POST /observatory/runs.
+type submitRunRequest struct {
+	Records []submitRecord `json:"records"`
+}
+
+type submitRecord struct {
+	Timestamp string          `json:"timestamp"` // RFC3339
+	Shift     int             `json:"shift"`
+	Model     string          `json:"model"`
+	Agent     string          `json:"agent"`
+	Scenario  string          `json:"scenario"`
+	Metrics   MetricsSnapshot `json:"metrics"`
+}
+
+type submitRunResponse struct {
+	RunID        string `json:"run_id"`
+	ConfigHash   string `json:"config_hash"`
+	RecordsStored int   `json:"records_stored"`
+	Status       string `json:"status"`
+}
+
+func (h *Handler) handleSubmitRun(w http.ResponseWriter, r *http.Request) {
+	defer func() { _ = r.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
+	if err != nil {
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxBodySize {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	var req submitRunRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Records) == 0 {
+		http.Error(w, "records array must not be empty", http.StatusBadRequest)
+		return
+	}
+
+	// Convert to ObservationRecords
+	records := make([]ObservationRecord, 0, len(req.Records))
+	for i, sr := range req.Records {
+		ts, err := time.Parse(time.RFC3339, sr.Timestamp)
+		if err != nil {
+			ts = time.Now()
+		}
+		if sr.Shift < 1 || sr.Shift > 3 {
+			http.Error(w, fmt.Sprintf("record[%d]: shift must be 1-3, got %d", i, sr.Shift), http.StatusBadRequest)
+			return
+		}
+		if sr.Model == "" {
+			http.Error(w, fmt.Sprintf("record[%d]: model must not be empty", i), http.StatusBadRequest)
+			return
+		}
+		records = append(records, ObservationRecord{
+			Timestamp: ts,
+			Shift:     sr.Shift,
+			Model:     sr.Model,
+			Agent:     sr.Agent,
+			Scenario:  sr.Scenario,
+			Metrics:   sr.Metrics,
+		})
+	}
+
+	runID := generateUUID()
+	configHash := ConfigHash(h.config)
+
+	if err := h.store.SubmitRun(runID, configHash, records); err != nil {
+		h.logger.Error("observatory submit run failed", "error", err)
+		http.Error(w, "failed to store run", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("observatory run submitted", "run_id", runID, "records", len(records))
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(submitRunResponse{
+		RunID:        runID,
+		ConfigHash:   configHash,
+		RecordsStored: len(records),
+		Status:       "completed",
+	})
+}
+
+type listRunsResponse struct {
+	Runs []RunSummary `json:"runs"`
+}
+
+func (h *Handler) handleListRuns(w http.ResponseWriter, _ *http.Request) {
+	runs, err := h.store.ListRuns()
+	if err != nil {
+		h.logger.Error("observatory list runs failed", "error", err)
+		http.Error(w, "failed to list runs", http.StatusInternalServerError)
+		return
+	}
+	if runs == nil {
+		runs = []RunSummary{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(listRunsResponse{Runs: runs})
+}
+
+type getRunResponse struct {
+	RunID       string              `json:"run_id"`
+	Records     []ObservationRecord `json:"records"`
+	RecordCount int                 `json:"record_count"`
+}
+
+func (h *Handler) handleGetRun(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("run_id")
+	if runID == "" {
+		http.Error(w, "run_id is required", http.StatusBadRequest)
+		return
+	}
+
+	filter := parseQueryFilter(r)
+
+	records, err := h.store.GetRunRecords(runID, filter)
+	if err != nil {
+		h.logger.Error("observatory get run failed", "error", err)
+		http.Error(w, "failed to get run records", http.StatusInternalServerError)
+		return
+	}
+	if records == nil {
+		records = []ObservationRecord{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(getRunResponse{
+		RunID:       runID,
+		Records:     records,
+		RecordCount: len(records),
+	})
+}
+
+func (h *Handler) handleReport(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "json"
+	}
+
+	filter := parseQueryFilter(r)
+	report := NewReportGenerator(h.store)
+
+	switch format {
+	case "json":
+		data, err := report.GenerateJSON(filter)
+		if err != nil {
+			h.logger.Error("observatory generate json report failed", "error", err)
+			http.Error(w, "failed to generate report", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+
+	case "markdown":
+		md := report.GenerateMarkdown(filter)
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = fmt.Fprint(w, md)
+
+	default:
+		http.Error(w, "format must be 'json' or 'markdown'", http.StatusBadRequest)
+	}
+}
+
+// parseQueryFilter extracts optional shift/model/scenario filter params from the request.
+func parseQueryFilter(r *http.Request) QueryFilter {
+	var filter QueryFilter
+
+	if s := r.URL.Query().Get("shift"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			filter.Shift = &v
+		}
+	}
+	if m := r.URL.Query().Get("model"); m != "" {
+		filter.Model = &m
+	}
+	if sc := r.URL.Query().Get("scenario"); sc != "" {
+		filter.Scenario = &sc
+	}
+
+	return filter
+}

--- a/cmd/cortex-gateway/internal/observatory/handler_test.go
+++ b/cmd/cortex-gateway/internal/observatory/handler_test.go
@@ -1,0 +1,304 @@
+package observatory
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func testHandler(t *testing.T) (*Handler, *http.ServeMux) {
+	t.Helper()
+
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Create a minimal valid config for ConfigHash
+	cfgFile := t.TempDir() + "/observatory.toml"
+	cfgContent := `[observatory]
+enabled = true
+[observatory.shift_1]
+model = "claude-sonnet"
+provider = "claude"
+agents = 15
+[observatory.shift_2]
+model = "llama-3.1-70b"
+provider = "ollama"
+agents = 15
+[observatory.shift_3]
+model = "qwen2.5-72b"
+provider = "ollama"
+agents = 15
+[observatory.scenarios]
+daily_routine = true
+crisis_response = true
+creative_task = true
+conflict_resolution = true
+`
+	if err := os.WriteFile(cfgFile, []byte(cfgContent), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(cfgFile)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	handler := NewHandler(store, cfg, nil)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+	return handler, mux
+}
+
+func TestHandleSubmitRun(t *testing.T) {
+	_, mux := testHandler(t)
+
+	body := `{"records":[
+		{"timestamp":"2026-02-16T10:00:00Z","shift":1,"model":"claude-sonnet","agent":"A1","scenario":"daily_routine","metrics":{"InfoPropagation":0.85,"GroupPolarization":0.15,"CommunicationScore":0.82,"PersonalityConsistency":0.91,"ResponseCreativity":0.67,"EmotionalRange":0.73}},
+		{"timestamp":"2026-02-16T10:01:00Z","shift":2,"model":"llama-3.1-70b","agent":"A2","scenario":"crisis_response","metrics":{"InfoPropagation":0.6,"GroupPolarization":0.3,"CommunicationScore":0.5}}
+	]}`
+
+	req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var resp submitRunResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Error("run_id is empty")
+	}
+	if resp.RecordsStored != 2 {
+		t.Errorf("records_stored = %d, want 2", resp.RecordsStored)
+	}
+	if resp.Status != "completed" {
+		t.Errorf("status = %q, want %q", resp.Status, "completed")
+	}
+	if resp.ConfigHash == "" {
+		t.Error("config_hash is empty")
+	}
+}
+
+func TestHandleSubmitRunInvalid(t *testing.T) {
+	_, mux := testHandler(t)
+
+	tests := []struct {
+		name string
+		body string
+		code int
+	}{
+		{"empty body", `{}`, http.StatusBadRequest},
+		{"empty records", `{"records":[]}`, http.StatusBadRequest},
+		{"invalid json", `{not json}`, http.StatusBadRequest},
+		{"invalid shift", `{"records":[{"shift":0,"model":"x","agent":"a","scenario":"s","timestamp":"2026-01-01T00:00:00Z","metrics":{}}]}`, http.StatusBadRequest},
+		{"empty model", `{"records":[{"shift":1,"model":"","agent":"a","scenario":"s","timestamp":"2026-01-01T00:00:00Z","metrics":{}}]}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(tt.body))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != tt.code {
+				t.Errorf("status = %d, want %d; body = %s", w.Code, tt.code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleListRuns(t *testing.T) {
+	_, mux := testHandler(t)
+
+	// Submit 2 runs
+	for i := 0; i < 2; i++ {
+		body := `{"records":[{"timestamp":"2026-02-16T10:00:00Z","shift":1,"model":"claude","agent":"A1","scenario":"daily","metrics":{}}]}`
+		req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("submit %d: status = %d", i, w.Code)
+		}
+	}
+
+	// List runs
+	req := httptest.NewRequest("GET", "/observatory/runs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp listRunsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Runs) != 2 {
+		t.Errorf("runs = %d, want 2", len(resp.Runs))
+	}
+}
+
+func TestHandleGetRun(t *testing.T) {
+	_, mux := testHandler(t)
+
+	// Submit a run
+	body := `{"records":[
+		{"timestamp":"2026-02-16T10:00:00Z","shift":1,"model":"claude","agent":"A1","scenario":"daily","metrics":{"InfoPropagation":0.8}},
+		{"timestamp":"2026-02-16T10:01:00Z","shift":2,"model":"llama","agent":"A2","scenario":"daily","metrics":{"InfoPropagation":0.6}}
+	]}`
+	req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var submitResp submitRunResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &submitResp)
+
+	// Get run records
+	req = httptest.NewRequest("GET", "/observatory/runs/"+submitResp.RunID, nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp getRunResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.RecordCount != 2 {
+		t.Errorf("record_count = %d, want 2", resp.RecordCount)
+	}
+
+	// Filter by shift
+	req = httptest.NewRequest("GET", "/observatory/runs/"+submitResp.RunID+"?shift=1", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.RecordCount != 1 {
+		t.Errorf("filtered record_count = %d, want 1", resp.RecordCount)
+	}
+}
+
+func TestHandleReportJSON(t *testing.T) {
+	_, mux := testHandler(t)
+
+	// Submit data
+	body := `{"records":[
+		{"timestamp":"2026-02-16T10:00:00Z","shift":1,"model":"claude-sonnet","agent":"A1","scenario":"daily","metrics":{"InfoPropagation":0.8,"GroupPolarization":0.1,"CommunicationScore":0.7,"PersonalityConsistency":0.9,"ResponseCreativity":0.6,"EmotionalRange":0.5}},
+		{"timestamp":"2026-02-16T10:01:00Z","shift":2,"model":"llama-70b","agent":"A2","scenario":"daily","metrics":{"InfoPropagation":0.6,"GroupPolarization":0.2,"CommunicationScore":0.5,"PersonalityConsistency":0.8,"ResponseCreativity":0.4,"EmotionalRange":0.3}}
+	]}`
+	req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Get JSON report
+	req = httptest.NewRequest("GET", "/observatory/report?format=json", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	// Verify it's valid jsonReport structure
+	var report jsonReport
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if report.Records != 2 {
+		t.Errorf("report records = %d, want 2", report.Records)
+	}
+	if len(report.Summaries) != 2 {
+		t.Errorf("report summaries = %d, want 2", len(report.Summaries))
+	}
+}
+
+func TestHandleReportMarkdown(t *testing.T) {
+	_, mux := testHandler(t)
+
+	// Submit data
+	body := `{"records":[{"timestamp":"2026-02-16T10:00:00Z","shift":1,"model":"claude","agent":"A1","scenario":"daily","metrics":{"InfoPropagation":0.8}}]}`
+	req := httptest.NewRequest("POST", "/observatory/runs", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Get markdown report
+	req = httptest.NewRequest("GET", "/observatory/report?format=markdown", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("Content-Type = %q, want text/markdown", ct)
+	}
+	if !strings.Contains(w.Body.String(), "# MARBLE Observatory Report") {
+		t.Error("markdown report missing header")
+	}
+}
+
+func TestHandleReportEmpty(t *testing.T) {
+	_, mux := testHandler(t)
+
+	req := httptest.NewRequest("GET", "/observatory/report?format=json", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var report jsonReport
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if report.Records != 0 {
+		t.Errorf("empty report records = %d, want 0", report.Records)
+	}
+}
+
+func TestHandleReportInvalidFormat(t *testing.T) {
+	_, mux := testHandler(t)
+
+	req := httptest.NewRequest("GET", "/observatory/report?format=xml", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleListRunsEmpty(t *testing.T) {
+	_, mux := testHandler(t)
+
+	req := httptest.NewRequest("GET", "/observatory/runs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp listRunsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Runs) != 0 {
+		t.Errorf("empty runs = %d, want 0", len(resp.Runs))
+	}
+}

--- a/cmd/cortex-gateway/internal/observatory/report.go
+++ b/cmd/cortex-gateway/internal/observatory/report.go
@@ -9,11 +9,11 @@ import (
 
 // ReportGenerator creates comparison reports from observatory data.
 type ReportGenerator struct {
-	store *ObservationStore
+	store ObservationStorer
 }
 
 // NewReportGenerator creates a ReportGenerator backed by the given store.
-func NewReportGenerator(store *ObservationStore) *ReportGenerator {
+func NewReportGenerator(store ObservationStorer) *ReportGenerator {
 	return &ReportGenerator{store: store}
 }
 

--- a/cmd/cortex-gateway/internal/observatory/run.go
+++ b/cmd/cortex-gateway/internal/observatory/run.go
@@ -1,0 +1,50 @@
+package observatory
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// RunSummary holds metadata for a single benchmark run.
+type RunSummary struct {
+	RunID       string    `json:"run_id"`
+	StartedAt   time.Time `json:"started_at"`
+	FinishedAt  time.Time `json:"finished_at,omitempty"`
+	ConfigHash  string    `json:"config_hash"`
+	Status      string    `json:"status"`
+	RecordCount int       `json:"record_count"`
+}
+
+// ConfigHash computes a SHA-256 hash of the observatory configuration
+// for reproducibility tracking (AC-1).
+func ConfigHash(cfg *ObservatoryConfig) string {
+	h := sha256.New()
+	shifts := cfg.Shifts()
+	for i, s := range shifts {
+		fmt.Fprintf(h, "shift_%d:%s:%s:%d;", i+1, s.Model, s.Provider, s.Agents)
+	}
+	sc := cfg.Observatory.Scenarios
+	fmt.Fprintf(h, "daily=%t;crisis=%t;creative=%t;conflict=%t",
+		sc.DailyRoutine, sc.CrisisResponse, sc.CreativeTask, sc.ConflictResolution)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// generateUUID returns a new random UUIDv4 string.
+func generateUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 2
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(b[0:4]),
+		hex.EncodeToString(b[4:6]),
+		hex.EncodeToString(b[6:8]),
+		hex.EncodeToString(b[8:10]),
+		hex.EncodeToString(b[10:16]),
+	)
+}

--- a/cmd/cortex-gateway/internal/observatory/sqlite_store.go
+++ b/cmd/cortex-gateway/internal/observatory/sqlite_store.go
@@ -1,0 +1,277 @@
+package observatory
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const sqlitePragmas = `
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA mmap_size = 268435456;
+PRAGMA page_size = 8192
+`
+
+const createRuns = `CREATE TABLE IF NOT EXISTS runs (
+	id          INTEGER PRIMARY KEY AUTOINCREMENT,
+	run_id      TEXT NOT NULL UNIQUE,
+	started_at  INTEGER NOT NULL,
+	finished_at INTEGER,
+	config_hash TEXT NOT NULL,
+	status      TEXT NOT NULL DEFAULT 'completed'
+)`
+
+const createRunsIndex = `CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status)`
+
+const createObservations = `CREATE TABLE IF NOT EXISTS observations (
+	id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+	run_id                  TEXT NOT NULL REFERENCES runs(run_id),
+	timestamp_ms            INTEGER NOT NULL,
+	shift                   INTEGER NOT NULL CHECK (shift BETWEEN 1 AND 3),
+	model                   TEXT NOT NULL,
+	agent                   TEXT NOT NULL,
+	scenario                TEXT NOT NULL,
+	info_propagation        REAL NOT NULL,
+	group_polarization      REAL NOT NULL,
+	communication_score     REAL NOT NULL,
+	personality_consistency REAL NOT NULL,
+	response_creativity     REAL NOT NULL,
+	emotional_range         REAL NOT NULL
+)`
+
+const createObsIndices = `
+CREATE INDEX IF NOT EXISTS idx_obs_run ON observations(run_id);
+CREATE INDEX IF NOT EXISTS idx_obs_shift ON observations(shift);
+CREATE INDEX IF NOT EXISTS idx_obs_model ON observations(model)
+`
+
+// SqliteStore provides persistent storage for observation records backed by SQLite.
+// It keeps an in-memory cache for fast reads and writes through to SQLite.
+type SqliteStore struct {
+	db      *sql.DB
+	mu      sync.RWMutex
+	records []ObservationRecord
+}
+
+// OpenSqliteStore opens (or creates) a SQLite observatory database at path.
+// It runs migrations and loads all existing records into the memory cache (AC-4).
+func OpenSqliteStore(path string) (*SqliteStore, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("observatory open: %w", err)
+	}
+
+	db.SetMaxOpenConns(1)
+
+	for _, ddl := range []string{sqlitePragmas, createRuns, createRunsIndex, createObservations, createObsIndices} {
+		if _, err := db.Exec(ddl); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("observatory migrate: %w", err)
+		}
+	}
+
+	s := &SqliteStore{db: db}
+	if err := s.loadRecords(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("observatory load records: %w", err)
+	}
+
+	return s, nil
+}
+
+// loadRecords reads all observation rows from SQLite into the memory cache.
+func (s *SqliteStore) loadRecords() error {
+	rows, err := s.db.Query(`SELECT timestamp_ms, shift, model, agent, scenario,
+		info_propagation, group_polarization, communication_score,
+		personality_consistency, response_creativity, emotional_range
+		FROM observations ORDER BY id`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var records []ObservationRecord
+	for rows.Next() {
+		var r ObservationRecord
+		var tsMs int64
+		if err := rows.Scan(&tsMs, &r.Shift, &r.Model, &r.Agent, &r.Scenario,
+			&r.Metrics.InfoPropagation, &r.Metrics.GroupPolarization,
+			&r.Metrics.CommunicationScore, &r.Metrics.PersonalityConsistency,
+			&r.Metrics.ResponseCreativity, &r.Metrics.EmotionalRange,
+		); err != nil {
+			return err
+		}
+		r.Timestamp = time.UnixMilli(tsMs)
+		records = append(records, r)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	s.records = records
+	return nil
+}
+
+// Add appends an observation record to both SQLite and the memory cache.
+func (s *SqliteStore) Add(record ObservationRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, _ = s.db.Exec(`INSERT INTO observations
+		(run_id, timestamp_ms, shift, model, agent, scenario,
+		 info_propagation, group_polarization, communication_score,
+		 personality_consistency, response_creativity, emotional_range)
+		VALUES ('_unassigned', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.Timestamp.UnixMilli(), record.Shift, record.Model,
+		record.Agent, record.Scenario,
+		record.Metrics.InfoPropagation, record.Metrics.GroupPolarization,
+		record.Metrics.CommunicationScore, record.Metrics.PersonalityConsistency,
+		record.Metrics.ResponseCreativity, record.Metrics.EmotionalRange,
+	)
+
+	s.records = append(s.records, record)
+}
+
+// Query returns all records matching the given filter criteria (from memory cache).
+func (s *SqliteStore) Query(filter QueryFilter) []ObservationRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []ObservationRecord
+	for _, r := range s.records {
+		if matchesFilter(r, filter) {
+			results = append(results, r)
+		}
+	}
+	return results
+}
+
+// AllRecords returns a copy of all stored observation records.
+func (s *SqliteStore) AllRecords() []ObservationRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]ObservationRecord, len(s.records))
+	copy(result, s.records)
+	return result
+}
+
+// Len returns the number of stored records.
+func (s *SqliteStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.records)
+}
+
+// SubmitRun atomically inserts a run and its observation records in a single transaction.
+func (s *SqliteStore) SubmitRun(runID, configHash string, records []ObservationRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("observatory begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UnixMilli()
+	if _, err := tx.Exec(`INSERT INTO runs (run_id, started_at, finished_at, config_hash, status)
+		VALUES (?, ?, ?, ?, 'completed')`, runID, now, now, configHash); err != nil {
+		return fmt.Errorf("observatory insert run: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO observations
+		(run_id, timestamp_ms, shift, model, agent, scenario,
+		 info_propagation, group_polarization, communication_score,
+		 personality_consistency, response_creativity, emotional_range)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("observatory prepare obs: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, r := range records {
+		if _, err := stmt.Exec(runID, r.Timestamp.UnixMilli(), r.Shift, r.Model,
+			r.Agent, r.Scenario,
+			r.Metrics.InfoPropagation, r.Metrics.GroupPolarization,
+			r.Metrics.CommunicationScore, r.Metrics.PersonalityConsistency,
+			r.Metrics.ResponseCreativity, r.Metrics.EmotionalRange,
+		); err != nil {
+			return fmt.Errorf("observatory insert observation: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("observatory commit: %w", err)
+	}
+
+	s.records = append(s.records, records...)
+	return nil
+}
+
+// ListRuns returns metadata for all benchmark runs.
+func (s *SqliteStore) ListRuns() ([]RunSummary, error) {
+	rows, err := s.db.Query(`SELECT r.run_id, r.started_at, r.finished_at, r.config_hash, r.status,
+		COUNT(o.id) as record_count
+		FROM runs r LEFT JOIN observations o ON r.run_id = o.run_id
+		GROUP BY r.run_id ORDER BY r.started_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var runs []RunSummary
+	for rows.Next() {
+		var rs RunSummary
+		var startMs int64
+		var finishMs sql.NullInt64
+		if err := rows.Scan(&rs.RunID, &startMs, &finishMs, &rs.ConfigHash, &rs.Status, &rs.RecordCount); err != nil {
+			return nil, err
+		}
+		rs.StartedAt = time.UnixMilli(startMs)
+		if finishMs.Valid {
+			rs.FinishedAt = time.UnixMilli(finishMs.Int64)
+		}
+		runs = append(runs, rs)
+	}
+	return runs, rows.Err()
+}
+
+// GetRunRecords returns observation records for a specific run, optionally filtered.
+func (s *SqliteStore) GetRunRecords(runID string, filter QueryFilter) ([]ObservationRecord, error) {
+	rows, err := s.db.Query(`SELECT timestamp_ms, shift, model, agent, scenario,
+		info_propagation, group_polarization, communication_score,
+		personality_consistency, response_creativity, emotional_range
+		FROM observations WHERE run_id = ? ORDER BY id`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []ObservationRecord
+	for rows.Next() {
+		var r ObservationRecord
+		var tsMs int64
+		if err := rows.Scan(&tsMs, &r.Shift, &r.Model, &r.Agent, &r.Scenario,
+			&r.Metrics.InfoPropagation, &r.Metrics.GroupPolarization,
+			&r.Metrics.CommunicationScore, &r.Metrics.PersonalityConsistency,
+			&r.Metrics.ResponseCreativity, &r.Metrics.EmotionalRange,
+		); err != nil {
+			return nil, err
+		}
+		r.Timestamp = time.UnixMilli(tsMs)
+		if matchesFilter(r, filter) {
+			records = append(records, r)
+		}
+	}
+	return records, rows.Err()
+}
+
+// Close closes the underlying database connection.
+func (s *SqliteStore) Close() error {
+	return s.db.Close()
+}

--- a/cmd/cortex-gateway/internal/observatory/sqlite_store_test.go
+++ b/cmd/cortex-gateway/internal/observatory/sqlite_store_test.go
@@ -1,0 +1,316 @@
+package observatory
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func tempDBPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "observatory_test.db")
+}
+
+func TestOpenSqliteStore(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	if store.Len() != 0 {
+		t.Errorf("empty store Len = %d, want 0", store.Len())
+	}
+
+	// Verify DB file exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Error("DB file was not created")
+	}
+}
+
+func TestSqliteStoreAdd(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	rec := ObservationRecord{
+		Timestamp: time.Now(),
+		Shift:     1,
+		Model:     "claude-sonnet",
+		Agent:     "AGENT-01",
+		Scenario:  "daily_routine",
+		Metrics: MetricsSnapshot{
+			InfoPropagation:        0.85,
+			GroupPolarization:      0.15,
+			CommunicationScore:     0.82,
+			PersonalityConsistency: 0.91,
+			ResponseCreativity:     0.67,
+			EmotionalRange:         0.73,
+		},
+	}
+
+	store.Add(rec)
+
+	if store.Len() != 1 {
+		t.Errorf("Len = %d, want 1", store.Len())
+	}
+
+	all := store.AllRecords()
+	if len(all) != 1 {
+		t.Fatalf("AllRecords len = %d, want 1", len(all))
+	}
+	if all[0].Model != "claude-sonnet" {
+		t.Errorf("Model = %q, want %q", all[0].Model, "claude-sonnet")
+	}
+	if all[0].Metrics.InfoPropagation != 0.85 {
+		t.Errorf("InfoPropagation = %f, want 0.85", all[0].Metrics.InfoPropagation)
+	}
+}
+
+// TestSqliteStoreReload verifies AC-4: restart resilience.
+func TestSqliteStoreReload(t *testing.T) {
+	path := tempDBPath(t)
+
+	// Phase 1: Open, add records, close
+	store1, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("open 1: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		store1.Add(ObservationRecord{
+			Timestamp: time.Now(),
+			Shift:     (i % 3) + 1,
+			Model:     "test-model",
+			Agent:     "AGENT-01",
+			Scenario:  "daily_routine",
+			Metrics: MetricsSnapshot{
+				InfoPropagation:   float64(i) * 0.1,
+				GroupPolarization: 0.2,
+			},
+		})
+	}
+
+	if store1.Len() != 5 {
+		t.Fatalf("store1 Len = %d, want 5", store1.Len())
+	}
+	if err := store1.Close(); err != nil {
+		t.Fatalf("close 1: %v", err)
+	}
+
+	// Phase 2: Reopen, verify records survived
+	store2, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("open 2: %v", err)
+	}
+	defer store2.Close()
+
+	if store2.Len() != 5 {
+		t.Errorf("store2 Len after reload = %d, want 5", store2.Len())
+	}
+
+	all := store2.AllRecords()
+	if len(all) != 5 {
+		t.Fatalf("AllRecords after reload = %d, want 5", len(all))
+	}
+	if all[0].Model != "test-model" {
+		t.Errorf("record[0].Model = %q, want %q", all[0].Model, "test-model")
+	}
+}
+
+func TestSqliteStoreSubmitRun(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	runID := "test-run-001"
+	configHash := "abc123"
+	records := []ObservationRecord{
+		{Timestamp: time.Now(), Shift: 1, Model: "claude-sonnet", Agent: "A1", Scenario: "daily_routine",
+			Metrics: MetricsSnapshot{InfoPropagation: 0.8, CommunicationScore: 0.7}},
+		{Timestamp: time.Now(), Shift: 2, Model: "llama-3.1-70b", Agent: "A1", Scenario: "daily_routine",
+			Metrics: MetricsSnapshot{InfoPropagation: 0.6, CommunicationScore: 0.5}},
+	}
+
+	if err := store.SubmitRun(runID, configHash, records); err != nil {
+		t.Fatalf("SubmitRun: %v", err)
+	}
+
+	if store.Len() != 2 {
+		t.Errorf("Len = %d, want 2", store.Len())
+	}
+
+	// Verify run metadata
+	runs, err := store.ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("ListRuns len = %d, want 1", len(runs))
+	}
+	if runs[0].RunID != runID {
+		t.Errorf("RunID = %q, want %q", runs[0].RunID, runID)
+	}
+	if runs[0].ConfigHash != configHash {
+		t.Errorf("ConfigHash = %q, want %q", runs[0].ConfigHash, configHash)
+	}
+	if runs[0].RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", runs[0].RecordCount)
+	}
+	if runs[0].Status != "completed" {
+		t.Errorf("Status = %q, want %q", runs[0].Status, "completed")
+	}
+}
+
+func TestSqliteStoreGetRunRecords(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	records := []ObservationRecord{
+		{Timestamp: time.Now(), Shift: 1, Model: "claude-sonnet", Agent: "A1", Scenario: "daily_routine",
+			Metrics: MetricsSnapshot{InfoPropagation: 0.8}},
+		{Timestamp: time.Now(), Shift: 2, Model: "llama-70b", Agent: "A2", Scenario: "crisis_response",
+			Metrics: MetricsSnapshot{InfoPropagation: 0.6}},
+		{Timestamp: time.Now(), Shift: 1, Model: "claude-sonnet", Agent: "A3", Scenario: "daily_routine",
+			Metrics: MetricsSnapshot{InfoPropagation: 0.9}},
+	}
+
+	if err := store.SubmitRun("run-filter", "hash", records); err != nil {
+		t.Fatalf("SubmitRun: %v", err)
+	}
+
+	// Get all records for the run
+	all, err := store.GetRunRecords("run-filter", QueryFilter{})
+	if err != nil {
+		t.Fatalf("GetRunRecords: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("all records = %d, want 3", len(all))
+	}
+
+	// Filter by shift
+	shift1 := 1
+	filtered, err := store.GetRunRecords("run-filter", QueryFilter{Shift: &shift1})
+	if err != nil {
+		t.Fatalf("GetRunRecords filtered: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("shift=1 records = %d, want 2", len(filtered))
+	}
+
+	// Filter by model
+	model := "llama-70b"
+	byModel, err := store.GetRunRecords("run-filter", QueryFilter{Model: &model})
+	if err != nil {
+		t.Fatalf("GetRunRecords by model: %v", err)
+	}
+	if len(byModel) != 1 {
+		t.Errorf("model=llama records = %d, want 1", len(byModel))
+	}
+}
+
+func TestSqliteStoreQueryFilter(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now()
+	store.Add(ObservationRecord{Timestamp: now, Shift: 1, Model: "claude", Agent: "A1", Scenario: "daily"})
+	store.Add(ObservationRecord{Timestamp: now, Shift: 2, Model: "llama", Agent: "A2", Scenario: "crisis"})
+	store.Add(ObservationRecord{Timestamp: now, Shift: 1, Model: "claude", Agent: "A3", Scenario: "daily"})
+
+	shift1 := 1
+	results := store.Query(QueryFilter{Shift: &shift1})
+	if len(results) != 2 {
+		t.Errorf("shift=1 query = %d, want 2", len(results))
+	}
+
+	model := "llama"
+	results = store.Query(QueryFilter{Model: &model})
+	if len(results) != 1 {
+		t.Errorf("model=llama query = %d, want 1", len(results))
+	}
+}
+
+func TestSqliteStoreConcurrent(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	var wg sync.WaitGroup
+	const writers = 5
+	const recsPerWriter = 20
+
+	// Concurrent writers
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(shift int) {
+			defer wg.Done()
+			for i := 0; i < recsPerWriter; i++ {
+				store.Add(ObservationRecord{
+					Timestamp: time.Now(),
+					Shift:     (shift % 3) + 1,
+					Model:     "concurrent-model",
+					Agent:     "A1",
+					Scenario:  "daily",
+				})
+			}
+		}(w)
+	}
+
+	// Concurrent readers
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				_ = store.Len()
+				_ = store.AllRecords()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	total := store.Len()
+	want := writers * recsPerWriter
+	if total != want {
+		t.Errorf("total records = %d, want %d", total, want)
+	}
+}
+
+func TestSqliteStoreListRunsEmpty(t *testing.T) {
+	path := tempDBPath(t)
+	store, err := OpenSqliteStore(path)
+	if err != nil {
+		t.Fatalf("OpenSqliteStore: %v", err)
+	}
+	defer store.Close()
+
+	runs, err := store.ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("ListRuns empty = %d, want 0", len(runs))
+	}
+}

--- a/cmd/cortex-gateway/internal/observatory/store_iface.go
+++ b/cmd/cortex-gateway/internal/observatory/store_iface.go
@@ -1,0 +1,11 @@
+package observatory
+
+// ObservationStorer is the storage abstraction for observation records.
+// Both the in-memory ObservationStore and the persistent SqliteStore
+// satisfy this interface.
+type ObservationStorer interface {
+	Add(record ObservationRecord)
+	Query(filter QueryFilter) []ObservationRecord
+	AllRecords() []ObservationRecord
+	Len() int
+}

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/eventstore"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/extraction"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/normalizer"
+	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/observatory"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy"
 )
 
@@ -93,6 +94,24 @@ func main() {
 		logger.Info("event store disabled (SENTINEL_CORTEX_EVENT_STORE_PATH not set)")
 	}
 
+	// 4c. Observatory (optional, enabled via config or SENTINEL_OBSERVATORY env)
+	var obsHandler *observatory.Handler
+	obsConfigPath := envOrDefault("SENTINEL_OBSERVATORY_CONFIG", "config/observatory.toml")
+	obsCfg, obsErr := observatory.LoadConfig(obsConfigPath)
+	if obsErr != nil {
+		logger.Info("observatory disabled", "reason", obsErr)
+	} else if obsCfg.IsEnabled() {
+		obsDBPath := envOrDefault("SENTINEL_OBSERVATORY_DB", "data/observatory.db")
+		obsStore, err := observatory.OpenSqliteStore(obsDBPath)
+		if err != nil {
+			logger.Error("failed to open observatory store", "path", obsDBPath, "error", err)
+			os.Exit(1)
+		}
+		defer func() { _ = obsStore.Close() }()
+		obsHandler = observatory.NewHandler(obsStore, obsCfg, logger)
+		logger.Info("observatory enabled", "db", obsDBPath)
+	}
+
 	// 5. Processing pipeline (fully wired)
 	pipelineHandler := proxy.NewPipelineHandler(proxy.PipelineConfig{
 		Registry:     registry,
@@ -124,6 +143,11 @@ func main() {
 	// 7. Control plane server (shared controlConfig → aenderungen wirken sofort)
 	controlPlane := control.NewPlane(controlConfig, logger)
 	controlMux := controlPlane.Handler()
+
+	// 7b. Register observatory routes on control plane (if enabled)
+	if obsHandler != nil {
+		obsHandler.RegisterRoutes(controlMux)
+	}
 
 	controlServer := &http.Server{
 		Addr:         ":" + controlPort,


### PR DESCRIPTION
## Summary
- SQLite-backed persistence for MARBLE Observatory benchmark runs (WAL mode, memory cache hybrid)
- REST API on control plane (:8081) with 4 endpoints for submitting, listing, and reporting benchmark runs
- `ObservationStorer` interface extraction enabling both in-memory and SQLite backends
- Optional wiring in main.go gated by `SENTINEL_OBSERVATORY_CONFIG` and `SENTINEL_OBSERVATORY_DB` env vars

Closes #27

## Changes
**New files (6):**
| File | Purpose |
|------|---------|
| `store_iface.go` | `ObservationStorer` interface |
| `run.go` | `RunSummary` type, `ConfigHash`, UUID helper |
| `sqlite_store.go` | SQLite persistence + in-memory cache |
| `sqlite_store_test.go` | Persistence, reload, concurrent tests |
| `handler.go` | HTTP API handler (4 endpoints) |
| `handler_test.go` | httptest-based API tests |

**Modified files (2):**
| File | Change |
|------|--------|
| `report.go` | `*ObservationStore` → `ObservationStorer` interface |
| `main.go` | Observatory wiring (Step 4c + 7b, optional) |

## API Endpoints
| Method | Route | Description |
|--------|-------|-------------|
| POST | `/observatory/runs` | Submit benchmark run batch |
| GET | `/observatory/runs` | List all runs |
| GET | `/observatory/runs/{run_id}` | Get run records (filterable by shift/model/scenario) |
| GET | `/observatory/report` | Generate report (JSON or Markdown) |

## Test plan
| Level | Command | Result |
|-------|---------|--------|
| Static | `go vet ./cmd/cortex-gateway/...` | pass |
| Unit | `go test ./cmd/cortex-gateway/internal/observatory/... -count=1` | 63 tests pass (42 existing + 21 new) |

### NOT Tested
- System/Artifact: No deployed binary tested (scope:partial)
- E2E: No end-to-end test against running gateway
- Reason: scope:partial delivery, persistence + API layer only
- Follow-up: Integration with live pipeline in future issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)