### PR TITLE
feat(sentinel-fs): CAS-FUSE agent filesystem with SHA-256 dedup (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `sentinel-fs` crate: CAS-FUSE agent filesystem with SHA-256 dedup and zstd compression (#56)
+  - Content-Addressed Storage (CAS) with atomic writes, 2-char prefix subdirs, zstd level-3 compression
+  - redb metadata store with agent-scoped composite keys (FS_INODES, FS_DIRENTS, CAS_REFCOUNT)
+  - Layer manager: shared base (readonly) + per-agent CoW layers with whiteout markers
+  - FUSE handler (feature-gated): single mount for all agents, path-based Agent-ID extraction
+  - CLI: stats, gc, populate commands
+  - 49 tests (unit + integration), 7 criterion benchmarks
+  - Integration tests verify >87% dedup rate, agent isolation, crash recovery
 - `OutboxPublisher<T>` background task: polls outbox entries and publishes via generic `OutboxTransport` trait
 - `OutboxTransport` trait in sentinel-limbo for transport abstraction (no zenoh dependency)
 - `OutboxPublisherConfig` with env-based configuration (`SENTINEL_OUTBOX_POLL_INTERVAL_MS`, `SENTINEL_OUTBOX_BATCH_SIZE`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3571,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "fuser",
+ "libc",
  "redb",
  "sentinel-common",
  "sentinel-telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,16 +1456,15 @@ dependencies = [
 
 [[package]]
 name = "fuser"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+checksum = "0bb29a3ae32279fe3e79a958fe01899f5fb23eadccee919cf88e145b54ed9367"
 dependencies = [
  "libc",
  "log",
  "memchr",
  "nix",
  "page_size",
- "pkg-config",
  "smallvec",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentinel-fs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "redb",
+ "sentinel-common",
+ "sentinel-telemetry",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
 name = "sentinel-hippocampus"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/sentinel-hippocampus",
     "crates/sentinel-inference",
     "crates/sentinel-projection",
+    "crates/sentinel-fs",
     "services/sentinel-nightrun",
     "services/sentinel-daemon",
 ]

--- a/crates/sentinel-fs/Cargo.toml
+++ b/crates/sentinel-fs/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "sentinel-fs"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[features]
+default = ["telemetry"]
+telemetry = ["sentinel-telemetry/telemetry"]
+fuse-tests = []
+
+[dependencies]
+anyhow = { workspace = true }
+redb = { workspace = true }
+sentinel-common = { path = "../sentinel-common" }
+sentinel-telemetry = { path = "../sentinel-telemetry" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tracing = { workspace = true }
+zstd = "0.13"
+
+[dev-dependencies]
+criterion = { workspace = true }
+tempfile = "3"
+
+[[bench]]
+name = "sentinel_fs_bench"
+harness = false

--- a/crates/sentinel-fs/Cargo.toml
+++ b/crates/sentinel-fs/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
-fuser = { version = "0.15", optional = true }
+fuser = { version = "0.16", optional = true }
 libc = { version = "0.2", optional = true }
 zstd = "0.13"
 

--- a/crates/sentinel-fs/Cargo.toml
+++ b/crates/sentinel-fs/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [features]
 default = ["telemetry"]
 telemetry = ["sentinel-telemetry/telemetry"]
-fuse-tests = []
+fuse-tests = ["fuser", "libc"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -19,6 +19,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
+fuser = { version = "0.15", optional = true }
+libc = { version = "0.2", optional = true }
 zstd = "0.13"
 
 [dev-dependencies]

--- a/crates/sentinel-fs/benches/sentinel_fs_bench.rs
+++ b/crates/sentinel-fs/benches/sentinel_fs_bench.rs
@@ -1,17 +1,20 @@
-//! Benchmarks for sentinel-fs CAS store operations.
+//! Benchmarks for sentinel-fs: CAS, metadata, and layer operations.
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
+use sentinel_fs::cas::CasStore;
+use sentinel_fs::layer::LayerManager;
+use sentinel_fs::metadata::MetadataStore;
 
 fn cas_hash_throughput(c: &mut Criterion) {
     let data = vec![0u8; 4096];
     c.bench_function("cas_hash_4k", |b| {
-        b.iter(|| sentinel_fs::cas::CasStore::hash(std::hint::black_box(&data)))
+        b.iter(|| CasStore::hash(std::hint::black_box(&data)))
     });
 }
 
 fn cas_store_dedup(c: &mut Criterion) {
     let dir = tempfile::tempdir().unwrap();
-    let store = sentinel_fs::cas::CasStore::open(dir.path()).unwrap();
+    let store = CasStore::open(dir.path()).unwrap();
     let data = vec![0xAA; 4096];
 
     // Pre-store so subsequent calls hit the dedup path
@@ -24,7 +27,7 @@ fn cas_store_dedup(c: &mut Criterion) {
 
 fn cas_read(c: &mut Criterion) {
     let dir = tempfile::tempdir().unwrap();
-    let store = sentinel_fs::cas::CasStore::open(dir.path()).unwrap();
+    let store = CasStore::open(dir.path()).unwrap();
     let data = vec![0xAA; 4096];
     let (hash, _) = store.store(&data).unwrap();
 
@@ -33,5 +36,96 @@ fn cas_read(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, cas_hash_throughput, cas_store_dedup, cas_read);
+fn metadata_lookup(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let meta = MetadataStore::open(dir.path().join("bench.redb")).unwrap();
+
+    // Pre-populate
+    let data = sentinel_fs::metadata::InodeData::regular([0xBB; 32], 1024, 0o644);
+    meta.set_inode("AGENT-01", 42, &data).unwrap();
+
+    c.bench_function("metadata_get_inode", |b| {
+        b.iter(|| {
+            meta.get_inode(std::hint::black_box("AGENT-01"), std::hint::black_box(42))
+                .unwrap()
+        })
+    });
+}
+
+fn metadata_dirent_lookup(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let meta = MetadataStore::open(dir.path().join("bench.redb")).unwrap();
+
+    meta.set_dirent("AGENT-01", 1, "hello.txt", 42).unwrap();
+
+    c.bench_function("metadata_get_dirent", |b| {
+        b.iter(|| {
+            meta.get_dirent(
+                std::hint::black_box("AGENT-01"),
+                std::hint::black_box(1),
+                std::hint::black_box("hello.txt"),
+            )
+            .unwrap()
+        })
+    });
+}
+
+fn layer_read_fallback(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let cas = CasStore::open(dir.path()).unwrap();
+    let meta = MetadataStore::open(dir.path().join("bench.redb")).unwrap();
+    let lm = LayerManager::new(cas, meta);
+    lm.init_base_root().unwrap();
+
+    // Populate base with a file
+    let base_inode = lm
+        .populate_base_file(1, "shared.txt", b"shared content data", 0o644)
+        .unwrap();
+
+    c.bench_function("layer_read_base_fallback", |b| {
+        b.iter(|| {
+            lm.read_file(
+                std::hint::black_box("AGENT-01"),
+                std::hint::black_box(base_inode),
+            )
+            .unwrap()
+        })
+    });
+}
+
+fn concurrent_writes(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let cas = CasStore::open(dir.path()).unwrap();
+    let meta = MetadataStore::open(dir.path().join("bench.redb")).unwrap();
+    let lm = LayerManager::new(cas, meta);
+    lm.init_base_root().unwrap();
+
+    let mut counter = 0u64;
+
+    c.bench_function("layer_write_file", |b| {
+        b.iter(|| {
+            counter += 1;
+            let name = format!("file-{counter}.txt");
+            lm.write_file(
+                std::hint::black_box("AGENT-01"),
+                1,
+                &name,
+                std::hint::black_box(b"benchmark content payload"),
+                0o644,
+            )
+            .unwrap()
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    cas_hash_throughput,
+    cas_store_dedup,
+    cas_read,
+    metadata_lookup,
+    metadata_dirent_lookup,
+    layer_read_fallback,
+    concurrent_writes
+);
 criterion_main!(benches);

--- a/crates/sentinel-fs/benches/sentinel_fs_bench.rs
+++ b/crates/sentinel-fs/benches/sentinel_fs_bench.rs
@@ -1,0 +1,37 @@
+//! Benchmarks for sentinel-fs CAS store operations.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn cas_hash_throughput(c: &mut Criterion) {
+    let data = vec![0u8; 4096];
+    c.bench_function("cas_hash_4k", |b| {
+        b.iter(|| sentinel_fs::cas::CasStore::hash(std::hint::black_box(&data)))
+    });
+}
+
+fn cas_store_dedup(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = sentinel_fs::cas::CasStore::open(dir.path()).unwrap();
+    let data = vec![0xAA; 4096];
+
+    // Pre-store so subsequent calls hit the dedup path
+    store.store(&data).unwrap();
+
+    c.bench_function("cas_store_dedup_4k", |b| {
+        b.iter(|| store.store(std::hint::black_box(&data)).unwrap())
+    });
+}
+
+fn cas_read(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let store = sentinel_fs::cas::CasStore::open(dir.path()).unwrap();
+    let data = vec![0xAA; 4096];
+    let (hash, _) = store.store(&data).unwrap();
+
+    c.bench_function("cas_read_4k", |b| {
+        b.iter(|| store.read(std::hint::black_box(&hash)).unwrap())
+    });
+}
+
+criterion_group!(benches, cas_hash_throughput, cas_store_dedup, cas_read);
+criterion_main!(benches);

--- a/crates/sentinel-fs/src/cas.rs
+++ b/crates/sentinel-fs/src/cas.rs
@@ -103,8 +103,8 @@ impl CasStore {
     #[instrument(skip(self), level = "trace")]
     pub fn read(&self, hash: &[u8; 32]) -> anyhow::Result<Vec<u8>> {
         let blob_path = self.blob_path(hash);
-        let encoded = fs::read(&blob_path)
-            .map_err(|e| anyhow::anyhow!("Blob {}: {e}", hex_encode(hash)))?;
+        let encoded =
+            fs::read(&blob_path).map_err(|e| anyhow::anyhow!("Blob {}: {e}", hex_encode(hash)))?;
         decode_blob(&encoded)
     }
 
@@ -393,7 +393,13 @@ mod tests {
 
         // Should be cas_dir / XX / YYYY...YY (2-char prefix subdir)
         let hex = hex_encode(&hash);
-        let parent_name = path.parent().unwrap().file_name().unwrap().to_str().unwrap();
+        let parent_name = path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert_eq!(parent_name, &hex[..2]);
 
         let file_name = path.file_name().unwrap().to_str().unwrap();

--- a/crates/sentinel-fs/src/cas.rs
+++ b/crates/sentinel-fs/src/cas.rs
@@ -1,0 +1,430 @@
+//! Content-Addressed Storage (CAS) with SHA-256 dedup and zstd compression.
+//!
+//! Blobs are stored as `{cas_dir}/{hex[0..2]}/{hex[2..64]}` where `hex` is the
+//! SHA-256 hash of the original (uncompressed) content. Each blob has a 1-byte
+//! prefix indicating the encoding: `0x00` = raw, `0x01` = zstd compressed.
+
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use tracing::instrument;
+
+/// Blob prefix: uncompressed raw data.
+const PREFIX_RAW: u8 = 0x00;
+
+/// Blob prefix: zstd compressed data.
+const PREFIX_ZSTD: u8 = 0x01;
+
+/// zstd compression level (3 = good balance of speed/ratio).
+const ZSTD_LEVEL: i32 = 3;
+
+/// Minimum data size for compression (below this, store raw).
+const MIN_COMPRESS_SIZE: usize = 256;
+
+/// Content-Addressed Storage with inline deduplication.
+///
+/// Each unique blob is stored exactly once. The SHA-256 hash serves as the
+/// content address. Blobs above 256 bytes are zstd-compressed. Writes are
+/// atomic (temp file + rename) for crash safety.
+pub struct CasStore {
+    cas_dir: PathBuf,
+}
+
+/// Statistics about the CAS store.
+#[derive(Debug, Clone)]
+pub struct CasStats {
+    pub blob_count: u64,
+    pub total_bytes_on_disk: u64,
+}
+
+/// Result of a garbage collection run.
+#[derive(Debug, Clone)]
+pub struct GcStats {
+    pub removed: u64,
+    pub freed_bytes: u64,
+}
+
+impl CasStore {
+    /// Open or create a CAS store. Blobs are stored under `{data_dir}/cas/`.
+    #[instrument(level = "debug", fields(data_dir = %data_dir.display()))]
+    pub fn open(data_dir: &Path) -> anyhow::Result<Self> {
+        let cas_dir = data_dir.join("cas");
+        fs::create_dir_all(&cas_dir)?;
+        Ok(Self { cas_dir })
+    }
+
+    /// Compute SHA-256 hash of data.
+    pub fn hash(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hasher.finalize().into()
+    }
+
+    /// Get the filesystem path for a blob by its hash.
+    fn blob_path(&self, hash: &[u8; 32]) -> PathBuf {
+        let hex = hex_encode(hash);
+        self.cas_dir.join(&hex[..2]).join(&hex[2..])
+    }
+
+    /// Check if a blob with the given hash exists.
+    pub fn contains(&self, hash: &[u8; 32]) -> bool {
+        self.blob_path(hash).exists()
+    }
+
+    /// Store data in the CAS. Returns `(hash, deduplicated)`.
+    ///
+    /// If `deduplicated` is true, the blob already existed and no disk I/O
+    /// was performed for the content — only metadata needs updating.
+    #[instrument(skip(self, data), level = "trace", fields(data_len = data.len()))]
+    pub fn store(&self, data: &[u8]) -> anyhow::Result<([u8; 32], bool)> {
+        let hash = Self::hash(data);
+
+        if self.contains(&hash) {
+            return Ok((hash, true));
+        }
+
+        let blob_path = self.blob_path(&hash);
+        if let Some(parent) = blob_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let encoded = encode_blob(data);
+
+        // Atomic write: temp file + rename
+        let tmp_path = blob_path.with_extension("tmp");
+        fs::write(&tmp_path, &encoded)?;
+        fs::rename(&tmp_path, &blob_path)?;
+
+        Ok((hash, false))
+    }
+
+    /// Read and decode a blob by its hash.
+    #[instrument(skip(self), level = "trace")]
+    pub fn read(&self, hash: &[u8; 32]) -> anyhow::Result<Vec<u8>> {
+        let blob_path = self.blob_path(hash);
+        let encoded = fs::read(&blob_path)
+            .map_err(|e| anyhow::anyhow!("Blob {}: {e}", hex_encode(hash)))?;
+        decode_blob(&encoded)
+    }
+
+    /// Remove a blob from the store. Returns true if it existed.
+    pub fn remove(&self, hash: &[u8; 32]) -> anyhow::Result<bool> {
+        let path = self.blob_path(hash);
+        if path.exists() {
+            fs::remove_file(&path)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Remove blobs with zero references.
+    #[instrument(skip(self, zero_ref_hashes), level = "debug", fields(count = zero_ref_hashes.len()))]
+    pub fn gc(&self, zero_ref_hashes: &[[u8; 32]]) -> anyhow::Result<GcStats> {
+        let mut removed = 0u64;
+        let mut freed_bytes = 0u64;
+
+        for hash in zero_ref_hashes {
+            let path = self.blob_path(hash);
+            if path.exists() {
+                if let Ok(meta) = fs::metadata(&path) {
+                    freed_bytes += meta.len();
+                }
+                fs::remove_file(&path)?;
+                removed += 1;
+            }
+        }
+
+        Ok(GcStats {
+            removed,
+            freed_bytes,
+        })
+    }
+
+    /// Get statistics about the CAS store.
+    pub fn stats(&self) -> anyhow::Result<CasStats> {
+        let mut blob_count = 0u64;
+        let mut total_bytes = 0u64;
+
+        if !self.cas_dir.exists() {
+            return Ok(CasStats {
+                blob_count: 0,
+                total_bytes_on_disk: 0,
+            });
+        }
+
+        for entry in fs::read_dir(&self.cas_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                for blob_entry in fs::read_dir(entry.path())? {
+                    let blob_entry = blob_entry?;
+                    if blob_entry.file_type()?.is_file() {
+                        blob_count += 1;
+                        total_bytes += blob_entry.metadata()?.len();
+                    }
+                }
+            }
+        }
+
+        Ok(CasStats {
+            blob_count,
+            total_bytes_on_disk: total_bytes,
+        })
+    }
+
+    /// Get the CAS directory path.
+    pub fn cas_dir(&self) -> &Path {
+        &self.cas_dir
+    }
+}
+
+/// Encode data as a CAS blob (prefix byte + optional zstd compression).
+fn encode_blob(data: &[u8]) -> Vec<u8> {
+    if data.len() >= MIN_COMPRESS_SIZE {
+        if let Ok(compressed) = zstd::encode_all(Cursor::new(data), ZSTD_LEVEL) {
+            // Only use compression if it actually saves space
+            if compressed.len() < data.len() {
+                let mut blob = Vec::with_capacity(1 + compressed.len());
+                blob.push(PREFIX_ZSTD);
+                blob.extend_from_slice(&compressed);
+                return blob;
+            }
+        }
+    }
+
+    // Raw storage: small data or compression didn't help
+    let mut blob = Vec::with_capacity(1 + data.len());
+    blob.push(PREFIX_RAW);
+    blob.extend_from_slice(data);
+    blob
+}
+
+/// Decode a CAS blob back to original data.
+fn decode_blob(encoded: &[u8]) -> anyhow::Result<Vec<u8>> {
+    if encoded.is_empty() {
+        return Err(anyhow::anyhow!("Empty blob"));
+    }
+
+    match encoded[0] {
+        PREFIX_RAW => Ok(encoded[1..].to_vec()),
+        PREFIX_ZSTD => {
+            let decompressed = zstd::decode_all(Cursor::new(&encoded[1..]))?;
+            Ok(decompressed)
+        }
+        other => Err(anyhow::anyhow!("Unknown blob prefix: 0x{other:02x}")),
+    }
+}
+
+/// Encode 32 bytes as lowercase hex string.
+pub fn hex_encode(bytes: &[u8; 32]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(64);
+    for byte in bytes {
+        write!(s, "{byte:02x}").unwrap();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_cas() -> (CasStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CasStore::open(dir.path()).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn hash_deterministic() {
+        let h1 = CasStore::hash(b"hello world");
+        let h2 = CasStore::hash(b"hello world");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_different_input() {
+        let h1 = CasStore::hash(b"hello");
+        let h2 = CasStore::hash(b"world");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn store_and_read_small() {
+        let (cas, _dir) = temp_cas();
+        let data = b"small data";
+        let (hash, deduped) = cas.store(data).unwrap();
+        assert!(!deduped);
+
+        let read_back = cas.read(&hash).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn store_and_read_large() {
+        let (cas, _dir) = temp_cas();
+        // Data larger than MIN_COMPRESS_SIZE to trigger zstd
+        let data: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+        let (hash, deduped) = cas.store(&data).unwrap();
+        assert!(!deduped);
+
+        let read_back = cas.read(&hash).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn dedup_identical_data() {
+        let (cas, _dir) = temp_cas();
+        let data = b"duplicate data for dedup test";
+
+        let (hash1, deduped1) = cas.store(data).unwrap();
+        assert!(!deduped1);
+
+        let (hash2, deduped2) = cas.store(data).unwrap();
+        assert!(deduped2);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn contains_check() {
+        let (cas, _dir) = temp_cas();
+        let data = b"test data";
+        let hash = CasStore::hash(data);
+
+        assert!(!cas.contains(&hash));
+        cas.store(data).unwrap();
+        assert!(cas.contains(&hash));
+    }
+
+    #[test]
+    fn remove_blob() {
+        let (cas, _dir) = temp_cas();
+        let data = b"removable";
+        let (hash, _) = cas.store(data).unwrap();
+
+        assert!(cas.contains(&hash));
+        assert!(cas.remove(&hash).unwrap());
+        assert!(!cas.contains(&hash));
+        assert!(!cas.remove(&hash).unwrap());
+    }
+
+    #[test]
+    fn gc_removes_specified_blobs() {
+        let (cas, _dir) = temp_cas();
+        let (hash1, _) = cas.store(b"blob one").unwrap();
+        let (hash2, _) = cas.store(b"blob two").unwrap();
+
+        let gc_stats = cas.gc(&[hash1]).unwrap();
+        assert_eq!(gc_stats.removed, 1);
+        assert!(gc_stats.freed_bytes > 0);
+        assert!(!cas.contains(&hash1));
+        assert!(cas.contains(&hash2));
+    }
+
+    #[test]
+    fn stats_counts_blobs() {
+        let (cas, _dir) = temp_cas();
+
+        let stats = cas.stats().unwrap();
+        assert_eq!(stats.blob_count, 0);
+
+        cas.store(b"blob1").unwrap();
+        cas.store(b"blob2").unwrap();
+        cas.store(b"blob1").unwrap(); // dedup, no new blob
+
+        let stats = cas.stats().unwrap();
+        assert_eq!(stats.blob_count, 2);
+        assert!(stats.total_bytes_on_disk > 0);
+    }
+
+    #[test]
+    fn zstd_roundtrip_compressible() {
+        let (cas, _dir) = temp_cas();
+        // Highly compressible repetitive data
+        let data = vec![0xAA; 4096];
+        let (hash, _) = cas.store(&data).unwrap();
+
+        let read_back = cas.read(&hash).unwrap();
+        assert_eq!(read_back, data);
+
+        // Verify compression actually reduced size on disk
+        let blob_path = cas.blob_path(&hash);
+        let on_disk = fs::metadata(&blob_path).unwrap().len();
+        assert!(
+            on_disk < data.len() as u64,
+            "zstd should compress repetitive data: {on_disk} >= {}",
+            data.len()
+        );
+    }
+
+    #[test]
+    fn zstd_roundtrip_incompressible() {
+        let (cas, _dir) = temp_cas();
+        // Random-ish data that doesn't compress well but is above threshold
+        let data: Vec<u8> = (0..512).map(|i| ((i * 7 + 13) % 256) as u8).collect();
+        let (hash, _) = cas.store(&data).unwrap();
+
+        let read_back = cas.read(&hash).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn hex_encode_works() {
+        let bytes = [0u8; 32];
+        assert_eq!(
+            hex_encode(&bytes),
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0xAB;
+        bytes[1] = 0xCD;
+        let hex = hex_encode(&bytes);
+        assert!(hex.starts_with("abcd"));
+        assert_eq!(hex.len(), 64);
+    }
+
+    #[test]
+    fn blob_path_uses_prefix_subdirs() {
+        let (cas, _dir) = temp_cas();
+        let hash = CasStore::hash(b"test");
+        let path = cas.blob_path(&hash);
+
+        // Should be cas_dir / XX / YYYY...YY (2-char prefix subdir)
+        let hex = hex_encode(&hash);
+        let parent_name = path.parent().unwrap().file_name().unwrap().to_str().unwrap();
+        assert_eq!(parent_name, &hex[..2]);
+
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(file_name.len(), 62); // 64 hex - 2 prefix
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_raw() {
+        let data = b"small";
+        let encoded = encode_blob(data);
+        assert_eq!(encoded[0], PREFIX_RAW);
+        let decoded = decode_blob(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_compressed() {
+        let data = vec![0x42; 1024]; // compressible
+        let encoded = encode_blob(&data);
+        assert_eq!(encoded[0], PREFIX_ZSTD);
+        let decoded = decode_blob(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn decode_empty_blob_errors() {
+        assert!(decode_blob(&[]).is_err());
+    }
+
+    #[test]
+    fn decode_unknown_prefix_errors() {
+        assert!(decode_blob(&[0xFF, 0x01, 0x02]).is_err());
+    }
+}

--- a/crates/sentinel-fs/src/cli.rs
+++ b/crates/sentinel-fs/src/cli.rs
@@ -1,0 +1,236 @@
+//! CLI interface for sentinel-fs operations.
+//!
+//! Commands: stats, gc, populate. FUSE mount/unmount requires the `fuse-tests` feature.
+
+use crate::cas::CasStore;
+use crate::layer::LayerManager;
+use crate::metadata::MetadataStore;
+use std::path::Path;
+
+/// Print CAS store statistics.
+pub fn cmd_stats(data_dir: &Path) -> anyhow::Result<()> {
+    let cas = CasStore::open(data_dir)?;
+    let stats = cas.stats()?;
+    println!("CAS Store: {}", data_dir.display());
+    println!("  Blobs:       {}", stats.blob_count);
+    println!(
+        "  Disk usage:  {} bytes ({:.2} MB)",
+        stats.total_bytes_on_disk,
+        stats.total_bytes_on_disk as f64 / 1_048_576.0
+    );
+    Ok(())
+}
+
+/// Run garbage collection on unreferenced blobs.
+pub fn cmd_gc(data_dir: &Path) -> anyhow::Result<()> {
+    let cas = CasStore::open(data_dir)?;
+    let meta_path = data_dir.join("metadata.redb");
+    let meta = MetadataStore::open(&meta_path)?;
+
+    // Find all blobs on disk
+    let mut all_hashes: Vec<[u8; 32]> = Vec::new();
+    let cas_dir = cas.cas_dir();
+    if cas_dir.exists() {
+        for prefix_entry in std::fs::read_dir(cas_dir)? {
+            let prefix_entry = prefix_entry?;
+            if prefix_entry.file_type()?.is_dir() {
+                for blob_entry in std::fs::read_dir(prefix_entry.path())? {
+                    let blob_entry = blob_entry?;
+                    if blob_entry.file_type()?.is_file() {
+                        let prefix_name = prefix_entry.file_name();
+                        let blob_name = blob_entry.file_name();
+                        let hex = format!(
+                            "{}{}",
+                            prefix_name.to_string_lossy(),
+                            blob_name.to_string_lossy()
+                        );
+                        if hex.len() == 64 {
+                            if let Ok(hash) = hex_to_hash(&hex) {
+                                all_hashes.push(hash);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Filter to zero-refcount hashes
+    let zero_refs: Vec<[u8; 32]> = all_hashes
+        .into_iter()
+        .filter(|h| meta.get_refcount(h).unwrap_or(0) == 0)
+        .collect();
+
+    if zero_refs.is_empty() {
+        println!("No unreferenced blobs found.");
+        return Ok(());
+    }
+
+    let gc_stats = cas.gc(&zero_refs)?;
+    println!(
+        "GC complete: removed {} blobs, freed {} bytes ({:.2} MB)",
+        gc_stats.removed,
+        gc_stats.freed_bytes,
+        gc_stats.freed_bytes as f64 / 1_048_576.0
+    );
+    Ok(())
+}
+
+/// Populate the base layer from a source directory.
+pub fn cmd_populate(data_dir: &Path, source_dir: &Path) -> anyhow::Result<()> {
+    let cas = CasStore::open(data_dir)?;
+    let meta_path = data_dir.join("metadata.redb");
+    let meta = MetadataStore::open(&meta_path)?;
+    let layer = LayerManager::new(cas, meta);
+    layer.init_base_root()?;
+
+    let mut file_count = 0u64;
+    let mut dir_count = 0u64;
+    let mut total_bytes = 0u64;
+
+    populate_recursive(&layer, source_dir, 1, &mut file_count, &mut dir_count, &mut total_bytes)?;
+
+    println!("Populated base layer from: {}", source_dir.display());
+    println!("  Directories: {dir_count}");
+    println!("  Files:       {file_count}");
+    println!(
+        "  Total bytes: {total_bytes} ({:.2} MB)",
+        total_bytes as f64 / 1_048_576.0
+    );
+
+    // Show dedup stats
+    let stats = layer.cas().stats()?;
+    println!(
+        "  CAS blobs:   {} ({:.2} MB on disk)",
+        stats.blob_count,
+        stats.total_bytes_on_disk as f64 / 1_048_576.0
+    );
+    if total_bytes > 0 {
+        let ratio = 1.0 - (stats.total_bytes_on_disk as f64 / total_bytes as f64);
+        println!("  Dedup ratio: {:.1}%", ratio * 100.0);
+    }
+
+    Ok(())
+}
+
+fn populate_recursive(
+    layer: &LayerManager,
+    dir: &Path,
+    parent_inode: u64,
+    file_count: &mut u64,
+    dir_count: &mut u64,
+    total_bytes: &mut u64,
+) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if ft.is_file() {
+            let content = std::fs::read(entry.path())?;
+            *total_bytes += content.len() as u64;
+            layer.populate_base_file(parent_inode, &name_str, &content, 0o644)?;
+            *file_count += 1;
+        } else if ft.is_dir() {
+            let sub_inode = layer.populate_base_dir(parent_inode, &name_str, 0o755)?;
+            *dir_count += 1;
+            populate_recursive(layer, &entry.path(), sub_inode, file_count, dir_count, total_bytes)?;
+        }
+        // Skip symlinks and other special files for now
+    }
+    Ok(())
+}
+
+/// Parse a 64-char hex string into a 32-byte hash.
+fn hex_to_hash(hex: &str) -> anyhow::Result<[u8; 32]> {
+    if hex.len() != 64 {
+        return Err(anyhow::anyhow!("Expected 64 hex chars, got {}", hex.len()));
+    }
+    let mut hash = [0u8; 32];
+    for i in 0..32 {
+        hash[i] = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)
+            .map_err(|e| anyhow::anyhow!("Invalid hex at pos {}: {e}", i * 2))?;
+    }
+    Ok(hash)
+}
+
+/// Start the FUSE daemon (requires `fuse-tests` feature).
+#[cfg(feature = "fuse-tests")]
+pub fn cmd_start(data_dir: &Path, mountpoint: &Path) -> anyhow::Result<()> {
+    println!("Starting sentinel-fs FUSE daemon...");
+    println!("  Data dir:   {}", data_dir.display());
+    println!("  Mountpoint: {}", mountpoint.display());
+    crate::fuse::start_fuse(data_dir, mountpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_to_hash_roundtrip() {
+        let original = [0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89,
+                       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                       0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+                       0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let hex = crate::cas::hex_encode(&original);
+        let parsed = hex_to_hash(&hex).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn hex_to_hash_invalid_length() {
+        assert!(hex_to_hash("abcd").is_err());
+    }
+
+    #[test]
+    fn populate_and_stats() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Create a source directory
+        let source = dir.path().join("source");
+        std::fs::create_dir_all(source.join("sub")).unwrap();
+        std::fs::write(source.join("a.txt"), b"hello").unwrap();
+        std::fs::write(source.join("b.txt"), b"hello").unwrap(); // dedup candidate
+        std::fs::write(source.join("sub").join("c.txt"), b"world").unwrap();
+
+        cmd_populate(&data_dir, &source).unwrap();
+
+        let cas = CasStore::open(&data_dir).unwrap();
+        let stats = cas.stats().unwrap();
+        // a.txt and b.txt have same content -> deduped to 1 blob
+        // c.txt is different -> 1 blob
+        assert_eq!(stats.blob_count, 2, "should have 2 unique blobs (dedup)");
+    }
+
+    #[test]
+    fn gc_removes_unreferenced() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let cas = CasStore::open(&data_dir).unwrap();
+        let meta = MetadataStore::open(data_dir.join("metadata.redb")).unwrap();
+
+        // Store a blob without any refcount entry
+        let (hash, _) = cas.store(b"orphan blob").unwrap();
+        assert!(cas.contains(&hash));
+        assert_eq!(meta.get_refcount(&hash).unwrap(), 0);
+
+        // Store a blob with refcount
+        let (hash2, _) = cas.store(b"referenced blob").unwrap();
+        meta.inc_refcount(&hash2).unwrap();
+
+        drop(cas);
+        drop(meta);
+
+        cmd_gc(&data_dir).unwrap();
+
+        let cas2 = CasStore::open(&data_dir).unwrap();
+        assert!(!cas2.contains(&hash), "orphan should be removed");
+        assert!(cas2.contains(&hash2), "referenced should remain");
+    }
+}

--- a/crates/sentinel-fs/src/cli.rs
+++ b/crates/sentinel-fs/src/cli.rs
@@ -88,7 +88,14 @@ pub fn cmd_populate(data_dir: &Path, source_dir: &Path) -> anyhow::Result<()> {
     let mut dir_count = 0u64;
     let mut total_bytes = 0u64;
 
-    populate_recursive(&layer, source_dir, 1, &mut file_count, &mut dir_count, &mut total_bytes)?;
+    populate_recursive(
+        &layer,
+        source_dir,
+        1,
+        &mut file_count,
+        &mut dir_count,
+        &mut total_bytes,
+    )?;
 
     println!("Populated base layer from: {}", source_dir.display());
     println!("  Directories: {dir_count}");
@@ -135,7 +142,14 @@ fn populate_recursive(
         } else if ft.is_dir() {
             let sub_inode = layer.populate_base_dir(parent_inode, &name_str, 0o755)?;
             *dir_count += 1;
-            populate_recursive(layer, &entry.path(), sub_inode, file_count, dir_count, total_bytes)?;
+            populate_recursive(
+                layer,
+                &entry.path(),
+                sub_inode,
+                file_count,
+                dir_count,
+                total_bytes,
+            )?;
         }
         // Skip symlinks and other special files for now
     }
@@ -170,10 +184,11 @@ mod tests {
 
     #[test]
     fn hex_to_hash_roundtrip() {
-        let original = [0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89,
-                       0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-                       0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
-                       0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let original = [
+            0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+            0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+        ];
         let hex = crate::cas::hex_encode(&original);
         let parsed = hex_to_hash(&hex).unwrap();
         assert_eq!(parsed, original);

--- a/crates/sentinel-fs/src/fuse.rs
+++ b/crates/sentinel-fs/src/fuse.rs
@@ -1,0 +1,375 @@
+//! FUSE filesystem handler — single mount for all agents.
+//!
+//! Mount point: `/cas-root/` with top-level directories per agent (`/cas-root/AGENT-01/`).
+//! Path-based Agent-ID extraction: first path component maps to an agent.
+//! Gated behind the `fuse-tests` feature (requires libfuse + kernel FUSE support).
+
+#[cfg(feature = "fuse-tests")]
+mod inner {
+    use crate::cas::CasStore;
+    use crate::layer::LayerManager;
+    use crate::metadata::{FileKind, InodeData, MetadataStore};
+    use fuser::{
+        FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory,
+        ReplyEntry, Request,
+    };
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+    use std::path::Path;
+    use std::sync::Mutex;
+    use std::time::{Duration, UNIX_EPOCH};
+    use tracing::warn;
+
+    const TTL: Duration = Duration::from_secs(1);
+
+    /// Virtual inode space: we map (agent_id, real_inode) to a global FUSE inode.
+    /// FUSE inode 1 = root of the mount (contains agent dirs).
+    /// Agent-specific inodes start at offset = agent_index * INODE_SPACE_PER_AGENT + 2.
+    const INODE_SPACE_PER_AGENT: u64 = 1_000_000;
+
+    /// FUSE handler for the CAS-backed agent filesystem.
+    pub struct SentinelFuse {
+        layer: LayerManager,
+        /// Map of known agent IDs to their inode offset base.
+        agents: Mutex<AgentRegistry>,
+    }
+
+    struct AgentRegistry {
+        /// Agent ID -> offset base for inode mapping.
+        map: HashMap<String, u64>,
+        next_offset: u64,
+    }
+
+    impl AgentRegistry {
+        fn new() -> Self {
+            Self {
+                map: HashMap::new(),
+                next_offset: 2, // 1 = root
+            }
+        }
+
+        fn get_or_insert(&mut self, agent_id: &str) -> u64 {
+            if let Some(&base) = self.map.get(agent_id) {
+                return base;
+            }
+            let base = self.next_offset;
+            self.map.insert(agent_id.to_string(), base);
+            self.next_offset += INODE_SPACE_PER_AGENT;
+            base
+        }
+
+        fn find_agent(&self, fuse_inode: u64) -> Option<(&str, u64)> {
+            for (agent_id, &base) in &self.map {
+                if fuse_inode >= base && fuse_inode < base + INODE_SPACE_PER_AGENT {
+                    let real_inode = fuse_inode - base + 1; // +1 because base maps to inode 1
+                    return Some((agent_id, real_inode));
+                }
+            }
+            None
+        }
+    }
+
+    impl SentinelFuse {
+        /// Create a new FUSE handler.
+        pub fn new(layer: LayerManager) -> Self {
+            Self {
+                layer,
+                agents: Mutex::new(AgentRegistry::new()),
+            }
+        }
+
+        /// Mount the filesystem. Blocks until unmounted.
+        pub fn mount(self, mountpoint: &Path) -> anyhow::Result<()> {
+            let options = vec![
+                MountOption::RW,
+                MountOption::FSName("sentinel-fs".to_string()),
+                MountOption::AutoUnmount,
+                MountOption::AllowOther,
+            ];
+            fuser::mount2(self, mountpoint, &options)
+                .map_err(|e| anyhow::anyhow!("FUSE mount failed: {e}"))
+        }
+
+        fn inode_to_attr(data: &InodeData, ino: u64) -> FileAttr {
+            let kind = match data.kind {
+                FileKind::Regular => FileType::RegularFile,
+                FileKind::Directory => FileType::Directory,
+                FileKind::Symlink => FileType::Symlink,
+            };
+            FileAttr {
+                ino,
+                size: data.size,
+                blocks: data.size.div_ceil(512),
+                atime: UNIX_EPOCH + Duration::from_secs(data.atime),
+                mtime: UNIX_EPOCH + Duration::from_secs(data.mtime),
+                ctime: UNIX_EPOCH + Duration::from_secs(data.ctime),
+                crtime: UNIX_EPOCH,
+                kind,
+                perm: data.mode as u16,
+                nlink: data.nlinks,
+                uid: data.uid,
+                gid: data.gid,
+                rdev: 0,
+                blksize: 4096,
+                flags: 0,
+            }
+        }
+
+        fn root_attr() -> FileAttr {
+            FileAttr {
+                ino: 1,
+                size: 0,
+                blocks: 0,
+                atime: UNIX_EPOCH,
+                mtime: UNIX_EPOCH,
+                ctime: UNIX_EPOCH,
+                crtime: UNIX_EPOCH,
+                kind: FileType::Directory,
+                perm: 0o755,
+                nlink: 2,
+                uid: 0,
+                gid: 0,
+                rdev: 0,
+                blksize: 4096,
+                flags: 0,
+            }
+        }
+    }
+
+    impl Filesystem for SentinelFuse {
+        fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+            if ino == 1 {
+                reply.attr(&TTL, &Self::root_attr());
+                return;
+            }
+
+            let agents = self.agents.lock().unwrap();
+            if let Some((agent_id, real_inode)) = agents.find_agent(ino) {
+                let agent_id = agent_id.to_string();
+                drop(agents);
+                match self.layer.lookup_inode(&agent_id, real_inode) {
+                    Ok(Some(data)) => reply.attr(&TTL, &Self::inode_to_attr(&data, ino)),
+                    Ok(None) => reply.error(libc::ENOENT),
+                    Err(e) => {
+                        warn!("getattr error: {e}");
+                        reply.error(libc::EIO);
+                    }
+                }
+            } else {
+                // Could be an agent root dir inode
+                reply.error(libc::ENOENT);
+            }
+        }
+
+        fn readdir(
+            &mut self,
+            _req: &Request,
+            ino: u64,
+            _fh: u64,
+            offset: i64,
+            mut reply: ReplyDirectory,
+        ) {
+            if ino == 1 {
+                // Root: list agent directories
+                let agents = self.agents.lock().unwrap();
+                let mut entries: Vec<(String, u64)> = agents
+                    .map
+                    .iter()
+                    .map(|(name, &base)| (name.clone(), base))
+                    .collect();
+                entries.sort_by(|a, b| a.0.cmp(&b.0));
+                drop(agents);
+
+                if offset <= 0 && reply.add(1, 1, FileType::Directory, ".") {
+                    reply.ok();
+                    return;
+                }
+                if offset <= 1 && reply.add(1, 2, FileType::Directory, "..") {
+                    reply.ok();
+                    return;
+                }
+
+                for (i, (name, base_ino)) in entries.iter().enumerate() {
+                    let entry_offset = (i as i64) + 2;
+                    if entry_offset < offset {
+                        continue;
+                    }
+                    if reply.add(*base_ino, entry_offset + 1, FileType::Directory, name) {
+                        break;
+                    }
+                }
+                reply.ok();
+                return;
+            }
+
+            let agents = self.agents.lock().unwrap();
+            if let Some((agent_id, real_inode)) = agents.find_agent(ino) {
+                let agent_id = agent_id.to_string();
+                let base_offset = agents.map.get(&agent_id).copied().unwrap_or(2);
+                drop(agents);
+
+                match self.layer.readdir(&agent_id, real_inode) {
+                    Ok(entries) => {
+                        if offset <= 0 && reply.add(ino, 1, FileType::Directory, ".") {
+                            reply.ok();
+                            return;
+                        }
+                        if offset <= 1 && reply.add(ino, 2, FileType::Directory, "..") {
+                            reply.ok();
+                            return;
+                        }
+                        for (i, (name, child_inode, kind)) in entries.iter().enumerate() {
+                            let entry_offset = (i as i64) + 2;
+                            if entry_offset < offset {
+                                continue;
+                            }
+                            let fuse_ino = base_offset + child_inode - 1;
+                            let ft = match kind {
+                                FileKind::Regular => FileType::RegularFile,
+                                FileKind::Directory => FileType::Directory,
+                                FileKind::Symlink => FileType::Symlink,
+                            };
+                            if reply.add(fuse_ino, entry_offset + 1, ft, name) {
+                                break;
+                            }
+                        }
+                        reply.ok();
+                    }
+                    Err(e) => {
+                        warn!("readdir error: {e}");
+                        reply.error(libc::EIO);
+                    }
+                }
+            } else {
+                reply.error(libc::ENOENT);
+            }
+        }
+
+        fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+            let name_str = match name.to_str() {
+                Some(s) => s,
+                None => {
+                    reply.error(libc::EINVAL);
+                    return;
+                }
+            };
+
+            if parent == 1 {
+                // Looking up an agent directory
+                let mut agents = self.agents.lock().unwrap();
+                if name_str.starts_with("AGENT-") {
+                    let base = agents.get_or_insert(name_str);
+                    // Ensure agent root exists
+                    drop(agents);
+                    if let Err(e) = self.layer.ensure_agent_root(name_str) {
+                        warn!("ensure_agent_root error: {e}");
+                        reply.error(libc::EIO);
+                        return;
+                    }
+                    let attr = FileAttr {
+                        ino: base,
+                        size: 0,
+                        blocks: 0,
+                        atime: UNIX_EPOCH,
+                        mtime: UNIX_EPOCH,
+                        ctime: UNIX_EPOCH,
+                        crtime: UNIX_EPOCH,
+                        kind: FileType::Directory,
+                        perm: 0o755,
+                        nlink: 2,
+                        uid: 0,
+                        gid: 0,
+                        rdev: 0,
+                        blksize: 4096,
+                        flags: 0,
+                    };
+                    reply.entry(&TTL, &attr, 0);
+                } else {
+                    reply.error(libc::ENOENT);
+                }
+                return;
+            }
+
+            let agents = self.agents.lock().unwrap();
+            if let Some((agent_id, real_parent)) = agents.find_agent(parent) {
+                let agent_id = agent_id.to_string();
+                let base_offset = agents.map.get(&agent_id).copied().unwrap_or(2);
+                drop(agents);
+
+                match self.layer.lookup_dirent(&agent_id, real_parent, name_str) {
+                    Ok(Some(child_inode)) => {
+                        let fuse_ino = base_offset + child_inode - 1;
+                        match self.layer.lookup_inode(&agent_id, child_inode) {
+                            Ok(Some(data)) => {
+                                reply.entry(&TTL, &Self::inode_to_attr(&data, fuse_ino), 0);
+                            }
+                            Ok(None) => reply.error(libc::ENOENT),
+                            Err(e) => {
+                                warn!("lookup inode error: {e}");
+                                reply.error(libc::EIO);
+                            }
+                        }
+                    }
+                    Ok(None) => reply.error(libc::ENOENT),
+                    Err(e) => {
+                        warn!("lookup dirent error: {e}");
+                        reply.error(libc::EIO);
+                    }
+                }
+            } else {
+                reply.error(libc::ENOENT);
+            }
+        }
+
+        fn read(
+            &mut self,
+            _req: &Request,
+            ino: u64,
+            _fh: u64,
+            offset: i64,
+            size: u32,
+            _flags: i32,
+            _lock_owner: Option<u64>,
+            reply: ReplyData,
+        ) {
+            let agents = self.agents.lock().unwrap();
+            if let Some((agent_id, real_inode)) = agents.find_agent(ino) {
+                let agent_id = agent_id.to_string();
+                drop(agents);
+
+                match self.layer.read_file(&agent_id, real_inode) {
+                    Ok(data) => {
+                        let start = offset as usize;
+                        if start >= data.len() {
+                            reply.data(&[]);
+                        } else {
+                            let end = (start + size as usize).min(data.len());
+                            reply.data(&data[start..end]);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("read error: {e}");
+                        reply.error(libc::EIO);
+                    }
+                }
+            } else {
+                reply.error(libc::ENOENT);
+            }
+        }
+    }
+
+    /// Start the FUSE daemon on the given mountpoint with the given data directory.
+    pub fn start_fuse(data_dir: &Path, mountpoint: &Path) -> anyhow::Result<()> {
+        let cas = CasStore::open(data_dir)?;
+        let meta_path = data_dir.join("metadata.redb");
+        let meta = MetadataStore::open(&meta_path)?;
+        let layer = LayerManager::new(cas, meta);
+        layer.init_base_root()?;
+
+        let fuse = SentinelFuse::new(layer);
+        fuse.mount(mountpoint)
+    }
+}
+
+#[cfg(feature = "fuse-tests")]
+pub use inner::*;

--- a/crates/sentinel-fs/src/layer.rs
+++ b/crates/sentinel-fs/src/layer.rs
@@ -1,0 +1,428 @@
+//! Layer manager: Base (readonly, shared) + Agent (rw, copy-on-write).
+//!
+//! Each agent sees the union of the shared base layer and its own agent layer.
+//! Writes always go to the agent layer. Reads fall back to the base layer.
+//! Deletes place a whiteout marker in the agent layer that hides the base entry.
+//! Agent layers are created lazily on first write.
+
+use crate::cas::CasStore;
+use crate::metadata::{FileKind, InodeData, MetadataStore};
+use tracing::instrument;
+
+/// Special agent ID for the shared base layer.
+const BASE_LAYER: &str = "__BASE__";
+
+/// Whiteout marker: inode data with a zeroed hash and size=u64::MAX.
+fn is_whiteout(data: &InodeData) -> bool {
+    data.size == u64::MAX && data.hash == [0u8; 32] && data.kind == FileKind::Regular
+}
+
+fn whiteout_marker() -> InodeData {
+    InodeData {
+        kind: FileKind::Regular,
+        hash: [0u8; 32],
+        size: u64::MAX,
+        mode: 0,
+        uid: 0,
+        gid: 0,
+        nlinks: 0,
+        mtime: 0,
+        ctime: 0,
+        atime: 0,
+        symlink_target: String::new(),
+    }
+}
+
+/// Layer manager that combines a shared base layer with per-agent CoW layers.
+pub struct LayerManager {
+    cas: CasStore,
+    meta: MetadataStore,
+}
+
+impl LayerManager {
+    /// Create a new layer manager.
+    pub fn new(cas: CasStore, meta: MetadataStore) -> Self {
+        Self { cas, meta }
+    }
+
+    /// Access the CAS store.
+    pub fn cas(&self) -> &CasStore {
+        &self.cas
+    }
+
+    /// Access the metadata store.
+    pub fn meta(&self) -> &MetadataStore {
+        &self.meta
+    }
+
+    // === BASE LAYER OPERATIONS (populating shared content) ===
+
+    /// Populate base layer: store a file's content in CAS and create inode + dirent.
+    #[instrument(skip(self, content), level = "debug", fields(name, parent_inode, content_len = content.len()))]
+    pub fn populate_base_file(
+        &self,
+        parent_inode: u64,
+        name: &str,
+        content: &[u8],
+        mode: u32,
+    ) -> anyhow::Result<u64> {
+        let (hash, _deduped) = self.cas.store(content)?;
+        let inode = self.meta.next_inode(BASE_LAYER)?;
+        let data = InodeData::regular(hash, content.len() as u64, mode);
+        self.meta
+            .create_file(BASE_LAYER, parent_inode, name, inode, &data)?;
+        Ok(inode)
+    }
+
+    /// Populate base layer: create a directory.
+    pub fn populate_base_dir(
+        &self,
+        parent_inode: u64,
+        name: &str,
+        mode: u32,
+    ) -> anyhow::Result<u64> {
+        let inode = self.meta.next_inode(BASE_LAYER)?;
+        let data = InodeData::directory(mode);
+        self.meta
+            .create_file(BASE_LAYER, parent_inode, name, inode, &data)?;
+        Ok(inode)
+    }
+
+    /// Initialize the base layer root directory (inode 1).
+    pub fn init_base_root(&self) -> anyhow::Result<()> {
+        if self.meta.get_inode(BASE_LAYER, 1)?.is_none() {
+            let root = InodeData::directory(0o755);
+            self.meta.set_inode(BASE_LAYER, 1, &root)?;
+        }
+        Ok(())
+    }
+
+    // === AGENT LAYER OPERATIONS ===
+
+    /// Ensure agent root directory exists (lazy creation).
+    pub fn ensure_agent_root(&self, agent_id: &str) -> anyhow::Result<()> {
+        if self.meta.get_inode(agent_id, 1)?.is_none() {
+            let root = InodeData::directory(0o755);
+            self.meta.set_inode(agent_id, 1, &root)?;
+        }
+        Ok(())
+    }
+
+    /// Lookup an inode: agent layer first, then base layer fallback.
+    /// Returns None if whiteout or not found in either layer.
+    pub fn lookup_inode(&self, agent_id: &str, inode: u64) -> anyhow::Result<Option<InodeData>> {
+        // Agent layer first
+        if let Some(data) = self.meta.get_inode(agent_id, inode)? {
+            if is_whiteout(&data) {
+                return Ok(None);
+            }
+            return Ok(Some(data));
+        }
+        // Base layer fallback
+        self.meta.get_inode(BASE_LAYER, inode)
+    }
+
+    /// Lookup a directory entry: agent layer first, then base layer.
+    pub fn lookup_dirent(
+        &self,
+        agent_id: &str,
+        parent: u64,
+        name: &str,
+    ) -> anyhow::Result<Option<u64>> {
+        // Check agent layer
+        if let Some(child) = self.meta.get_dirent(agent_id, parent, name)? {
+            // Check for whiteout on the child inode
+            if let Some(data) = self.meta.get_inode(agent_id, child)? {
+                if is_whiteout(&data) {
+                    return Ok(None);
+                }
+            }
+            return Ok(Some(child));
+        }
+        // Base layer fallback
+        self.meta.get_dirent(BASE_LAYER, parent, name)
+    }
+
+    /// Read file content by looking up the inode and reading from CAS.
+    pub fn read_file(&self, agent_id: &str, inode: u64) -> anyhow::Result<Vec<u8>> {
+        let data = self
+            .lookup_inode(agent_id, inode)?
+            .ok_or_else(|| anyhow::anyhow!("Inode {inode} not found for {agent_id}"))?;
+
+        if data.kind != FileKind::Regular {
+            return Err(anyhow::anyhow!("Inode {inode} is not a regular file"));
+        }
+
+        self.cas.read(&data.hash)
+    }
+
+    /// Write a file in the agent layer (CoW: always writes to agent layer).
+    #[instrument(skip(self, content), level = "debug", fields(agent_id, parent_inode, name, content_len = content.len()))]
+    pub fn write_file(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        content: &[u8],
+        mode: u32,
+    ) -> anyhow::Result<u64> {
+        self.ensure_agent_root(agent_id)?;
+
+        let (hash, _deduped) = self.cas.store(content)?;
+        let inode = self.meta.next_inode(agent_id)?;
+        let data = InodeData::regular(hash, content.len() as u64, mode);
+        self.meta
+            .create_file(agent_id, parent_inode, name, inode, &data)?;
+        Ok(inode)
+    }
+
+    /// Create a directory in the agent layer.
+    pub fn mkdir(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        mode: u32,
+    ) -> anyhow::Result<u64> {
+        self.ensure_agent_root(agent_id)?;
+
+        let inode = self.meta.next_inode(agent_id)?;
+        let data = InodeData::directory(mode);
+        self.meta
+            .create_file(agent_id, parent_inode, name, inode, &data)?;
+        Ok(inode)
+    }
+
+    /// Delete a file/directory in the agent layer.
+    /// If the entry exists in the base layer, places a whiteout marker.
+    pub fn unlink(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        inode: u64,
+    ) -> anyhow::Result<()> {
+        self.ensure_agent_root(agent_id)?;
+
+        // Remove from agent layer if present
+        self.meta.remove_file(agent_id, parent_inode, name, inode)?;
+
+        // If entry exists in base layer, place whiteout
+        if self.meta.get_dirent(BASE_LAYER, parent_inode, name)?.is_some() {
+            let wo = whiteout_marker();
+            self.meta
+                .set_inode(agent_id, inode, &wo)?;
+            self.meta
+                .set_dirent(agent_id, parent_inode, name, inode)?;
+        }
+
+        Ok(())
+    }
+
+    /// List directory entries: union of agent + base, minus whiteouts.
+    pub fn readdir(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+    ) -> anyhow::Result<Vec<(String, u64, FileKind)>> {
+        let mut result: Vec<(String, u64, FileKind)> = Vec::new();
+        let mut whiteout_names: Vec<String> = Vec::new();
+        let mut seen_names: Vec<String> = Vec::new();
+
+        // Agent layer entries first
+        let agent_entries = self.meta.list_dirents(agent_id, parent_inode)?;
+        for (name, child_inode) in agent_entries {
+            if let Some(data) = self.meta.get_inode(agent_id, child_inode)? {
+                if is_whiteout(&data) {
+                    whiteout_names.push(name);
+                    continue;
+                }
+                seen_names.push(name.clone());
+                result.push((name, child_inode, data.kind));
+            }
+        }
+
+        // Base layer entries (only if not already in agent layer or whiteout)
+        let base_entries = self.meta.list_dirents(BASE_LAYER, parent_inode)?;
+        for (name, child_inode) in base_entries {
+            if seen_names.contains(&name) || whiteout_names.contains(&name) {
+                continue;
+            }
+            if let Some(data) = self.meta.get_inode(BASE_LAYER, child_inode)? {
+                result.push((name, child_inode, data.kind));
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_layer() -> (LayerManager, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = CasStore::open(dir.path()).unwrap();
+        let meta_path = dir.path().join("meta.redb");
+        let meta = MetadataStore::open(&meta_path).unwrap();
+        let lm = LayerManager::new(cas, meta);
+        lm.init_base_root().unwrap();
+        (lm, dir)
+    }
+
+    #[test]
+    fn base_layer_populate_and_read() {
+        let (lm, _dir) = temp_layer();
+
+        let inode = lm
+            .populate_base_file(1, "readme.txt", b"Hello World", 0o644)
+            .unwrap();
+
+        // Read via base layer
+        let content = lm.read_file(BASE_LAYER, inode).unwrap();
+        assert_eq!(content, b"Hello World");
+
+        // Agent sees base content
+        let content = lm.read_file("AGENT-01", inode).unwrap();
+        assert_eq!(content, b"Hello World");
+    }
+
+    #[test]
+    fn agent_write_does_not_affect_base() {
+        let (lm, _dir) = temp_layer();
+
+        let base_inode = lm
+            .populate_base_file(1, "shared.txt", b"base content", 0o644)
+            .unwrap();
+
+        // Agent writes a new file
+        let agent_inode = lm
+            .write_file("AGENT-01", 1, "agent.txt", b"agent content", 0o644)
+            .unwrap();
+
+        // Agent sees its file
+        let content = lm.read_file("AGENT-01", agent_inode).unwrap();
+        assert_eq!(content, b"agent content");
+
+        // Base still has original content
+        let base_content = lm.read_file(BASE_LAYER, base_inode).unwrap();
+        assert_eq!(base_content, b"base content");
+
+        // Other agent doesn't see AGENT-01's file
+        assert!(lm.lookup_dirent("AGENT-02", 1, "agent.txt").unwrap().is_none());
+    }
+
+    #[test]
+    fn agent_isolation() {
+        let (lm, _dir) = temp_layer();
+
+        lm.write_file("AGENT-01", 1, "secret.txt", b"agent-01 data", 0o600)
+            .unwrap();
+        lm.write_file("AGENT-02", 1, "secret.txt", b"agent-02 data", 0o600)
+            .unwrap();
+
+        let a1 = lm.lookup_dirent("AGENT-01", 1, "secret.txt").unwrap().unwrap();
+        let a2 = lm.lookup_dirent("AGENT-02", 1, "secret.txt").unwrap().unwrap();
+
+        assert_eq!(lm.read_file("AGENT-01", a1).unwrap(), b"agent-01 data");
+        assert_eq!(lm.read_file("AGENT-02", a2).unwrap(), b"agent-02 data");
+    }
+
+    #[test]
+    fn whiteout_hides_base_entry() {
+        let (lm, _dir) = temp_layer();
+
+        let base_inode = lm
+            .populate_base_file(1, "deleteme.txt", b"to be deleted", 0o644)
+            .unwrap();
+
+        // Agent can see it before delete
+        assert!(lm.lookup_dirent("AGENT-01", 1, "deleteme.txt").unwrap().is_some());
+
+        // Agent deletes it
+        lm.unlink("AGENT-01", 1, "deleteme.txt", base_inode)
+            .unwrap();
+
+        // Agent no longer sees it
+        assert!(lm.lookup_dirent("AGENT-01", 1, "deleteme.txt").unwrap().is_none());
+
+        // Other agent still sees it
+        assert!(lm.lookup_dirent("AGENT-02", 1, "deleteme.txt").unwrap().is_some());
+
+        // Base layer untouched
+        assert!(lm.meta().get_dirent(BASE_LAYER, 1, "deleteme.txt").unwrap().is_some());
+    }
+
+    #[test]
+    fn readdir_merges_layers() {
+        let (lm, _dir) = temp_layer();
+
+        // Base has two files
+        lm.populate_base_file(1, "base1.txt", b"b1", 0o644).unwrap();
+        lm.populate_base_file(1, "base2.txt", b"b2", 0o644).unwrap();
+
+        // Agent adds one, deletes one base file
+        lm.write_file("AGENT-01", 1, "agent1.txt", b"a1", 0o644).unwrap();
+
+        let base2_inode = lm.meta().get_dirent(BASE_LAYER, 1, "base2.txt").unwrap().unwrap();
+        lm.unlink("AGENT-01", 1, "base2.txt", base2_inode).unwrap();
+
+        let entries = lm.readdir("AGENT-01", 1).unwrap();
+        let names: Vec<&str> = entries.iter().map(|(n, _, _)| n.as_str()).collect();
+
+        assert!(names.contains(&"base1.txt"), "should see base1");
+        assert!(names.contains(&"agent1.txt"), "should see agent file");
+        assert!(!names.contains(&"base2.txt"), "base2 should be whiteout");
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn lazy_agent_root_creation() {
+        let (lm, _dir) = temp_layer();
+
+        // Agent root doesn't exist yet
+        assert!(lm.meta().get_inode("AGENT-99", 1).unwrap().is_none());
+
+        // Writing creates it lazily
+        lm.write_file("AGENT-99", 1, "first.txt", b"data", 0o644)
+            .unwrap();
+
+        // Now agent root exists
+        assert!(lm.meta().get_inode("AGENT-99", 1).unwrap().is_some());
+    }
+
+    #[test]
+    fn dedup_across_agents() {
+        let (lm, _dir) = temp_layer();
+        let content = b"identical content for all agents";
+
+        lm.write_file("AGENT-01", 1, "same.txt", content, 0o644).unwrap();
+        lm.write_file("AGENT-02", 1, "same.txt", content, 0o644).unwrap();
+        lm.write_file("AGENT-03", 1, "same.txt", content, 0o644).unwrap();
+
+        // Only one blob in CAS
+        let stats = lm.cas().stats().unwrap();
+        assert_eq!(stats.blob_count, 1, "identical content should be deduped");
+
+        // Refcount should be 3
+        let hash = CasStore::hash(content);
+        assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 3);
+    }
+
+    #[test]
+    fn mkdir_in_agent_layer() {
+        let (lm, _dir) = temp_layer();
+
+        let dir_inode = lm.mkdir("AGENT-01", 1, "subdir", 0o755).unwrap();
+        let data = lm.lookup_inode("AGENT-01", dir_inode).unwrap().unwrap();
+        assert_eq!(data.kind, FileKind::Directory);
+
+        // Write file inside subdir
+        let file_inode = lm
+            .write_file("AGENT-01", dir_inode, "nested.txt", b"nested", 0o644)
+            .unwrap();
+        let content = lm.read_file("AGENT-01", file_inode).unwrap();
+        assert_eq!(content, b"nested");
+    }
+}

--- a/crates/sentinel-fs/src/layer.rs
+++ b/crates/sentinel-fs/src/layer.rs
@@ -208,12 +208,14 @@ impl LayerManager {
         self.meta.remove_file(agent_id, parent_inode, name, inode)?;
 
         // If entry exists in base layer, place whiteout
-        if self.meta.get_dirent(BASE_LAYER, parent_inode, name)?.is_some() {
+        if self
+            .meta
+            .get_dirent(BASE_LAYER, parent_inode, name)?
+            .is_some()
+        {
             let wo = whiteout_marker();
-            self.meta
-                .set_inode(agent_id, inode, &wo)?;
-            self.meta
-                .set_dirent(agent_id, parent_inode, name, inode)?;
+            self.meta.set_inode(agent_id, inode, &wo)?;
+            self.meta.set_dirent(agent_id, parent_inode, name, inode)?;
         }
 
         Ok(())
@@ -310,7 +312,10 @@ mod tests {
         assert_eq!(base_content, b"base content");
 
         // Other agent doesn't see AGENT-01's file
-        assert!(lm.lookup_dirent("AGENT-02", 1, "agent.txt").unwrap().is_none());
+        assert!(lm
+            .lookup_dirent("AGENT-02", 1, "agent.txt")
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -322,8 +327,14 @@ mod tests {
         lm.write_file("AGENT-02", 1, "secret.txt", b"agent-02 data", 0o600)
             .unwrap();
 
-        let a1 = lm.lookup_dirent("AGENT-01", 1, "secret.txt").unwrap().unwrap();
-        let a2 = lm.lookup_dirent("AGENT-02", 1, "secret.txt").unwrap().unwrap();
+        let a1 = lm
+            .lookup_dirent("AGENT-01", 1, "secret.txt")
+            .unwrap()
+            .unwrap();
+        let a2 = lm
+            .lookup_dirent("AGENT-02", 1, "secret.txt")
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lm.read_file("AGENT-01", a1).unwrap(), b"agent-01 data");
         assert_eq!(lm.read_file("AGENT-02", a2).unwrap(), b"agent-02 data");
@@ -338,20 +349,33 @@ mod tests {
             .unwrap();
 
         // Agent can see it before delete
-        assert!(lm.lookup_dirent("AGENT-01", 1, "deleteme.txt").unwrap().is_some());
+        assert!(lm
+            .lookup_dirent("AGENT-01", 1, "deleteme.txt")
+            .unwrap()
+            .is_some());
 
         // Agent deletes it
         lm.unlink("AGENT-01", 1, "deleteme.txt", base_inode)
             .unwrap();
 
         // Agent no longer sees it
-        assert!(lm.lookup_dirent("AGENT-01", 1, "deleteme.txt").unwrap().is_none());
+        assert!(lm
+            .lookup_dirent("AGENT-01", 1, "deleteme.txt")
+            .unwrap()
+            .is_none());
 
         // Other agent still sees it
-        assert!(lm.lookup_dirent("AGENT-02", 1, "deleteme.txt").unwrap().is_some());
+        assert!(lm
+            .lookup_dirent("AGENT-02", 1, "deleteme.txt")
+            .unwrap()
+            .is_some());
 
         // Base layer untouched
-        assert!(lm.meta().get_dirent(BASE_LAYER, 1, "deleteme.txt").unwrap().is_some());
+        assert!(lm
+            .meta()
+            .get_dirent(BASE_LAYER, 1, "deleteme.txt")
+            .unwrap()
+            .is_some());
     }
 
     #[test]
@@ -363,9 +387,14 @@ mod tests {
         lm.populate_base_file(1, "base2.txt", b"b2", 0o644).unwrap();
 
         // Agent adds one, deletes one base file
-        lm.write_file("AGENT-01", 1, "agent1.txt", b"a1", 0o644).unwrap();
+        lm.write_file("AGENT-01", 1, "agent1.txt", b"a1", 0o644)
+            .unwrap();
 
-        let base2_inode = lm.meta().get_dirent(BASE_LAYER, 1, "base2.txt").unwrap().unwrap();
+        let base2_inode = lm
+            .meta()
+            .get_dirent(BASE_LAYER, 1, "base2.txt")
+            .unwrap()
+            .unwrap();
         lm.unlink("AGENT-01", 1, "base2.txt", base2_inode).unwrap();
 
         let entries = lm.readdir("AGENT-01", 1).unwrap();
@@ -397,9 +426,12 @@ mod tests {
         let (lm, _dir) = temp_layer();
         let content = b"identical content for all agents";
 
-        lm.write_file("AGENT-01", 1, "same.txt", content, 0o644).unwrap();
-        lm.write_file("AGENT-02", 1, "same.txt", content, 0o644).unwrap();
-        lm.write_file("AGENT-03", 1, "same.txt", content, 0o644).unwrap();
+        lm.write_file("AGENT-01", 1, "same.txt", content, 0o644)
+            .unwrap();
+        lm.write_file("AGENT-02", 1, "same.txt", content, 0o644)
+            .unwrap();
+        lm.write_file("AGENT-03", 1, "same.txt", content, 0o644)
+            .unwrap();
 
         // Only one blob in CAS
         let stats = lm.cas().stats().unwrap();

--- a/crates/sentinel-fs/src/lib.rs
+++ b/crates/sentinel-fs/src/lib.rs
@@ -4,3 +4,4 @@
 //! Architecture: CAS Store (blobs) + redb Metadata + Layer Manager (base/agent CoW) + FUSE.
 
 pub mod cas;
+pub mod metadata;

--- a/crates/sentinel-fs/src/lib.rs
+++ b/crates/sentinel-fs/src/lib.rs
@@ -4,6 +4,7 @@
 //! Architecture: CAS Store (blobs) + redb Metadata + Layer Manager (base/agent CoW) + FUSE.
 
 pub mod cas;
+pub mod cli;
 pub mod fuse;
 pub mod layer;
 pub mod metadata;

--- a/crates/sentinel-fs/src/lib.rs
+++ b/crates/sentinel-fs/src/lib.rs
@@ -4,4 +4,5 @@
 //! Architecture: CAS Store (blobs) + redb Metadata + Layer Manager (base/agent CoW) + FUSE.
 
 pub mod cas;
+pub mod layer;
 pub mod metadata;

--- a/crates/sentinel-fs/src/lib.rs
+++ b/crates/sentinel-fs/src/lib.rs
@@ -4,5 +4,6 @@
 //! Architecture: CAS Store (blobs) + redb Metadata + Layer Manager (base/agent CoW) + FUSE.
 
 pub mod cas;
+pub mod fuse;
 pub mod layer;
 pub mod metadata;

--- a/crates/sentinel-fs/src/lib.rs
+++ b/crates/sentinel-fs/src/lib.rs
@@ -1,0 +1,6 @@
+//! sentinel-fs: CAS-FUSE agent filesystem with SHA-256 dedup and zstd compression.
+//!
+//! Provides isolated, deduplicated filesystems for agents via a single FUSE mount.
+//! Architecture: CAS Store (blobs) + redb Metadata + Layer Manager (base/agent CoW) + FUSE.
+
+pub mod cas;

--- a/crates/sentinel-fs/src/metadata.rs
+++ b/crates/sentinel-fs/src/metadata.rs
@@ -157,11 +157,7 @@ impl MetadataStore {
     }
 
     /// Remove an inode. Returns the old data if it existed.
-    pub fn remove_inode(
-        &self,
-        agent_id: &str,
-        inode: u64,
-    ) -> anyhow::Result<Option<InodeData>> {
+    pub fn remove_inode(&self, agent_id: &str, inode: u64) -> anyhow::Result<Option<InodeData>> {
         let write_txn = self.db.begin_write()?;
         let old = {
             let mut table = write_txn.open_table(FS_INODES)?;
@@ -231,11 +227,7 @@ impl MetadataStore {
     }
 
     /// List all entries in a directory for an agent.
-    pub fn list_dirents(
-        &self,
-        agent_id: &str,
-        parent: u64,
-    ) -> anyhow::Result<Vec<(String, u64)>> {
+    pub fn list_dirents(&self, agent_id: &str, parent: u64) -> anyhow::Result<Vec<(String, u64)>> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(FS_DIRENTS)?;
 
@@ -571,8 +563,12 @@ mod tests {
         let hash = [0xEE; 32];
 
         let data = InodeData::regular(hash, 100, 0o644);
-        store.create_file("AGENT-01", 1, "shared.txt", 2, &data).unwrap();
-        store.create_file("AGENT-02", 1, "shared.txt", 2, &data).unwrap();
+        store
+            .create_file("AGENT-01", 1, "shared.txt", 2, &data)
+            .unwrap();
+        store
+            .create_file("AGENT-02", 1, "shared.txt", 2, &data)
+            .unwrap();
 
         // Both agents reference the same hash
         assert_eq!(store.get_refcount(&hash).unwrap(), 2);

--- a/crates/sentinel-fs/src/metadata.rs
+++ b/crates/sentinel-fs/src/metadata.rs
@@ -1,0 +1,632 @@
+//! Filesystem metadata store backed by redb.
+//!
+//! Three tables with agent-scoped composite keys:
+//! - `FS_INODES`: `(agent_id, inode)` -> serialized `InodeData`
+//! - `FS_DIRENTS`: `(agent_id, parent_inode, name)` -> child inode
+//! - `CAS_REFCOUNT`: `sha256_hash` -> reference count (u32)
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::SystemTime;
+use tracing::instrument;
+
+// --- Table Definitions ---
+
+/// Inode metadata: `(agent_id, inode_number)` -> serialized InodeData.
+const FS_INODES: TableDefinition<(&str, u64), &[u8]> = TableDefinition::new("fs_inodes");
+
+/// Directory entries: `(agent_id, parent_inode, entry_name)` -> child inode.
+const FS_DIRENTS: TableDefinition<(&str, u64, &str), u64> = TableDefinition::new("fs_dirents");
+
+/// CAS blob reference counts: `sha256_hash` -> count.
+const CAS_REFCOUNT: TableDefinition<&[u8; 32], u32> = TableDefinition::new("cas_refcount");
+
+// --- Types ---
+
+/// File type in the virtual filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FileKind {
+    Regular,
+    Directory,
+    Symlink,
+}
+
+/// Inode metadata stored in redb.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InodeData {
+    pub kind: FileKind,
+    /// SHA-256 hash of content (only meaningful for Regular files).
+    pub hash: [u8; 32],
+    /// Original (uncompressed) size in bytes.
+    pub size: u64,
+    /// Unix permission bits.
+    pub mode: u32,
+    pub uid: u32,
+    pub gid: u32,
+    /// Number of hard links.
+    pub nlinks: u32,
+    /// Seconds since UNIX epoch.
+    pub mtime: u64,
+    pub ctime: u64,
+    pub atime: u64,
+    /// Symlink target (empty for non-symlinks).
+    pub symlink_target: String,
+}
+
+impl InodeData {
+    /// Create metadata for a new regular file.
+    pub fn regular(hash: [u8; 32], size: u64, mode: u32) -> Self {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            kind: FileKind::Regular,
+            hash,
+            size,
+            mode,
+            uid: 0,
+            gid: 0,
+            nlinks: 1,
+            mtime: now,
+            ctime: now,
+            atime: now,
+            symlink_target: String::new(),
+        }
+    }
+
+    /// Create metadata for a new directory.
+    pub fn directory(mode: u32) -> Self {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self {
+            kind: FileKind::Directory,
+            hash: [0u8; 32],
+            size: 0,
+            mode,
+            uid: 0,
+            gid: 0,
+            nlinks: 2,
+            mtime: now,
+            ctime: now,
+            atime: now,
+            symlink_target: String::new(),
+        }
+    }
+
+    fn serialize(&self) -> anyhow::Result<Vec<u8>> {
+        serde_json::to_vec(self).map_err(|e| anyhow::anyhow!("InodeData serialize: {e}"))
+    }
+
+    fn deserialize(data: &[u8]) -> anyhow::Result<Self> {
+        serde_json::from_slice(data).map_err(|e| anyhow::anyhow!("InodeData deserialize: {e}"))
+    }
+}
+
+// --- MetadataStore ---
+
+/// Filesystem metadata backed by a single redb database.
+pub struct MetadataStore {
+    db: Database,
+}
+
+impl MetadataStore {
+    /// Open or create the metadata store at the given path.
+    #[instrument(level = "debug", fields(path = %path.as_ref().display()))]
+    pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let db = Database::create(path.as_ref())
+            .map_err(|e| anyhow::anyhow!("MetadataStore open: {e}"))?;
+
+        // Initialize all tables
+        let write_txn = db.begin_write()?;
+        {
+            write_txn.open_table(FS_INODES)?;
+            write_txn.open_table(FS_DIRENTS)?;
+            write_txn.open_table(CAS_REFCOUNT)?;
+        }
+        write_txn.commit()?;
+
+        Ok(Self { db })
+    }
+
+    // === INODE OPERATIONS ===
+
+    /// Get inode metadata for an agent.
+    pub fn get_inode(&self, agent_id: &str, inode: u64) -> anyhow::Result<Option<InodeData>> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(FS_INODES)?;
+        match table.get((agent_id, inode))? {
+            Some(guard) => Ok(Some(InodeData::deserialize(guard.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Set inode metadata for an agent.
+    pub fn set_inode(&self, agent_id: &str, inode: u64, data: &InodeData) -> anyhow::Result<()> {
+        let serialized = data.serialize()?;
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(FS_INODES)?;
+            table.insert((agent_id, inode), serialized.as_slice())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Remove an inode. Returns the old data if it existed.
+    pub fn remove_inode(
+        &self,
+        agent_id: &str,
+        inode: u64,
+    ) -> anyhow::Result<Option<InodeData>> {
+        let write_txn = self.db.begin_write()?;
+        let old = {
+            let mut table = write_txn.open_table(FS_INODES)?;
+            let x = match table.remove((agent_id, inode))? {
+                Some(guard) => Some(InodeData::deserialize(guard.value())?),
+                None => None,
+            };
+            x
+        };
+        write_txn.commit()?;
+        Ok(old)
+    }
+
+    // === DIRECTORY ENTRY OPERATIONS ===
+
+    /// Look up a directory entry. Returns the child inode number.
+    pub fn get_dirent(
+        &self,
+        agent_id: &str,
+        parent: u64,
+        name: &str,
+    ) -> anyhow::Result<Option<u64>> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(FS_DIRENTS)?;
+        Ok(table
+            .get((agent_id, parent, name))?
+            .map(|guard| guard.value()))
+    }
+
+    /// Insert or update a directory entry.
+    pub fn set_dirent(
+        &self,
+        agent_id: &str,
+        parent: u64,
+        name: &str,
+        child_inode: u64,
+    ) -> anyhow::Result<()> {
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(FS_DIRENTS)?;
+            table.insert((agent_id, parent, name), child_inode)?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Remove a directory entry. Returns the child inode if it existed.
+    pub fn remove_dirent(
+        &self,
+        agent_id: &str,
+        parent: u64,
+        name: &str,
+    ) -> anyhow::Result<Option<u64>> {
+        let write_txn = self.db.begin_write()?;
+        let old = {
+            let mut table = write_txn.open_table(FS_DIRENTS)?;
+            // Deliberate match instead of .map() — redb AccessGuard lifetime workaround
+            #[allow(clippy::manual_map)]
+            let x = match table.remove((agent_id, parent, name))? {
+                Some(guard) => Some(guard.value()),
+                None => None,
+            };
+            x
+        };
+        write_txn.commit()?;
+        Ok(old)
+    }
+
+    /// List all entries in a directory for an agent.
+    pub fn list_dirents(
+        &self,
+        agent_id: &str,
+        parent: u64,
+    ) -> anyhow::Result<Vec<(String, u64)>> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(FS_DIRENTS)?;
+
+        let range_start = (agent_id, parent, "");
+        let range_end = (agent_id, parent + 1, "");
+
+        let mut entries = Vec::new();
+        let range = table.range(range_start..range_end)?;
+        for entry in range {
+            let (key, value) = entry?;
+            let (_, _, name) = key.value();
+            entries.push((name.to_string(), value.value()));
+        }
+        Ok(entries)
+    }
+
+    // === REFCOUNT OPERATIONS ===
+
+    /// Get the reference count for a CAS hash.
+    pub fn get_refcount(&self, hash: &[u8; 32]) -> anyhow::Result<u32> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(CAS_REFCOUNT)?;
+        Ok(table.get(hash)?.map(|g| g.value()).unwrap_or(0))
+    }
+
+    /// Increment reference count. Returns the new count.
+    pub fn inc_refcount(&self, hash: &[u8; 32]) -> anyhow::Result<u32> {
+        let write_txn = self.db.begin_write()?;
+        let new_count = {
+            let mut table = write_txn.open_table(CAS_REFCOUNT)?;
+            let current = table.get(hash)?.map(|g| g.value()).unwrap_or(0);
+            let new = current + 1;
+            table.insert(hash, new)?;
+            new
+        };
+        write_txn.commit()?;
+        Ok(new_count)
+    }
+
+    /// Decrement reference count. Returns the new count (clamped to 0).
+    pub fn dec_refcount(&self, hash: &[u8; 32]) -> anyhow::Result<u32> {
+        let write_txn = self.db.begin_write()?;
+        let new_count = {
+            let mut table = write_txn.open_table(CAS_REFCOUNT)?;
+            let current = table.get(hash)?.map(|g| g.value()).unwrap_or(0);
+            let new = current.saturating_sub(1);
+            if new == 0 {
+                table.remove(hash)?;
+            } else {
+                table.insert(hash, new)?;
+            }
+            new
+        };
+        write_txn.commit()?;
+        Ok(new_count)
+    }
+
+    /// Collect all hashes with zero references (GC candidates).
+    /// Since we remove zero-ref entries, this returns hashes that exist
+    /// in CAS but have no refcount entry.
+    pub fn zero_ref_hashes(&self) -> anyhow::Result<Vec<[u8; 32]>> {
+        // Refcount entries with value 0 are removed on dec, so this
+        // method is mainly useful when called with an external blob list.
+        // For now, return empty — the layer manager will track GC externally.
+        Ok(Vec::new())
+    }
+
+    // === BATCH / TRANSACTIONAL OPERATIONS ===
+
+    /// Atomically create a file: set inode + dirent + inc refcount in one transaction.
+    pub fn create_file(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        inode: u64,
+        data: &InodeData,
+    ) -> anyhow::Result<()> {
+        let serialized = data.serialize()?;
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut inodes = write_txn.open_table(FS_INODES)?;
+            inodes.insert((agent_id, inode), serialized.as_slice())?;
+
+            let mut dirents = write_txn.open_table(FS_DIRENTS)?;
+            dirents.insert((agent_id, parent_inode, name), inode)?;
+
+            if data.kind == FileKind::Regular {
+                let mut refs = write_txn.open_table(CAS_REFCOUNT)?;
+                let current = refs.get(&data.hash)?.map(|g| g.value()).unwrap_or(0);
+                refs.insert(&data.hash, current + 1)?;
+            }
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Atomically remove a file: remove inode + dirent + dec refcount in one transaction.
+    /// Returns the removed InodeData if it existed.
+    pub fn remove_file(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        inode: u64,
+    ) -> anyhow::Result<Option<InodeData>> {
+        let write_txn = self.db.begin_write()?;
+        let old_data = {
+            let mut inodes = write_txn.open_table(FS_INODES)?;
+            let old = match inodes.remove((agent_id, inode))? {
+                Some(guard) => Some(InodeData::deserialize(guard.value())?),
+                None => None,
+            };
+            drop(inodes);
+
+            let mut dirents = write_txn.open_table(FS_DIRENTS)?;
+            dirents.remove((agent_id, parent_inode, name))?;
+            drop(dirents);
+
+            if let Some(ref inode_data) = old {
+                if inode_data.kind == FileKind::Regular {
+                    let mut refs = write_txn.open_table(CAS_REFCOUNT)?;
+                    let current = match refs.get(&inode_data.hash)? {
+                        Some(g) => g.value(),
+                        None => 0,
+                    };
+                    let new = current.saturating_sub(1);
+                    if new == 0 {
+                        refs.remove(&inode_data.hash)?;
+                    } else {
+                        refs.insert(&inode_data.hash, new)?;
+                    }
+                }
+            }
+
+            old
+        };
+        write_txn.commit()?;
+        Ok(old_data)
+    }
+
+    /// Allocate the next inode number for an agent.
+    /// Uses a special inode 0 entry to track the counter.
+    pub fn next_inode(&self, agent_id: &str) -> anyhow::Result<u64> {
+        let write_txn = self.db.begin_write()?;
+        let next = {
+            let mut table = write_txn.open_table(FS_INODES)?;
+            // Use inode 0 as the counter (never a real inode in FUSE — root is 1)
+            let current = table
+                .get((agent_id, 0u64))?
+                .map(|g| {
+                    let bytes = g.value();
+                    if bytes.len() == 8 {
+                        u64::from_le_bytes(bytes.try_into().unwrap())
+                    } else {
+                        1
+                    }
+                })
+                .unwrap_or(1);
+            let next = current + 1;
+            table.insert((agent_id, 0u64), next.to_le_bytes().as_slice())?;
+            next
+        };
+        write_txn.commit()?;
+        Ok(next)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_meta() -> (MetadataStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-meta.redb");
+        let store = MetadataStore::open(&path).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn inode_crud() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+
+        // Not found
+        assert!(store.get_inode(agent, 1).unwrap().is_none());
+
+        // Create
+        let data = InodeData::regular([0xAA; 32], 1024, 0o644);
+        store.set_inode(agent, 1, &data).unwrap();
+
+        // Read back
+        let read = store.get_inode(agent, 1).unwrap().unwrap();
+        assert_eq!(read.size, 1024);
+        assert_eq!(read.mode, 0o644);
+        assert_eq!(read.hash, [0xAA; 32]);
+        assert_eq!(read.kind, FileKind::Regular);
+
+        // Update
+        let mut updated = data.clone();
+        updated.size = 2048;
+        store.set_inode(agent, 1, &updated).unwrap();
+        assert_eq!(store.get_inode(agent, 1).unwrap().unwrap().size, 2048);
+
+        // Remove
+        let old = store.remove_inode(agent, 1).unwrap().unwrap();
+        assert_eq!(old.size, 2048);
+        assert!(store.get_inode(agent, 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn agent_isolation() {
+        let (store, _dir) = temp_meta();
+
+        let data_a = InodeData::regular([0x01; 32], 100, 0o644);
+        let data_b = InodeData::regular([0x02; 32], 200, 0o755);
+
+        store.set_inode("AGENT-01", 1, &data_a).unwrap();
+        store.set_inode("AGENT-02", 1, &data_b).unwrap();
+
+        // Same inode number, different agents
+        let a = store.get_inode("AGENT-01", 1).unwrap().unwrap();
+        let b = store.get_inode("AGENT-02", 1).unwrap().unwrap();
+        assert_eq!(a.size, 100);
+        assert_eq!(b.size, 200);
+        assert_ne!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn dirent_crud() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-07";
+
+        // Not found
+        assert!(store.get_dirent(agent, 1, "hello.txt").unwrap().is_none());
+
+        // Create
+        store.set_dirent(agent, 1, "hello.txt", 2).unwrap();
+        assert_eq!(store.get_dirent(agent, 1, "hello.txt").unwrap(), Some(2));
+
+        // Overwrite
+        store.set_dirent(agent, 1, "hello.txt", 3).unwrap();
+        assert_eq!(store.get_dirent(agent, 1, "hello.txt").unwrap(), Some(3));
+
+        // Remove
+        let old = store.remove_dirent(agent, 1, "hello.txt").unwrap();
+        assert_eq!(old, Some(3));
+        assert!(store.get_dirent(agent, 1, "hello.txt").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_dirents_returns_children() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+
+        store.set_dirent(agent, 1, "a.txt", 10).unwrap();
+        store.set_dirent(agent, 1, "b.txt", 11).unwrap();
+        store.set_dirent(agent, 1, "sub", 12).unwrap();
+
+        // Different parent — should not appear
+        store.set_dirent(agent, 2, "c.txt", 20).unwrap();
+
+        let entries = store.list_dirents(agent, 1).unwrap();
+        assert_eq!(entries.len(), 3);
+
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"a.txt"));
+        assert!(names.contains(&"b.txt"));
+        assert!(names.contains(&"sub"));
+    }
+
+    #[test]
+    fn refcount_inc_dec() {
+        let (store, _dir) = temp_meta();
+        let hash = [0xBB; 32];
+
+        assert_eq!(store.get_refcount(&hash).unwrap(), 0);
+
+        assert_eq!(store.inc_refcount(&hash).unwrap(), 1);
+        assert_eq!(store.inc_refcount(&hash).unwrap(), 2);
+        assert_eq!(store.inc_refcount(&hash).unwrap(), 3);
+
+        assert_eq!(store.dec_refcount(&hash).unwrap(), 2);
+        assert_eq!(store.dec_refcount(&hash).unwrap(), 1);
+        assert_eq!(store.dec_refcount(&hash).unwrap(), 0);
+
+        // Already zero, stays zero
+        assert_eq!(store.dec_refcount(&hash).unwrap(), 0);
+    }
+
+    #[test]
+    fn create_file_atomic() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+        let hash = [0xCC; 32];
+        let data = InodeData::regular(hash, 512, 0o644);
+
+        store.create_file(agent, 1, "test.txt", 2, &data).unwrap();
+
+        // Inode exists
+        let inode = store.get_inode(agent, 2).unwrap().unwrap();
+        assert_eq!(inode.size, 512);
+
+        // Dirent exists
+        assert_eq!(store.get_dirent(agent, 1, "test.txt").unwrap(), Some(2));
+
+        // Refcount incremented
+        assert_eq!(store.get_refcount(&hash).unwrap(), 1);
+    }
+
+    #[test]
+    fn remove_file_atomic() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+        let hash = [0xDD; 32];
+        let data = InodeData::regular(hash, 256, 0o644);
+
+        store.create_file(agent, 1, "gone.txt", 3, &data).unwrap();
+        assert_eq!(store.get_refcount(&hash).unwrap(), 1);
+
+        let removed = store.remove_file(agent, 1, "gone.txt", 3).unwrap().unwrap();
+        assert_eq!(removed.size, 256);
+
+        // Everything cleaned up
+        assert!(store.get_inode(agent, 3).unwrap().is_none());
+        assert!(store.get_dirent(agent, 1, "gone.txt").unwrap().is_none());
+        assert_eq!(store.get_refcount(&hash).unwrap(), 0);
+    }
+
+    #[test]
+    fn shared_refcount_across_agents() {
+        let (store, _dir) = temp_meta();
+        let hash = [0xEE; 32];
+
+        let data = InodeData::regular(hash, 100, 0o644);
+        store.create_file("AGENT-01", 1, "shared.txt", 2, &data).unwrap();
+        store.create_file("AGENT-02", 1, "shared.txt", 2, &data).unwrap();
+
+        // Both agents reference the same hash
+        assert_eq!(store.get_refcount(&hash).unwrap(), 2);
+
+        // Remove one — refcount drops to 1
+        store.remove_file("AGENT-01", 1, "shared.txt", 2).unwrap();
+        assert_eq!(store.get_refcount(&hash).unwrap(), 1);
+    }
+
+    #[test]
+    fn next_inode_sequential() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+
+        let i1 = store.next_inode(agent).unwrap();
+        let i2 = store.next_inode(agent).unwrap();
+        let i3 = store.next_inode(agent).unwrap();
+
+        assert_eq!(i1, 2); // starts at 2 (root=1)
+        assert_eq!(i2, 3);
+        assert_eq!(i3, 4);
+
+        // Different agent has its own counter
+        let j1 = store.next_inode("AGENT-02").unwrap();
+        assert_eq!(j1, 2);
+    }
+
+    #[test]
+    fn directory_inode() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-01";
+        let dir_data = InodeData::directory(0o755);
+
+        store.set_inode(agent, 1, &dir_data).unwrap();
+        let read = store.get_inode(agent, 1).unwrap().unwrap();
+        assert_eq!(read.kind, FileKind::Directory);
+        assert_eq!(read.mode, 0o755);
+        assert_eq!(read.nlinks, 2);
+    }
+
+    #[test]
+    fn db_size_reasonable() {
+        let (store, dir) = temp_meta();
+        store
+            .create_file(
+                "AGENT-01",
+                1,
+                "f.txt",
+                2,
+                &InodeData::regular([0; 32], 10, 0o644),
+            )
+            .unwrap();
+        let path = dir.path().join("test-meta.redb");
+        let size = std::fs::metadata(&path).unwrap().len();
+        assert!(size < 2_097_152, "DB should be <2MB, was {size}");
+    }
+}

--- a/crates/sentinel-fs/tests/integration.rs
+++ b/crates/sentinel-fs/tests/integration.rs
@@ -249,9 +249,12 @@ fn refcount_integrity_across_operations() {
     let hash = CasStore::hash(content);
 
     // Multiple agents reference same content
-    lm.write_file("AGENT-01", 1, "f.txt", content, 0o644).unwrap();
-    lm.write_file("AGENT-02", 1, "f.txt", content, 0o644).unwrap();
-    lm.write_file("AGENT-03", 1, "f.txt", content, 0o644).unwrap();
+    lm.write_file("AGENT-01", 1, "f.txt", content, 0o644)
+        .unwrap();
+    lm.write_file("AGENT-02", 1, "f.txt", content, 0o644)
+        .unwrap();
+    lm.write_file("AGENT-03", 1, "f.txt", content, 0o644)
+        .unwrap();
     assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 3);
 
     // Remove one agent's file

--- a/crates/sentinel-fs/tests/integration.rs
+++ b/crates/sentinel-fs/tests/integration.rs
@@ -1,0 +1,287 @@
+//! Integration tests for sentinel-fs: CAS + Metadata + Layer Manager.
+//!
+//! These tests verify cross-component behavior that unit tests can't cover.
+
+use sentinel_fs::cas::CasStore;
+use sentinel_fs::layer::LayerManager;
+use sentinel_fs::metadata::{FileKind, MetadataStore};
+
+fn setup() -> (LayerManager, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let cas = CasStore::open(dir.path()).unwrap();
+    let meta = MetadataStore::open(dir.path().join("meta.redb")).unwrap();
+    let lm = LayerManager::new(cas, meta);
+    lm.init_base_root().unwrap();
+    (lm, dir)
+}
+
+// === AC-1: Deduplication Rate ===
+
+#[test]
+fn ac1_dedup_15_identical_trees() {
+    let (lm, _dir) = setup();
+
+    // Simulate 15 agents each with identical file trees
+    let files = [
+        ("package.json", br#"{"name":"app","version":"1.0.0"}"#.as_slice()),
+        ("index.js", b"console.log('hello world');"),
+        ("README.md", b"# My App\n\nA sample application."),
+        ("config.toml", b"[server]\nport = 8080\nhost = '0.0.0.0'"),
+        ("Makefile", b"all:\n\techo build\n\ntest:\n\techo test"),
+    ];
+
+    // Populate base layer with these files
+    for (name, content) in &files {
+        lm.populate_base_file(1, name, content, 0o644).unwrap();
+    }
+
+    // Each agent writes the same files (simulating npm install / copy)
+    for agent_num in 1..=15 {
+        let agent_id = format!("AGENT-{agent_num:02}");
+        for (name, content) in &files {
+            lm.write_file(&agent_id, 1, name, content, 0o644).unwrap();
+        }
+    }
+
+    let stats = lm.cas().stats().unwrap();
+
+    // 5 unique files × (base + 15 agents) = 80 writes, but only 5 unique blobs
+    assert_eq!(
+        stats.blob_count, 5,
+        "Should have exactly 5 unique blobs, got {}",
+        stats.blob_count
+    );
+
+    // Total raw size = 5 files × 16 agents = 80 copies
+    let total_raw: u64 = files.iter().map(|(_, c)| c.len() as u64).sum::<u64>() * 16;
+    let dedup_ratio = 1.0 - (stats.total_bytes_on_disk as f64 / total_raw as f64);
+    assert!(
+        dedup_ratio > 0.87,
+        "Dedup ratio should be >87%, got {:.1}%",
+        dedup_ratio * 100.0
+    );
+}
+
+// === AC-3: Agent Isolation ===
+
+#[test]
+fn ac3_agent_01_writes_agent_02_cannot_see() {
+    let (lm, _dir) = setup();
+
+    // Agent-01 writes a private file
+    let inode = lm
+        .write_file("AGENT-01", 1, "secret.txt", b"top secret data", 0o600)
+        .unwrap();
+
+    // Agent-01 can read it
+    let content = lm.read_file("AGENT-01", inode).unwrap();
+    assert_eq!(content, b"top secret data");
+
+    // Agent-02 cannot see the dirent
+    assert!(
+        lm.lookup_dirent("AGENT-02", 1, "secret.txt")
+            .unwrap()
+            .is_none(),
+        "AGENT-02 should not see AGENT-01's file"
+    );
+
+    // Agent-02 cannot read the inode (doesn't exist in their layer)
+    assert!(
+        lm.lookup_inode("AGENT-02", inode).unwrap().is_none(),
+        "AGENT-02 should not see AGENT-01's inode"
+    );
+}
+
+#[test]
+fn ac3_agent_isolation_readdir() {
+    let (lm, _dir) = setup();
+
+    lm.write_file("AGENT-01", 1, "a01.txt", b"a", 0o644).unwrap();
+    lm.write_file("AGENT-02", 1, "a02.txt", b"b", 0o644).unwrap();
+
+    let a01_entries = lm.readdir("AGENT-01", 1).unwrap();
+    let a01_names: Vec<&str> = a01_entries.iter().map(|(n, _, _)| n.as_str()).collect();
+    assert!(a01_names.contains(&"a01.txt"));
+    assert!(!a01_names.contains(&"a02.txt"), "AGENT-01 must not see AGENT-02's file");
+
+    let a02_entries = lm.readdir("AGENT-02", 1).unwrap();
+    let a02_names: Vec<&str> = a02_entries.iter().map(|(n, _, _)| n.as_str()).collect();
+    assert!(a02_names.contains(&"a02.txt"));
+    assert!(!a02_names.contains(&"a01.txt"), "AGENT-02 must not see AGENT-01's file");
+}
+
+// === AC-4: Crash Recovery (redb ACID) ===
+
+#[test]
+fn ac4_crash_recovery_redb_acid() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Phase 1: Write data
+    {
+        let cas = CasStore::open(dir.path()).unwrap();
+        let meta = MetadataStore::open(dir.path().join("meta.redb")).unwrap();
+        let lm = LayerManager::new(cas, meta);
+        lm.init_base_root().unwrap();
+
+        lm.write_file("AGENT-01", 1, "persist.txt", b"persistent data", 0o644)
+            .unwrap();
+        lm.populate_base_file(1, "base.txt", b"base data", 0o644)
+            .unwrap();
+    }
+    // LayerManager + MetadataStore dropped — simulates crash/restart
+
+    // Phase 2: Reopen and verify data survived
+    {
+        let cas = CasStore::open(dir.path()).unwrap();
+        let meta = MetadataStore::open(dir.path().join("meta.redb")).unwrap();
+        let lm = LayerManager::new(cas, meta);
+
+        let dirent = lm.lookup_dirent("AGENT-01", 1, "persist.txt").unwrap();
+        assert!(dirent.is_some(), "Agent file should survive restart");
+
+        let inode = dirent.unwrap();
+        let content = lm.read_file("AGENT-01", inode).unwrap();
+        assert_eq!(content, b"persistent data");
+
+        let base_dirent = lm
+            .lookup_dirent("AGENT-01", 1, "base.txt")
+            .unwrap();
+        assert!(base_dirent.is_some(), "Base file should survive restart");
+    }
+}
+
+// === Copy-on-Write semantics ===
+
+#[test]
+fn cow_agent_override_does_not_modify_base() {
+    let (lm, _dir) = setup();
+
+    let base_inode = lm
+        .populate_base_file(1, "config.txt", b"default config", 0o644)
+        .unwrap();
+
+    // Agent overrides the file
+    let _agent_inode = lm
+        .write_file("AGENT-01", 1, "config.txt", b"custom config", 0o644)
+        .unwrap();
+
+    // Agent sees their version
+    let agent_dirent = lm.lookup_dirent("AGENT-01", 1, "config.txt").unwrap().unwrap();
+    let agent_content = lm.read_file("AGENT-01", agent_dirent).unwrap();
+    assert_eq!(agent_content, b"custom config");
+
+    // Base layer still has original
+    let base_content = lm.read_file("__BASE__", base_inode).unwrap();
+    assert_eq!(base_content, b"default config");
+
+    // Other agent sees base version
+    let other_dirent = lm
+        .lookup_dirent("AGENT-02", 1, "config.txt")
+        .unwrap()
+        .unwrap();
+    let other_content = lm.read_file("AGENT-02", other_dirent).unwrap();
+    assert_eq!(other_content, b"default config");
+}
+
+// === Whiteout + Readdir merge ===
+
+#[test]
+fn whiteout_and_readdir_complex() {
+    let (lm, _dir) = setup();
+
+    // Base: 4 files
+    lm.populate_base_file(1, "keep1.txt", b"k1", 0o644).unwrap();
+    lm.populate_base_file(1, "keep2.txt", b"k2", 0o644).unwrap();
+    let del1_inode = lm.populate_base_file(1, "delete1.txt", b"d1", 0o644).unwrap();
+    let del2_inode = lm.populate_base_file(1, "delete2.txt", b"d2", 0o644).unwrap();
+
+    // Agent: delete 2, add 1
+    lm.unlink("AGENT-01", 1, "delete1.txt", del1_inode).unwrap();
+    lm.unlink("AGENT-01", 1, "delete2.txt", del2_inode).unwrap();
+    lm.write_file("AGENT-01", 1, "new.txt", b"new", 0o644).unwrap();
+
+    let entries = lm.readdir("AGENT-01", 1).unwrap();
+    let names: Vec<&str> = entries.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert_eq!(names.len(), 3, "should have keep1, keep2, new");
+    assert!(names.contains(&"keep1.txt"));
+    assert!(names.contains(&"keep2.txt"));
+    assert!(names.contains(&"new.txt"));
+    assert!(!names.contains(&"delete1.txt"));
+    assert!(!names.contains(&"delete2.txt"));
+}
+
+// === Nested directories ===
+
+#[test]
+fn nested_directory_structure() {
+    let (lm, _dir) = setup();
+
+    // Create: /root/src/main.rs
+    let src_inode = lm.mkdir("AGENT-01", 1, "src", 0o755).unwrap();
+    let main_inode = lm
+        .write_file("AGENT-01", src_inode, "main.rs", b"fn main() {}", 0o644)
+        .unwrap();
+
+    // Verify lookup chain
+    let found_src = lm.lookup_dirent("AGENT-01", 1, "src").unwrap().unwrap();
+    assert_eq!(found_src, src_inode);
+
+    let found_main = lm.lookup_dirent("AGENT-01", src_inode, "main.rs").unwrap().unwrap();
+    assert_eq!(found_main, main_inode);
+
+    let content = lm.read_file("AGENT-01", main_inode).unwrap();
+    assert_eq!(content, b"fn main() {}");
+
+    // Readdir of src/
+    let entries = lm.readdir("AGENT-01", src_inode).unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].0, "main.rs");
+    assert_eq!(entries[0].2, FileKind::Regular);
+}
+
+// === Refcount integrity ===
+
+#[test]
+fn refcount_integrity_across_operations() {
+    let (lm, _dir) = setup();
+    let content = b"shared content across operations";
+    let hash = CasStore::hash(content);
+
+    // Multiple agents reference same content
+    lm.write_file("AGENT-01", 1, "f.txt", content, 0o644).unwrap();
+    lm.write_file("AGENT-02", 1, "f.txt", content, 0o644).unwrap();
+    lm.write_file("AGENT-03", 1, "f.txt", content, 0o644).unwrap();
+    assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 3);
+
+    // Remove one agent's file
+    let a1_inode = lm.lookup_dirent("AGENT-01", 1, "f.txt").unwrap().unwrap();
+    lm.meta().remove_file("AGENT-01", 1, "f.txt", a1_inode).unwrap();
+    assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 2);
+
+    // Content still accessible by other agents
+    let a2_inode = lm.lookup_dirent("AGENT-02", 1, "f.txt").unwrap().unwrap();
+    let data = lm.read_file("AGENT-02", a2_inode).unwrap();
+    assert_eq!(data, content);
+}
+
+// === Scale test: many agents ===
+
+#[test]
+fn scale_100_agents_with_shared_content() {
+    let (lm, _dir) = setup();
+    let content = b"identical package-lock content for all 100 agents";
+
+    for i in 1..=100 {
+        let agent = format!("AGENT-{i:04}");
+        lm.write_file(&agent, 1, "lock.json", content, 0o644).unwrap();
+    }
+
+    // Only 1 blob despite 100 writes
+    let stats = lm.cas().stats().unwrap();
+    assert_eq!(stats.blob_count, 1);
+
+    // Refcount = 100
+    let hash = CasStore::hash(content);
+    assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 100);
+}

--- a/crates/sentinel-fs/tests/integration.rs
+++ b/crates/sentinel-fs/tests/integration.rs
@@ -256,7 +256,9 @@ fn refcount_integrity_across_operations() {
 
     // Remove one agent's file
     let a1_inode = lm.lookup_dirent("AGENT-01", 1, "f.txt").unwrap().unwrap();
-    lm.meta().remove_file("AGENT-01", 1, "f.txt", a1_inode).unwrap();
+    lm.meta()
+        .remove_file("AGENT-01", 1, "f.txt", a1_inode)
+        .unwrap();
     assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 2);
 
     // Content still accessible by other agents
@@ -274,7 +276,8 @@ fn scale_100_agents_with_shared_content() {
 
     for i in 1..=100 {
         let agent = format!("AGENT-{i:04}");
-        lm.write_file(&agent, 1, "lock.json", content, 0o644).unwrap();
+        lm.write_file(&agent, 1, "lock.json", content, 0o644)
+            .unwrap();
     }
 
     // Only 1 blob despite 100 writes

--- a/crates/sentinel-fs/tests/integration.rs
+++ b/crates/sentinel-fs/tests/integration.rs
@@ -23,7 +23,10 @@ fn ac1_dedup_15_identical_trees() {
 
     // Simulate 15 agents each with identical file trees
     let files = [
-        ("package.json", br#"{"name":"app","version":"1.0.0"}"#.as_slice()),
+        (
+            "package.json",
+            br#"{"name":"app","version":"1.0.0"}"#.as_slice(),
+        ),
         ("index.js", b"console.log('hello world');"),
         ("README.md", b"# My App\n\nA sample application."),
         ("config.toml", b"[server]\nport = 8080\nhost = '0.0.0.0'"),
@@ -96,18 +99,26 @@ fn ac3_agent_01_writes_agent_02_cannot_see() {
 fn ac3_agent_isolation_readdir() {
     let (lm, _dir) = setup();
 
-    lm.write_file("AGENT-01", 1, "a01.txt", b"a", 0o644).unwrap();
-    lm.write_file("AGENT-02", 1, "a02.txt", b"b", 0o644).unwrap();
+    lm.write_file("AGENT-01", 1, "a01.txt", b"a", 0o644)
+        .unwrap();
+    lm.write_file("AGENT-02", 1, "a02.txt", b"b", 0o644)
+        .unwrap();
 
     let a01_entries = lm.readdir("AGENT-01", 1).unwrap();
     let a01_names: Vec<&str> = a01_entries.iter().map(|(n, _, _)| n.as_str()).collect();
     assert!(a01_names.contains(&"a01.txt"));
-    assert!(!a01_names.contains(&"a02.txt"), "AGENT-01 must not see AGENT-02's file");
+    assert!(
+        !a01_names.contains(&"a02.txt"),
+        "AGENT-01 must not see AGENT-02's file"
+    );
 
     let a02_entries = lm.readdir("AGENT-02", 1).unwrap();
     let a02_names: Vec<&str> = a02_entries.iter().map(|(n, _, _)| n.as_str()).collect();
     assert!(a02_names.contains(&"a02.txt"));
-    assert!(!a02_names.contains(&"a01.txt"), "AGENT-02 must not see AGENT-01's file");
+    assert!(
+        !a02_names.contains(&"a01.txt"),
+        "AGENT-02 must not see AGENT-01's file"
+    );
 }
 
 // === AC-4: Crash Recovery (redb ACID) ===
@@ -143,9 +154,7 @@ fn ac4_crash_recovery_redb_acid() {
         let content = lm.read_file("AGENT-01", inode).unwrap();
         assert_eq!(content, b"persistent data");
 
-        let base_dirent = lm
-            .lookup_dirent("AGENT-01", 1, "base.txt")
-            .unwrap();
+        let base_dirent = lm.lookup_dirent("AGENT-01", 1, "base.txt").unwrap();
         assert!(base_dirent.is_some(), "Base file should survive restart");
     }
 }
@@ -166,7 +175,10 @@ fn cow_agent_override_does_not_modify_base() {
         .unwrap();
 
     // Agent sees their version
-    let agent_dirent = lm.lookup_dirent("AGENT-01", 1, "config.txt").unwrap().unwrap();
+    let agent_dirent = lm
+        .lookup_dirent("AGENT-01", 1, "config.txt")
+        .unwrap()
+        .unwrap();
     let agent_content = lm.read_file("AGENT-01", agent_dirent).unwrap();
     assert_eq!(agent_content, b"custom config");
 
@@ -192,13 +204,18 @@ fn whiteout_and_readdir_complex() {
     // Base: 4 files
     lm.populate_base_file(1, "keep1.txt", b"k1", 0o644).unwrap();
     lm.populate_base_file(1, "keep2.txt", b"k2", 0o644).unwrap();
-    let del1_inode = lm.populate_base_file(1, "delete1.txt", b"d1", 0o644).unwrap();
-    let del2_inode = lm.populate_base_file(1, "delete2.txt", b"d2", 0o644).unwrap();
+    let del1_inode = lm
+        .populate_base_file(1, "delete1.txt", b"d1", 0o644)
+        .unwrap();
+    let del2_inode = lm
+        .populate_base_file(1, "delete2.txt", b"d2", 0o644)
+        .unwrap();
 
     // Agent: delete 2, add 1
     lm.unlink("AGENT-01", 1, "delete1.txt", del1_inode).unwrap();
     lm.unlink("AGENT-01", 1, "delete2.txt", del2_inode).unwrap();
-    lm.write_file("AGENT-01", 1, "new.txt", b"new", 0o644).unwrap();
+    lm.write_file("AGENT-01", 1, "new.txt", b"new", 0o644)
+        .unwrap();
 
     let entries = lm.readdir("AGENT-01", 1).unwrap();
     let names: Vec<&str> = entries.iter().map(|(n, _, _)| n.as_str()).collect();
@@ -227,7 +244,10 @@ fn nested_directory_structure() {
     let found_src = lm.lookup_dirent("AGENT-01", 1, "src").unwrap().unwrap();
     assert_eq!(found_src, src_inode);
 
-    let found_main = lm.lookup_dirent("AGENT-01", src_inode, "main.rs").unwrap().unwrap();
+    let found_main = lm
+        .lookup_dirent("AGENT-01", src_inode, "main.rs")
+        .unwrap()
+        .unwrap();
     assert_eq!(found_main, main_inode);
 
     let content = lm.read_file("AGENT-01", main_inode).unwrap();


### PR DESCRIPTION
## Summary

New `sentinel-fs` crate: Content-Addressed Storage filesystem with FUSE interface for agent isolation. Single FUSE mount serves all agents via path-based Agent-ID extraction. SHA-256 inline deduplication with zstd compression. Shared base layer (readonly) + per-agent CoW layers with whiteout markers.

## Changes

- **CAS Store** (`cas.rs`): SHA-256 hashing, zstd level-3 compression (min 256B), atomic writes (temp+rename), 2-char prefix subdirs, garbage collection
- **Metadata Store** (`metadata.rs`): redb with 3 tables (FS_INODES, FS_DIRENTS, CAS_REFCOUNT), agent-scoped composite keys, atomic create_file/remove_file transactions
- **Layer Manager** (`layer.rs`): Base (readonly, shared) + Agent (rw, CoW), read fallback, whiteout markers, readdir merge, lazy agent creation
- **FUSE Handler** (`fuse.rs`): `impl fuser::Filesystem`, single mount `/cas-root/`, virtual inode space (1M/agent), feature-gated
- **CLI** (`cli.rs`): stats, gc, populate, start commands
- Deploy VM kernel upgraded 6.8.0 → 6.17.0 (HWE package)

## Linked Issues

Closes #56

## Test Plan

- **Unit tests**: 40 tests across 4 modules (CAS, metadata, layer, CLI)
- **Integration tests**: 9 tests covering AC-1 (dedup >87%), AC-3 (agent isolation), AC-4 (crash recovery), CoW, whiteouts, refcounts, scale (100 agents)
- **FUSE E2E**: Real mount on deploy VM (kernel 6.17.0), read files through `/mount/AGENT-01/hello.txt`
- **Clippy**: Clean with `-D warnings` (both default and fuse-tests features)

## Benchmarks

7 criterion benchmarks (cas_hash, cas_store_dedup, cas_read, metadata_get_inode, metadata_get_dirent, layer_read_base_fallback, layer_write_file). Not yet run on target hardware — will benchmark on deploy VM post-merge.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `ac1_dedup_15_identical_trees`: 15x identical file trees → 5 unique blobs, >87% dedup verified |
| AC-3 | PASS | `ac3_agent_01_writes_agent_02_cannot_see` + `ac3_agent_isolation_readdir`: agent writes invisible to others |
| AC-4 | PASS | `ac4_crash_recovery_redb_acid`: close + reopen → data survives (redb ACID) |
| AC-6 | PASS | FUSE E2E on deploy VM: `cat /mount/AGENT-01/hello.txt` → `Hello from CAS-FUSE!` |

## Checklist

- [x] `cargo remote -- test -p sentinel-fs -v` — 49 passed, 0 failed
- [x] `cargo remote -- clippy -p sentinel-fs --all-targets -- -D warnings` — 0 warnings
- [x] `cargo remote -- clippy -p sentinel-fs --features fuse-tests --all-targets -- -D warnings` — 0 warnings
- [x] All 49 tests pass on deploy VM with fuse-tests feature
- [x] FUSE E2E mount verified on deploy VM (kernel 6.17.0-14-generic)
- [x] CHANGELOG.md updated
- [x] Conventional commits