### PR TITLE
feat: add OutboxPublisher background task with transport abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `OutboxPublisher<T>` background task: polls outbox entries and publishes via generic `OutboxTransport` trait
+- `OutboxTransport` trait in sentinel-limbo for transport abstraction (no zenoh dependency)
+- `OutboxPublisherConfig` with env-based configuration (`SENTINEL_OUTBOX_POLL_INTERVAL_MS`, `SENTINEL_OUTBOX_BATCH_SIZE`)
+- Graceful shutdown support via `tokio::sync::watch` channel with drain-on-exit
+- 6 unit tests for OutboxPublisher (publish, retry, empty, shutdown, batch-size, config)
+- E2E acceptance test `ac_57_06` covering full outbox publish flow
+- `Clone` derive on `EventStore` (was already `Arc<Mutex>` internally)
 - Configurable provider deadline via `SENTINEL_CORTEX_PROVIDER_DEADLINE_SECONDS` (10-30s, default 20s)
 - `resilience` package: Zenoh query deadline with InFlightMap and stale-drop logic
 - Configurable Zenoh query deadline via `SENTINEL_CORTEX_ZENOH_DEADLINE_MS` (50-120ms, default 100ms)

--- a/crates/sentinel-limbo/src/event_store.rs
+++ b/crates/sentinel-limbo/src/event_store.rs
@@ -137,6 +137,7 @@ pub struct SnapshotRow {
 ///
 /// Thread-safe via `Arc<Mutex<Connection>>`. Fuer async-Kontexte:
 /// in tokio::task::spawn_blocking wrappen.
+#[derive(Clone)]
 pub struct EventStore {
     conn: Arc<Mutex<Connection>>,
 }
@@ -695,6 +696,23 @@ impl EventStore {
     fn conn(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().unwrap()
     }
+}
+
+// ──────────────────────────────────────────────
+// OutboxTransport Trait
+// ──────────────────────────────────────────────
+
+/// Transport backend for outbox event publishing.
+///
+/// Implementiert von Zenoh-Adapter (sentinel-runtime) oder Mock (Tests).
+/// Generisch gehalten damit sentinel-limbo NICHT von sentinel-zenoh abhaengt.
+pub trait OutboxTransport: Send + Sync + 'static {
+    /// Publiziert ein Event an den angegebenen Topic.
+    fn publish<'a>(
+        &'a self,
+        topic: &'a str,
+        payload: &'a [u8],
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send + 'a;
 }
 
 // ──────────────────────────────────────────────

--- a/crates/sentinel-limbo/src/lib.rs
+++ b/crates/sentinel-limbo/src/lib.rs
@@ -9,8 +9,10 @@
 //! with tokio::task::spawn_blocking for async compatibility.
 
 pub mod event_store;
+pub mod outbox_publisher;
 
-pub use event_store::{EventStore, MonotonicityError, OutboxEntry, SnapshotRow};
+pub use event_store::{EventStore, MonotonicityError, OutboxEntry, OutboxTransport, SnapshotRow};
+pub use outbox_publisher::{OutboxPublisher, OutboxPublisherConfig, PublishCycleStats};
 
 use rusqlite::{params, Connection};
 use sentinel_common::{AgentId, Emotion, EventType, RoomId, Tick, Timestamp};

--- a/crates/sentinel-limbo/src/outbox_publisher.rs
+++ b/crates/sentinel-limbo/src/outbox_publisher.rs
@@ -1,0 +1,426 @@
+//! Background-Task der Outbox-Eintraege pollt und via Transport publiziert.
+//!
+//! Verbindet den append-only EventStore (SQLite) mit einem externen
+//! Pub/Sub-System (z.B. Zenoh). Polling-basiert mit konfigurierbarem
+//! Intervall und Batch-Groesse.
+//!
+//! Graceful Shutdown via `tokio::sync::watch` Channel.
+
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use crate::event_store::{EventStore, OutboxTransport};
+
+/// Default-Polling-Intervall in Millisekunden.
+const DEFAULT_POLL_INTERVAL_MS: u64 = 100;
+
+/// Default Batch-Groesse pro Poll-Zyklus.
+const DEFAULT_BATCH_SIZE: usize = 50;
+
+/// Konfiguration fuer den OutboxPublisher.
+#[derive(Debug, Clone)]
+pub struct OutboxPublisherConfig {
+    /// Polling-Intervall zwischen Outbox-Abfragen.
+    pub poll_interval: Duration,
+    /// Maximale Anzahl Eintraege pro Poll-Zyklus.
+    pub batch_size: usize,
+}
+
+impl Default for OutboxPublisherConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_millis(DEFAULT_POLL_INTERVAL_MS),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+}
+
+impl OutboxPublisherConfig {
+    /// Liest Konfiguration aus Umgebungsvariablen.
+    ///
+    /// - `SENTINEL_OUTBOX_POLL_INTERVAL_MS` (default: 100)
+    /// - `SENTINEL_OUTBOX_BATCH_SIZE` (default: 50)
+    pub fn from_env() -> Self {
+        let poll_interval_ms: u64 = std::env::var("SENTINEL_OUTBOX_POLL_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_POLL_INTERVAL_MS);
+
+        let batch_size: usize = std::env::var("SENTINEL_OUTBOX_BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_BATCH_SIZE);
+
+        Self {
+            poll_interval: Duration::from_millis(poll_interval_ms),
+            batch_size,
+        }
+    }
+}
+
+/// Background-Publisher der Outbox-Events an einen Transport weiterleitet.
+///
+/// Pollt den EventStore in regelmaessigen Intervallen nach pending Outbox-Eintraegen,
+/// publiziert sie via Transport und markiert sie als published.
+///
+/// Fehlgeschlagene Publishes bleiben als pending erhalten und werden beim
+/// naechsten Zyklus erneut versucht (at-least-once Semantik).
+pub struct OutboxPublisher<T: OutboxTransport> {
+    store: EventStore,
+    transport: T,
+    config: OutboxPublisherConfig,
+}
+
+/// Statistiken eines einzelnen Poll-Zyklus.
+#[derive(Debug, Default)]
+pub struct PublishCycleStats {
+    /// Anzahl erfolgreich publizierter Eintraege.
+    pub published: usize,
+    /// Anzahl fehlgeschlagener Publishes (bleiben pending).
+    pub failed: usize,
+}
+
+impl<T: OutboxTransport> OutboxPublisher<T> {
+    /// Erstellt einen neuen OutboxPublisher.
+    pub fn new(store: EventStore, transport: T, config: OutboxPublisherConfig) -> Self {
+        Self {
+            store,
+            transport,
+            config,
+        }
+    }
+
+    /// Startet die Publish-Loop bis ein Shutdown-Signal empfangen wird.
+    ///
+    /// Blockiert den aktuellen Task. Typische Nutzung:
+    /// ```ignore
+    /// let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    /// tokio::spawn(async move { publisher.run(shutdown_rx).await });
+    /// // Spaeter: shutdown_tx.send(true) zum Beenden
+    /// ```
+    pub async fn run(&self, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+        info!(
+            poll_interval_ms = self.config.poll_interval.as_millis() as u64,
+            batch_size = self.config.batch_size,
+            "outbox publisher started"
+        );
+
+        loop {
+            tokio::select! {
+                () = tokio::time::sleep(self.config.poll_interval) => {
+                    let stats = self.process_batch().await;
+                    if stats.published > 0 || stats.failed > 0 {
+                        debug!(
+                            published = stats.published,
+                            failed = stats.failed,
+                            "outbox publish cycle completed"
+                        );
+                    }
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("outbox publisher shutting down");
+                        // Drain remaining entries before exit
+                        let stats = self.process_batch().await;
+                        if stats.published > 0 {
+                            info!(published = stats.published, "drained remaining outbox entries");
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Verarbeitet einen Batch von Outbox-Eintraegen.
+    ///
+    /// Kann auch direkt aufgerufen werden (ohne run-Loop) fuer Tests
+    /// oder einmalige Verarbeitung.
+    pub async fn process_batch(&self) -> PublishCycleStats {
+        let mut stats = PublishCycleStats::default();
+
+        let entries = match self.store.poll_outbox(self.config.batch_size) {
+            Ok(entries) => entries,
+            Err(e) => {
+                warn!(error = %e, "outbox poll failed");
+                return stats;
+            }
+        };
+
+        if entries.is_empty() {
+            return stats;
+        }
+
+        for entry in &entries {
+            match self
+                .transport
+                .publish(&entry.topic, entry.payload.as_bytes())
+                .await
+            {
+                Ok(()) => {
+                    if let Err(e) = self.store.mark_published(&entry.event_id) {
+                        warn!(
+                            outbox_id = entry.id,
+                            event_id = %entry.event_id,
+                            error = %e,
+                            "failed to mark outbox entry as published"
+                        );
+                        stats.failed += 1;
+                    } else {
+                        stats.published += 1;
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        outbox_id = entry.id,
+                        event_id = %entry.event_id,
+                        topic = %entry.topic,
+                        error = %e,
+                        "outbox publish failed, will retry next cycle"
+                    );
+                    stats.failed += 1;
+                }
+            }
+        }
+
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            for _ in 0..stats.published {
+                reg.counter("sentinel.limbo.outbox.publish.count")
+                    .increment();
+            }
+            for _ in 0..stats.failed {
+                reg.counter("sentinel.limbo.outbox.publish.errors")
+                    .increment();
+            }
+        }
+
+        stats
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EventStore;
+    use sentinel_common::DomainEvent;
+    use std::sync::{Arc, Mutex};
+
+    type PublishedPayloads = Vec<(String, Vec<u8>)>;
+
+    /// Mock-Transport der published Payloads sammelt.
+    #[derive(Clone, Default)]
+    struct MockTransport {
+        published: Arc<Mutex<PublishedPayloads>>,
+        fail_next: Arc<Mutex<bool>>,
+    }
+
+    impl OutboxTransport for MockTransport {
+        async fn publish(&self, topic: &str, payload: &[u8]) -> anyhow::Result<()> {
+            if *self.fail_next.lock().unwrap() {
+                *self.fail_next.lock().unwrap() = false;
+                return Err(anyhow::anyhow!("simulated transport failure"));
+            }
+            self.published
+                .lock()
+                .unwrap()
+                .push((topic.to_string(), payload.to_vec()));
+            Ok(())
+        }
+    }
+
+    fn test_event(i: u64) -> DomainEvent {
+        DomainEvent::new(
+            "test_event",
+            &format!("AGG-{i}"),
+            &format!("{{\"seq\": {i}}}"),
+            "corr-001",
+            i,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_process_batch_publishes_pending_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EventStore::open(dir.path().join("test.db").to_str().unwrap()).unwrap();
+        let transport = MockTransport::default();
+
+        // 3 Events mit Outbox einfuegen
+        for i in 0..3 {
+            store
+                .append_with_outbox(&test_event(i), &format!("topic/test/{i}"))
+                .unwrap();
+        }
+
+        let publisher = OutboxPublisher::new(
+            store.clone(),
+            transport.clone(),
+            OutboxPublisherConfig {
+                batch_size: 10,
+                ..Default::default()
+            },
+        );
+
+        let stats = publisher.process_batch().await;
+
+        assert_eq!(stats.published, 3);
+        assert_eq!(stats.failed, 0);
+
+        // Transport hat alle 3 empfangen
+        let published = transport.published.lock().unwrap();
+        assert_eq!(published.len(), 3);
+        assert_eq!(published[0].0, "topic/test/0");
+        assert_eq!(published[1].0, "topic/test/1");
+        assert_eq!(published[2].0, "topic/test/2");
+
+        // Outbox ist leer (alle published)
+        let remaining = store.poll_outbox(10).unwrap();
+        assert!(remaining.is_empty(), "outbox should be empty after publish");
+    }
+
+    #[tokio::test]
+    async fn test_process_batch_retries_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EventStore::open(dir.path().join("test.db").to_str().unwrap()).unwrap();
+        let transport = MockTransport::default();
+
+        store
+            .append_with_outbox(&test_event(0), "topic/retry")
+            .unwrap();
+
+        // Ersten Publish fehlschlagen lassen
+        *transport.fail_next.lock().unwrap() = true;
+
+        let publisher = OutboxPublisher::new(
+            store.clone(),
+            transport.clone(),
+            OutboxPublisherConfig::default(),
+        );
+
+        // Erster Versuch: fehlgeschlagen
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 0);
+        assert_eq!(stats.failed, 1);
+
+        // Entry bleibt pending
+        let pending = store.poll_outbox(10).unwrap();
+        assert_eq!(pending.len(), 1, "failed entry should remain pending");
+
+        // Zweiter Versuch: erfolgreich (fail_next wurde zurueckgesetzt)
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 1);
+        assert_eq!(stats.failed, 0);
+
+        // Jetzt leer
+        let remaining = store.poll_outbox(10).unwrap();
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_process_batch_empty_outbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EventStore::open(dir.path().join("test.db").to_str().unwrap()).unwrap();
+        let transport = MockTransport::default();
+
+        let publisher =
+            OutboxPublisher::new(store, transport.clone(), OutboxPublisherConfig::default());
+
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 0);
+        assert_eq!(stats.failed, 0);
+        assert!(transport.published.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_with_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EventStore::open(dir.path().join("test.db").to_str().unwrap()).unwrap();
+        let transport = MockTransport::default();
+
+        store
+            .append_with_outbox(&test_event(0), "topic/shutdown")
+            .unwrap();
+
+        let publisher = OutboxPublisher::new(
+            store.clone(),
+            transport.clone(),
+            OutboxPublisherConfig {
+                poll_interval: Duration::from_millis(10),
+                batch_size: 10,
+            },
+        );
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        // Publisher in Background starten
+        let handle = tokio::spawn(async move {
+            publisher.run(shutdown_rx).await;
+        });
+
+        // Kurz warten damit mindestens ein Poll-Zyklus durchlaeuft
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Shutdown senden
+        shutdown_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        // Event sollte publiziert worden sein
+        let published = transport.published.lock().unwrap();
+        assert!(
+            !published.is_empty(),
+            "should have published at least one entry"
+        );
+        assert_eq!(published[0].0, "topic/shutdown");
+    }
+
+    #[tokio::test]
+    async fn test_batch_size_respected() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EventStore::open(dir.path().join("test.db").to_str().unwrap()).unwrap();
+        let transport = MockTransport::default();
+
+        // 5 Events einfuegen
+        for i in 0..5 {
+            store
+                .append_with_outbox(&test_event(i), &format!("topic/batch/{i}"))
+                .unwrap();
+        }
+
+        let publisher = OutboxPublisher::new(
+            store.clone(),
+            transport.clone(),
+            OutboxPublisherConfig {
+                batch_size: 2, // Nur 2 pro Zyklus
+                ..Default::default()
+            },
+        );
+
+        // Erster Zyklus: 2 von 5
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 2);
+
+        // Zweiter Zyklus: 2 von 3
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 2);
+
+        // Dritter Zyklus: 1 von 1
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 1);
+
+        // Vierter Zyklus: leer
+        let stats = publisher.process_batch().await;
+        assert_eq!(stats.published, 0);
+
+        assert_eq!(transport.published.lock().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn test_config_from_env_defaults() {
+        // Ohne ENV-Variablen: Defaults
+        let config = OutboxPublisherConfig::default();
+        assert_eq!(config.poll_interval, Duration::from_millis(100));
+        assert_eq!(config.batch_size, 50);
+    }
+}

--- a/crates/sentinel-limbo/tests/acceptance.rs
+++ b/crates/sentinel-limbo/tests/acceptance.rs
@@ -355,3 +355,76 @@ fn ac_08_07_compensation_type() {
     assert_eq!(events[0].compensation_type, "none");
     assert_eq!(events[1].compensation_type, "rollback");
 }
+
+// ──────────────────────────────────────────────
+// Issue #57: OutboxPublisher Acceptance Tests
+// ──────────────────────────────────────────────
+
+type PublishedPayloads = Vec<(String, Vec<u8>)>;
+
+/// Mock-Transport fuer Acceptance Tests.
+struct AcceptanceMockTransport {
+    published: std::sync::Arc<std::sync::Mutex<PublishedPayloads>>,
+}
+
+impl AcceptanceMockTransport {
+    fn new() -> Self {
+        Self {
+            published: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl sentinel_limbo::OutboxTransport for AcceptanceMockTransport {
+    async fn publish(&self, topic: &str, payload: &[u8]) -> anyhow::Result<()> {
+        self.published
+            .lock()
+            .unwrap()
+            .push((topic.to_string(), payload.to_vec()));
+        Ok(())
+    }
+}
+
+/// AC-6 (Issue #57): E2E Flow — Event append → Outbox poll → Publish → Mark published → Offset update.
+#[tokio::test]
+async fn ac_57_06_e2e_outbox_publish_flow() {
+    use sentinel_limbo::{OutboxPublisher, OutboxPublisherConfig};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ac57_06.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+    let transport = AcceptanceMockTransport::new();
+    let published = transport.published.clone();
+
+    // 1. Agent-Action als Event mit Outbox persistieren
+    let event = test_event("agent_action_received", "AGENT-05");
+    let row_id = store
+        .append_with_outbox(&event, "sentinel/agent/AGENT-05/action")
+        .unwrap();
+    assert!(row_id > 0, "event should be persisted");
+
+    // 2. OutboxPublisher verarbeitet pending entries
+    let publisher =
+        OutboxPublisher::new(store.clone(), transport, OutboxPublisherConfig::default());
+    let stats = publisher.process_batch().await;
+    assert_eq!(stats.published, 1, "one entry should be published");
+    assert_eq!(stats.failed, 0, "no failures expected");
+
+    // 3. Transport hat das Event empfangen
+    let msgs = published.lock().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].0, "sentinel/agent/AGENT-05/action");
+
+    // 4. Outbox ist leer (alle published)
+    let pending = store.poll_outbox(10).unwrap();
+    assert!(pending.is_empty(), "outbox should be drained");
+
+    // 5. Projection-Offset aktualisieren (monoton)
+    store.update_offset("agent_projection", row_id).unwrap();
+    let offset = store.get_offset("agent_projection").unwrap();
+    assert_eq!(offset, Some(row_id), "offset should match row_id");
+
+    // 6. Monotonie-Verletzung wird abgefangen
+    let result = store.update_offset("agent_projection", row_id - 1);
+    assert!(result.is_err(), "backward offset should fail");
+}


### PR DESCRIPTION
## Summary

Implements the missing AC-6 from Issue #57: a generic `OutboxPublisher<T>` background task that polls pending outbox entries from the EventStore and publishes them via a pluggable `OutboxTransport` trait. ~95% of Issue #57 was already implemented in Sprint 1-4 (Issue #8) — this PR adds the final missing piece.

## Changes

- **`OutboxTransport` trait** (`event_store.rs`): Generic transport abstraction using RPITIT (Rust 1.93 native async traits, no `async-trait` crate). Allows sentinel-limbo to remain independent of sentinel-zenoh.
- **`OutboxPublisher<T>`** (`outbox_publisher.rs`, NEW): Background polling task with configurable interval/batch size, graceful shutdown via `tokio::sync::watch`, telemetry counters, at-least-once delivery semantics.
- **`OutboxPublisherConfig`** with env-based configuration (`SENTINEL_OUTBOX_POLL_INTERVAL_MS` default 100ms, `SENTINEL_OUTBOX_BATCH_SIZE` default 50).
- **`Clone` derive on `EventStore`**: Safe because it only contains `Arc<Mutex<Connection>>`.
- **Acceptance test `ac_57_06`**: Full E2E flow — append event with outbox → publisher polls → transport receives → outbox drained → offset updated → monotonicity enforced.
- **6 unit tests**: publish success, retry on failure, empty outbox, graceful shutdown, batch size enforcement, config defaults.

## Linked Issues

Closes #57

## Test Plan

| Level | Command | Result |
|-------|---------|--------|
| Static | `cargo remote -- clippy -p sentinel-limbo --all-targets -- -D warnings` | 0 warnings |
| Unit | `cargo remote -- test -p sentinel-limbo -v` | 28 lib tests pass |
| Integration | `cargo remote -- test -p sentinel-limbo -v` | 12 acceptance tests pass |
| Benchmark | `cargo remote -- bench -p sentinel-limbo --no-run` | Compiles OK |
| Format | `cargo fmt -- --check` | Clean |

## Benchmarks

Existing 14 Criterion benchmarks compile and are unaffected. No new benchmarks added (OutboxPublisher is I/O-bound, not CPU-bound — benchmarking mock transport latency would be meaningless).

## Evidence (AC Mapping)

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Atomic Event+Outbox write | pass | Existing `ac_08_02_event_outbox_atomic` test |
| AC-2 | Append-only (no UPDATE/DELETE API) | pass | Existing `ac_08_01_events_append_only` test |
| AC-3 | Idempotency via operation_id | pass | Existing `ac_08_03_operation_id_idempotent` test |
| AC-4 | Causation chain | pass | Existing `test_causation_chain` unit test |
| AC-5 | Monotonic offset enforcement | pass | Existing `ac_08_04_offsets_monotonic` test |
| AC-6 | OutboxPublisher background task | pass | NEW `ac_57_06_e2e_outbox_publish_flow` + 6 unit tests |
| AC-N1 | All data persistent in SQLite | pass | All tests use file-backed SQLite (tempdir) |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Tests prove fix/feature works (40 tests total, all green)
- [x] New and existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean
- [x] Benchmarks compile
- [x] CHANGELOG.md updated
- [x] No new warnings generated