### PR TITLE
feat: LLM guardrails — rate limiting, budget tracking, cost control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **LLM Guardrails: Cost & Throughput Limits** (#59)
+  - Token-bucket rate limiter with per-agent and global limits (configurable RPM)
+  - Budget tracker with hourly/daily token limits and automatic window reset
+  - Cost tracker with per-provider pricing (USD/1M tokens)
+  - Automatic fallback to Ollama when cloud budget is exhausted
+  - Enforcer facade combining rate limiter, budget, cost, and fallback
+  - Pipeline integration: pre-flight Check() + post-call Record()
+  - Dashboard endpoint: GET /api/guardrails/status (budget, cost, rate info)
+  - Prometheus metrics: sentinel_tokens_total, sentinel_cost_usd_total, sentinel_rate_limited_total, sentinel_budget_used_tokens
+  - LLMResponse extended with InputTokens/OutputTokens for accurate cost tracking
+  - Environment-based configuration (SENTINEL_GUARDRAILS_*)
+  - 46 tests, 5 benchmarks (EnforcerCheck <500ns, RateLimitCheck <300ns)
 - **Prompt Compiler: 3-Source Assembly** (#58)
   - TOML DNA loader with in-memory cache (Big Five, Bio, Quirks)
   - Evolution data integration from redb (Voice Style, Behavioral Notes, Narrative, Relationships)

--- a/cmd/cortex-gateway/internal/guardrails/bench_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/bench_test.go
@@ -1,0 +1,73 @@
+package guardrails
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkRateLimitCheck(b *testing.B) {
+	rl := NewRateLimiter(20, 300, 2)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rl.Allow(fmt.Sprintf("AGENT-%02d", i%54))
+	}
+}
+
+func BenchmarkBudgetCheck(b *testing.B) {
+	bt := NewBudgetTracker(5_000_000, 50_000_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bt.Allow(4096)
+	}
+}
+
+func BenchmarkCostRecord(b *testing.B) {
+	prices := map[string]PriceTable{
+		"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+	}
+	ct := NewCostTracker(prices)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ct.Record("claude", 1000, 500)
+	}
+}
+
+func BenchmarkEnforcerCheck(b *testing.B) {
+	cfg := Config{
+		Enabled:            true,
+		BudgetHourlyTokens: 5_000_000,
+		BudgetDailyTokens:  50_000_000,
+		RateLimitPerAgent:  20,
+		RateLimitGlobal:    300,
+		BurstMultiple:      2,
+		FallbackProvider:   "ollama",
+		ProviderPrices: map[string]PriceTable{
+			"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+		},
+	}
+	e := New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Check(fmt.Sprintf("AGENT-%02d", i%54), 4096)
+	}
+}
+
+func BenchmarkEnforcerRecord(b *testing.B) {
+	cfg := Config{
+		Enabled:            true,
+		BudgetHourlyTokens: 50_000_000_000, // huge limit to avoid exhaustion
+		BudgetDailyTokens:  500_000_000_000,
+		RateLimitPerAgent:  200,
+		RateLimitGlobal:    3000,
+		BurstMultiple:      2,
+		FallbackProvider:   "ollama",
+		ProviderPrices: map[string]PriceTable{
+			"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+		},
+	}
+	e := New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Record("claude", 1000, 500)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/budget.go
+++ b/cmd/cortex-gateway/internal/guardrails/budget.go
@@ -1,0 +1,102 @@
+package guardrails
+
+import (
+	"sync"
+	"time"
+)
+
+// BudgetStatus represents the current budget usage for the dashboard.
+type BudgetStatus struct {
+	HourlyUsed  int64 `json:"hourly_used"`
+	HourlyLimit int64 `json:"hourly_limit"`
+	DailyUsed   int64 `json:"daily_used"`
+	DailyLimit  int64 `json:"daily_limit"`
+}
+
+// BudgetTracker tracks token usage against hourly and daily limits.
+type BudgetTracker struct {
+	mu          sync.Mutex
+	hourlyLimit int64
+	dailyLimit  int64
+	hourlyUsed  int64
+	dailyUsed   int64
+	hourlyReset time.Time
+	dailyReset  time.Time
+	nowFunc     func() time.Time
+}
+
+// NewBudgetTracker creates a budget tracker. Limits of 0 mean unlimited.
+func NewBudgetTracker(hourlyLimit, dailyLimit int64) *BudgetTracker {
+	now := time.Now()
+	return &BudgetTracker{
+		hourlyLimit: hourlyLimit,
+		dailyLimit:  dailyLimit,
+		hourlyReset: now.Truncate(time.Hour).Add(time.Hour),
+		dailyReset:  nextMidnight(now),
+		nowFunc:     time.Now,
+	}
+}
+
+func nextMidnight(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d+1, 0, 0, 0, 0, t.Location())
+}
+
+// maybeReset resets counters if the time window has elapsed.
+// Must be called with mu held.
+func (bt *BudgetTracker) maybeReset() {
+	now := bt.nowFunc()
+	if now.After(bt.hourlyReset) || now.Equal(bt.hourlyReset) {
+		bt.hourlyUsed = 0
+		bt.hourlyReset = now.Truncate(time.Hour).Add(time.Hour)
+	}
+	if now.After(bt.dailyReset) || now.Equal(bt.dailyReset) {
+		bt.dailyUsed = 0
+		bt.dailyReset = nextMidnight(now)
+	}
+}
+
+// Allow checks whether a request with estimatedTokens fits within budget.
+func (bt *BudgetTracker) Allow(estimatedTokens int) bool {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	bt.maybeReset()
+
+	est := int64(estimatedTokens)
+
+	if bt.hourlyLimit > 0 && bt.hourlyUsed+est > bt.hourlyLimit {
+		return false
+	}
+	if bt.dailyLimit > 0 && bt.dailyUsed+est > bt.dailyLimit {
+		return false
+	}
+	return true
+}
+
+// Record updates the budget with actual token usage after a provider call.
+func (bt *BudgetTracker) Record(inputTokens, outputTokens int) {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	bt.maybeReset()
+
+	total := int64(inputTokens + outputTokens)
+	bt.hourlyUsed += total
+	bt.dailyUsed += total
+}
+
+// Status returns the current budget usage for the dashboard endpoint.
+func (bt *BudgetTracker) Status() BudgetStatus {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	bt.maybeReset()
+
+	return BudgetStatus{
+		HourlyUsed:  bt.hourlyUsed,
+		HourlyLimit: bt.hourlyLimit,
+		DailyUsed:   bt.dailyUsed,
+		DailyLimit:  bt.dailyLimit,
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/budget_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/budget_test.go
@@ -1,0 +1,120 @@
+package guardrails
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBudgetTracker_AllowWithinLimits(t *testing.T) {
+	bt := NewBudgetTracker(1000, 10000)
+	if !bt.Allow(500) {
+		t.Fatal("should allow 500 tokens within 1000 hourly limit")
+	}
+}
+
+func TestBudgetTracker_AllowExceedsHourly(t *testing.T) {
+	bt := NewBudgetTracker(1000, 10000)
+	if bt.Allow(1001) {
+		t.Fatal("should deny when estimated tokens exceed hourly limit")
+	}
+}
+
+func TestBudgetTracker_AllowExceedsDaily(t *testing.T) {
+	bt := NewBudgetTracker(0, 1000) // unlimited hourly, limited daily
+	if bt.Allow(1001) {
+		t.Fatal("should deny when estimated tokens exceed daily limit")
+	}
+}
+
+func TestBudgetTracker_AllowUnlimited(t *testing.T) {
+	bt := NewBudgetTracker(0, 0) // both unlimited
+	if !bt.Allow(999_999_999) {
+		t.Fatal("should always allow when limits are 0 (unlimited)")
+	}
+}
+
+func TestBudgetTracker_RecordAccumulates(t *testing.T) {
+	bt := NewBudgetTracker(1000, 10000)
+	bt.Record(300, 200) // 500 total
+	bt.Record(200, 100) // 300 total, cumulative 800
+
+	status := bt.Status()
+	if status.HourlyUsed != 800 {
+		t.Fatalf("expected hourly used 800, got %d", status.HourlyUsed)
+	}
+	if status.DailyUsed != 800 {
+		t.Fatalf("expected daily used 800, got %d", status.DailyUsed)
+	}
+}
+
+func TestBudgetTracker_AllowChecksCumulative(t *testing.T) {
+	bt := NewBudgetTracker(1000, 10000)
+	bt.Record(400, 400) // 800 used
+
+	// 800 + 300 = 1100 > 1000
+	if bt.Allow(300) {
+		t.Fatal("should deny when cumulative + estimate exceeds hourly limit")
+	}
+
+	// 800 + 100 = 900 <= 1000
+	if !bt.Allow(100) {
+		t.Fatal("should allow when cumulative + estimate is within hourly limit")
+	}
+}
+
+func TestBudgetTracker_HourlyReset(t *testing.T) {
+	bt := NewBudgetTracker(1000, 100000)
+	now := time.Now()
+	bt.nowFunc = func() time.Time { return now }
+
+	bt.Record(500, 400) // 900 used
+
+	// Advance past the hour boundary
+	now = bt.hourlyReset.Add(time.Second)
+
+	status := bt.Status()
+	if status.HourlyUsed != 0 {
+		t.Fatalf("expected hourly reset to 0, got %d", status.HourlyUsed)
+	}
+	// Daily should NOT reset
+	if status.DailyUsed != 900 {
+		t.Fatalf("expected daily used 900 (not reset), got %d", status.DailyUsed)
+	}
+}
+
+func TestBudgetTracker_DailyReset(t *testing.T) {
+	bt := NewBudgetTracker(100000, 1000)
+	now := time.Now()
+	bt.nowFunc = func() time.Time { return now }
+
+	bt.Record(400, 400) // 800
+
+	// Advance past midnight
+	now = bt.dailyReset.Add(time.Second)
+
+	status := bt.Status()
+	if status.DailyUsed != 0 {
+		t.Fatalf("expected daily reset to 0, got %d", status.DailyUsed)
+	}
+}
+
+func TestBudgetTracker_StatusReturnsLimits(t *testing.T) {
+	bt := NewBudgetTracker(5000, 50000)
+	status := bt.Status()
+
+	if status.HourlyLimit != 5000 {
+		t.Fatalf("expected hourly limit 5000, got %d", status.HourlyLimit)
+	}
+	if status.DailyLimit != 50000 {
+		t.Fatalf("expected daily limit 50000, got %d", status.DailyLimit)
+	}
+}
+
+func TestBudgetTracker_BudgetExhaustionFallback(t *testing.T) {
+	// AC-1: Budget=100, send 101 tokens → denied
+	bt := NewBudgetTracker(100, 100)
+	bt.Record(50, 50) // 100 used
+	if bt.Allow(1) {
+		t.Fatal("AC-1: should deny when budget is exactly exhausted")
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/config.go
+++ b/cmd/cortex-gateway/internal/guardrails/config.go
@@ -35,7 +35,7 @@ func DefaultConfig() Config {
 }
 
 // ConfigFromEnv creates a Config from environment variables with sensible defaults.
-// Recognised variables:
+// Recognized variables:
 //
 //	SENTINEL_GUARDRAILS_ENABLED          (bool, default: false)
 //	SENTINEL_GUARDRAILS_BUDGET_HOURLY    (int64, tokens/hour, default: 5000000)

--- a/cmd/cortex-gateway/internal/guardrails/config.go
+++ b/cmd/cortex-gateway/internal/guardrails/config.go
@@ -1,0 +1,73 @@
+package guardrails
+
+import (
+	"os"
+	"strconv"
+)
+
+// Config holds all guardrails configuration values.
+type Config struct {
+	Enabled            bool                  `toml:"enabled"`
+	BudgetHourlyTokens int64                 `toml:"budget_hourly_tokens"`
+	BudgetDailyTokens  int64                 `toml:"budget_daily_tokens"`
+	RateLimitPerAgent  int                   `toml:"rate_limit_per_agent_rpm"`
+	RateLimitGlobal    int                   `toml:"rate_limit_global_rpm"`
+	BurstMultiple      int                   `toml:"burst_multiple"`
+	FallbackProvider   string                `toml:"fallback_provider"`
+	ProviderPrices     map[string]PriceTable `toml:"provider_prices"`
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:            false,
+		BudgetHourlyTokens: 5_000_000,
+		BudgetDailyTokens:  50_000_000,
+		RateLimitPerAgent:  20,
+		RateLimitGlobal:    300,
+		BurstMultiple:      2,
+		FallbackProvider:   "ollama",
+		ProviderPrices: map[string]PriceTable{
+			"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+			"ollama": {InputPricePerMToken: 0.0, OutputPricePerMToken: 0.0},
+		},
+	}
+}
+
+// ConfigFromEnv creates a Config from environment variables with sensible defaults.
+// Recognised variables:
+//
+//	SENTINEL_GUARDRAILS_ENABLED          (bool, default: false)
+//	SENTINEL_GUARDRAILS_BUDGET_HOURLY    (int64, tokens/hour, default: 5000000)
+//	SENTINEL_GUARDRAILS_BUDGET_DAILY     (int64, tokens/day, default: 50000000)
+//	SENTINEL_GUARDRAILS_RATE_AGENT_RPM   (int, per-agent calls/min, default: 20)
+//	SENTINEL_GUARDRAILS_RATE_GLOBAL_RPM  (int, global calls/min, default: 300)
+//	SENTINEL_GUARDRAILS_BURST_MULTIPLE   (int, default: 2)
+//	SENTINEL_GUARDRAILS_FALLBACK         (string, default: "ollama")
+func ConfigFromEnv() Config {
+	cfg := DefaultConfig()
+
+	if v := os.Getenv("SENTINEL_GUARDRAILS_ENABLED"); v == "true" || v == "1" {
+		cfg.Enabled = true
+	}
+	if v, err := strconv.ParseInt(os.Getenv("SENTINEL_GUARDRAILS_BUDGET_HOURLY"), 10, 64); err == nil && v > 0 {
+		cfg.BudgetHourlyTokens = v
+	}
+	if v, err := strconv.ParseInt(os.Getenv("SENTINEL_GUARDRAILS_BUDGET_DAILY"), 10, 64); err == nil && v > 0 {
+		cfg.BudgetDailyTokens = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("SENTINEL_GUARDRAILS_RATE_AGENT_RPM")); err == nil && v > 0 {
+		cfg.RateLimitPerAgent = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("SENTINEL_GUARDRAILS_RATE_GLOBAL_RPM")); err == nil && v > 0 {
+		cfg.RateLimitGlobal = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("SENTINEL_GUARDRAILS_BURST_MULTIPLE")); err == nil && v > 0 {
+		cfg.BurstMultiple = v
+	}
+	if v := os.Getenv("SENTINEL_GUARDRAILS_FALLBACK"); v != "" {
+		cfg.FallbackProvider = v
+	}
+
+	return cfg
+}

--- a/cmd/cortex-gateway/internal/guardrails/config_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/config_test.go
@@ -1,0 +1,117 @@
+package guardrails
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Enabled {
+		t.Fatal("default config should be disabled")
+	}
+	if cfg.BudgetHourlyTokens != 5_000_000 {
+		t.Fatalf("expected 5M hourly, got %d", cfg.BudgetHourlyTokens)
+	}
+	if cfg.BudgetDailyTokens != 50_000_000 {
+		t.Fatalf("expected 50M daily, got %d", cfg.BudgetDailyTokens)
+	}
+	if cfg.RateLimitPerAgent != 20 {
+		t.Fatalf("expected 20 rpm, got %d", cfg.RateLimitPerAgent)
+	}
+	if cfg.RateLimitGlobal != 300 {
+		t.Fatalf("expected 300 global rpm, got %d", cfg.RateLimitGlobal)
+	}
+	if cfg.FallbackProvider != "ollama" {
+		t.Fatalf("expected ollama fallback, got %q", cfg.FallbackProvider)
+	}
+}
+
+func TestConfigFromEnv_Defaults(t *testing.T) {
+	// Ensure env vars are not set
+	for _, key := range []string{
+		"SENTINEL_GUARDRAILS_ENABLED",
+		"SENTINEL_GUARDRAILS_BUDGET_HOURLY",
+		"SENTINEL_GUARDRAILS_BUDGET_DAILY",
+		"SENTINEL_GUARDRAILS_RATE_AGENT_RPM",
+		"SENTINEL_GUARDRAILS_RATE_GLOBAL_RPM",
+		"SENTINEL_GUARDRAILS_BURST_MULTIPLE",
+		"SENTINEL_GUARDRAILS_FALLBACK",
+	} {
+		os.Unsetenv(key)
+	}
+
+	cfg := ConfigFromEnv()
+	def := DefaultConfig()
+
+	if cfg.Enabled != def.Enabled {
+		t.Fatal("ConfigFromEnv should match defaults when no env vars set")
+	}
+	if cfg.BudgetHourlyTokens != def.BudgetHourlyTokens {
+		t.Fatal("hourly budget should match default")
+	}
+}
+
+func TestConfigFromEnv_OverrideEnabled(t *testing.T) {
+	t.Setenv("SENTINEL_GUARDRAILS_ENABLED", "true")
+
+	cfg := ConfigFromEnv()
+	if !cfg.Enabled {
+		t.Fatal("expected enabled=true")
+	}
+}
+
+func TestConfigFromEnv_OverrideBudget(t *testing.T) {
+	t.Setenv("SENTINEL_GUARDRAILS_BUDGET_HOURLY", "1000000")
+	t.Setenv("SENTINEL_GUARDRAILS_BUDGET_DAILY", "20000000")
+
+	cfg := ConfigFromEnv()
+	if cfg.BudgetHourlyTokens != 1_000_000 {
+		t.Fatalf("expected 1M hourly, got %d", cfg.BudgetHourlyTokens)
+	}
+	if cfg.BudgetDailyTokens != 20_000_000 {
+		t.Fatalf("expected 20M daily, got %d", cfg.BudgetDailyTokens)
+	}
+}
+
+func TestConfigFromEnv_OverrideRateLimits(t *testing.T) {
+	t.Setenv("SENTINEL_GUARDRAILS_RATE_AGENT_RPM", "10")
+	t.Setenv("SENTINEL_GUARDRAILS_RATE_GLOBAL_RPM", "150")
+	t.Setenv("SENTINEL_GUARDRAILS_BURST_MULTIPLE", "3")
+
+	cfg := ConfigFromEnv()
+	if cfg.RateLimitPerAgent != 10 {
+		t.Fatalf("expected 10, got %d", cfg.RateLimitPerAgent)
+	}
+	if cfg.RateLimitGlobal != 150 {
+		t.Fatalf("expected 150, got %d", cfg.RateLimitGlobal)
+	}
+	if cfg.BurstMultiple != 3 {
+		t.Fatalf("expected 3, got %d", cfg.BurstMultiple)
+	}
+}
+
+func TestConfigFromEnv_OverrideFallback(t *testing.T) {
+	t.Setenv("SENTINEL_GUARDRAILS_FALLBACK", "bitnet")
+
+	cfg := ConfigFromEnv()
+	if cfg.FallbackProvider != "bitnet" {
+		t.Fatalf("expected bitnet, got %q", cfg.FallbackProvider)
+	}
+}
+
+func TestConfigFromEnv_InvalidValues(t *testing.T) {
+	t.Setenv("SENTINEL_GUARDRAILS_BUDGET_HOURLY", "notanumber")
+	t.Setenv("SENTINEL_GUARDRAILS_RATE_AGENT_RPM", "-5")
+
+	cfg := ConfigFromEnv()
+	// Invalid values should keep defaults
+	if cfg.BudgetHourlyTokens != 5_000_000 {
+		t.Fatalf("expected default 5M, got %d", cfg.BudgetHourlyTokens)
+	}
+	// Negative number: our check is v > 0, so -5 is rejected
+	if cfg.RateLimitPerAgent != 20 {
+		t.Fatalf("expected default 20, got %d", cfg.RateLimitPerAgent)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/config_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/config_test.go
@@ -1,7 +1,6 @@
 package guardrails
 
 import (
-	"os"
 	"testing"
 )
 
@@ -39,7 +38,7 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 		"SENTINEL_GUARDRAILS_BURST_MULTIPLE",
 		"SENTINEL_GUARDRAILS_FALLBACK",
 	} {
-		os.Unsetenv(key)
+		t.Setenv(key, "") // t.Setenv restores after test
 	}
 
 	cfg := ConfigFromEnv()

--- a/cmd/cortex-gateway/internal/guardrails/cost.go
+++ b/cmd/cortex-gateway/internal/guardrails/cost.go
@@ -1,0 +1,83 @@
+package guardrails
+
+import (
+	"sync"
+)
+
+// PriceTable holds per-provider token pricing (USD per 1M tokens).
+type PriceTable struct {
+	InputPricePerMToken  float64 `toml:"input_price_per_m_token"`
+	OutputPricePerMToken float64 `toml:"output_price_per_m_token"`
+}
+
+// CostStatus represents cost data for the dashboard.
+type CostStatus struct {
+	ByProvider map[string]float64 `json:"by_provider"`
+	Total      float64            `json:"total_usd"`
+}
+
+// CostTracker accumulates costs per provider based on token usage and pricing.
+type CostTracker struct {
+	mu     sync.Mutex
+	prices map[string]PriceTable
+	costs  map[string]float64
+	total  float64
+}
+
+// NewCostTracker creates a cost tracker with the given pricing table.
+func NewCostTracker(prices map[string]PriceTable) *CostTracker {
+	if prices == nil {
+		prices = make(map[string]PriceTable)
+	}
+	return &CostTracker{
+		prices: prices,
+		costs:  make(map[string]float64),
+	}
+}
+
+// Record calculates and accumulates cost for a provider call.
+func (ct *CostTracker) Record(provider string, inputTokens, outputTokens int) float64 {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	pt, ok := ct.prices[provider]
+	if !ok {
+		return 0
+	}
+
+	cost := float64(inputTokens)/1_000_000*pt.InputPricePerMToken +
+		float64(outputTokens)/1_000_000*pt.OutputPricePerMToken
+
+	ct.costs[provider] += cost
+	ct.total += cost
+	return cost
+}
+
+// CostByProvider returns the accumulated cost for a specific provider.
+func (ct *CostTracker) CostByProvider(provider string) float64 {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.costs[provider]
+}
+
+// TotalCost returns the total accumulated cost across all providers.
+func (ct *CostTracker) TotalCost() float64 {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.total
+}
+
+// Status returns a snapshot for the dashboard endpoint.
+func (ct *CostTracker) Status() CostStatus {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	byProvider := make(map[string]float64, len(ct.costs))
+	for k, v := range ct.costs {
+		byProvider[k] = v
+	}
+	return CostStatus{
+		ByProvider: byProvider,
+		Total:      ct.total,
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/cost_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/cost_test.go
@@ -1,0 +1,96 @@
+package guardrails
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCostTracker_RecordClaude(t *testing.T) {
+	// AC-3: Claude 1000 input + 500 output
+	// Cost = 1000/1M * $3.0 + 500/1M * $15.0 = $0.003 + $0.0075 = $0.0105
+	prices := map[string]PriceTable{
+		"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+	}
+	ct := NewCostTracker(prices)
+
+	cost := ct.Record("claude", 1000, 500)
+	expected := 0.0105
+	if math.Abs(cost-expected) > 1e-9 {
+		t.Fatalf("AC-3: expected cost %.6f, got %.6f", expected, cost)
+	}
+}
+
+func TestCostTracker_RecordOllamaFree(t *testing.T) {
+	// AC-3: Ollama should be $0
+	prices := map[string]PriceTable{
+		"ollama": {InputPricePerMToken: 0.0, OutputPricePerMToken: 0.0},
+	}
+	ct := NewCostTracker(prices)
+
+	cost := ct.Record("ollama", 10000, 5000)
+	if cost != 0 {
+		t.Fatalf("AC-3: expected ollama cost 0, got %f", cost)
+	}
+}
+
+func TestCostTracker_UnknownProviderZeroCost(t *testing.T) {
+	ct := NewCostTracker(nil)
+	cost := ct.Record("unknown", 1000, 500)
+	if cost != 0 {
+		t.Fatalf("expected 0 for unknown provider, got %f", cost)
+	}
+}
+
+func TestCostTracker_AccumulatesAcrossRecords(t *testing.T) {
+	prices := map[string]PriceTable{
+		"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+	}
+	ct := NewCostTracker(prices)
+
+	ct.Record("claude", 1_000_000, 0)  // $3.0
+	ct.Record("claude", 0, 1_000_000)  // $15.0
+	total := ct.TotalCost()
+	expected := 18.0
+	if math.Abs(total-expected) > 1e-9 {
+		t.Fatalf("expected total %.2f, got %.6f", expected, total)
+	}
+}
+
+func TestCostTracker_CostByProvider(t *testing.T) {
+	prices := map[string]PriceTable{
+		"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+		"ollama": {InputPricePerMToken: 0.0, OutputPricePerMToken: 0.0},
+	}
+	ct := NewCostTracker(prices)
+
+	ct.Record("claude", 1_000_000, 0) // $3.0
+	ct.Record("ollama", 1_000_000, 1_000_000) // $0
+
+	claudeCost := ct.CostByProvider("claude")
+	if math.Abs(claudeCost-3.0) > 1e-9 {
+		t.Fatalf("expected claude cost 3.0, got %f", claudeCost)
+	}
+
+	ollamaCost := ct.CostByProvider("ollama")
+	if ollamaCost != 0 {
+		t.Fatalf("expected ollama cost 0, got %f", ollamaCost)
+	}
+}
+
+func TestCostTracker_Status(t *testing.T) {
+	prices := map[string]PriceTable{
+		"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+	}
+	ct := NewCostTracker(prices)
+	ct.Record("claude", 1_000_000, 500_000)
+
+	status := ct.Status()
+	if len(status.ByProvider) != 1 {
+		t.Fatalf("expected 1 provider in status, got %d", len(status.ByProvider))
+	}
+
+	expected := 3.0 + 7.5 // 10.5
+	if math.Abs(status.Total-expected) > 1e-9 {
+		t.Fatalf("expected total %.2f, got %.6f", expected, status.Total)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/enforcer.go
+++ b/cmd/cortex-gateway/internal/guardrails/enforcer.go
@@ -1,0 +1,108 @@
+package guardrails
+
+// CheckResult holds the outcome of a guardrails pre-flight check.
+type CheckResult struct {
+	Allowed          bool
+	RateLimited      bool
+	RateLimitReason  string
+	BudgetExhausted  bool
+	FallbackProvider string
+}
+
+// GuardrailsStatus aggregates all status data for the dashboard endpoint.
+type GuardrailsStatus struct {
+	Budget   BudgetStatus `json:"budget"`
+	Cost     CostStatus   `json:"cost"`
+	RateInfo RateStatus   `json:"rate_limit"`
+}
+
+// RateStatus holds rate limiter configuration for status reporting.
+type RateStatus struct {
+	PerAgentRPM int `json:"per_agent_rpm"`
+	GlobalRPM   int `json:"global_rpm"`
+}
+
+// Enforcer is the main facade combining rate limiter, budget, cost, and fallback.
+type Enforcer struct {
+	rateLimiter *RateLimiter
+	budget      *BudgetTracker
+	costs       *CostTracker
+	fallback    *FallbackHandler
+	enabled     bool
+	rateInfo    RateStatus
+}
+
+// New creates an Enforcer from the given config. Returns nil if disabled.
+func New(cfg Config) *Enforcer {
+	if !cfg.Enabled {
+		return nil
+	}
+	return &Enforcer{
+		rateLimiter: NewRateLimiter(cfg.RateLimitPerAgent, cfg.RateLimitGlobal, cfg.BurstMultiple),
+		budget:      NewBudgetTracker(cfg.BudgetHourlyTokens, cfg.BudgetDailyTokens),
+		costs:       NewCostTracker(cfg.ProviderPrices),
+		fallback:    NewFallbackHandler(cfg.FallbackProvider),
+		enabled:     true,
+		rateInfo: RateStatus{
+			PerAgentRPM: cfg.RateLimitPerAgent,
+			GlobalRPM:   cfg.RateLimitGlobal,
+		},
+	}
+}
+
+// Check performs pre-flight guardrails checks before a provider call.
+func (e *Enforcer) Check(agentID string, estimatedTokens int) CheckResult {
+	if !e.enabled {
+		return CheckResult{Allowed: true}
+	}
+
+	// Rate limit check
+	allowed, reason := e.rateLimiter.Allow(agentID)
+	if !allowed {
+		recordRateLimited(agentID, reason)
+		return CheckResult{
+			Allowed:         false,
+			RateLimited:     true,
+			RateLimitReason: reason,
+		}
+	}
+
+	// Budget check
+	if !e.budget.Allow(estimatedTokens) {
+		budgetExhaustedTotal.Inc()
+		fbProvider, _ := e.fallback.ShouldFallback(true)
+		return CheckResult{
+			Allowed:          true,
+			BudgetExhausted:  true,
+			FallbackProvider: fbProvider,
+		}
+	}
+
+	return CheckResult{Allowed: true}
+}
+
+// Record updates budget, cost tracking, and metrics after a provider call.
+func (e *Enforcer) Record(provider string, inputTokens, outputTokens int) {
+	if !e.enabled {
+		return
+	}
+
+	e.budget.Record(inputTokens, outputTokens)
+	cost := e.costs.Record(provider, inputTokens, outputTokens)
+
+	recordTokenMetrics(provider, inputTokens, outputTokens)
+	recordCostMetric(provider, cost)
+	updateBudgetGauges(e.budget.Status())
+}
+
+// Status returns a snapshot of all guardrails state for the dashboard.
+func (e *Enforcer) Status() GuardrailsStatus {
+	if !e.enabled {
+		return GuardrailsStatus{}
+	}
+	return GuardrailsStatus{
+		Budget:   e.budget.Status(),
+		Cost:     e.costs.Status(),
+		RateInfo: e.rateInfo,
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/enforcer_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/enforcer_test.go
@@ -1,0 +1,174 @@
+package guardrails
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestConfig() Config {
+	return Config{
+		Enabled:            true,
+		BudgetHourlyTokens: 10000,
+		BudgetDailyTokens:  100000,
+		RateLimitPerAgent:  20,
+		RateLimitGlobal:    300,
+		BurstMultiple:      2,
+		FallbackProvider:   "ollama",
+		ProviderPrices: map[string]PriceTable{
+			"claude": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+			"ollama": {InputPricePerMToken: 0.0, OutputPricePerMToken: 0.0},
+		},
+	}
+}
+
+func TestEnforcer_NewDisabled(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Enabled = false
+	e := New(cfg)
+	if e != nil {
+		t.Fatal("expected nil enforcer when disabled")
+	}
+}
+
+func TestEnforcer_CheckAllowed(t *testing.T) {
+	e := New(newTestConfig())
+	result := e.Check("AGENT-01", 100)
+	if !result.Allowed {
+		t.Fatal("expected allowed for normal request")
+	}
+	if result.RateLimited {
+		t.Fatal("should not be rate limited")
+	}
+	if result.BudgetExhausted {
+		t.Fatal("should not have exhausted budget")
+	}
+}
+
+func TestEnforcer_CheckRateLimited(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.RateLimitPerAgent = 60 // 1/sec
+	cfg.BurstMultiple = 1      // no burst
+	e := New(cfg)
+
+	now := time.Now()
+	e.rateLimiter.nowFunc = func() time.Time { return now }
+
+	// First call allowed
+	r := e.Check("AGENT-01", 100)
+	if !r.Allowed {
+		t.Fatal("first call should be allowed")
+	}
+
+	// Second call rate-limited
+	r = e.Check("AGENT-01", 100)
+	if r.Allowed {
+		t.Fatal("second call should be denied")
+	}
+	if !r.RateLimited {
+		t.Fatal("should be flagged as rate limited")
+	}
+}
+
+func TestEnforcer_CheckBudgetExhaustedWithFallback(t *testing.T) {
+	// AC-1: Budget exhaustion triggers fallback
+	cfg := newTestConfig()
+	cfg.BudgetHourlyTokens = 100
+	e := New(cfg)
+
+	e.budget.Record(50, 50) // 100 used, budget exhausted
+
+	result := e.Check("AGENT-01", 1)
+	if !result.Allowed {
+		t.Fatal("AC-1: budget exhaustion should still allow (with fallback)")
+	}
+	if !result.BudgetExhausted {
+		t.Fatal("AC-1: should flag budget as exhausted")
+	}
+	if result.FallbackProvider != "ollama" {
+		t.Fatalf("AC-1: expected fallback to ollama, got %q", result.FallbackProvider)
+	}
+}
+
+func TestEnforcer_Record(t *testing.T) {
+	e := New(newTestConfig())
+	e.Record("claude", 1000, 500)
+
+	status := e.Status()
+	if status.Budget.HourlyUsed != 1500 {
+		t.Fatalf("expected 1500 tokens used, got %d", status.Budget.HourlyUsed)
+	}
+	if status.Cost.Total == 0 {
+		t.Fatal("expected non-zero cost after recording claude usage")
+	}
+}
+
+func TestEnforcer_StatusDisabled(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Enabled = false
+	// Manually create an enforcer that's disabled
+	e := &Enforcer{enabled: false}
+	status := e.Status()
+	if status.Budget.HourlyLimit != 0 && status.Cost.Total != 0 {
+		t.Fatal("disabled enforcer should return empty status")
+	}
+}
+
+func TestEnforcer_CheckDisabledAlwaysAllows(t *testing.T) {
+	e := &Enforcer{enabled: false}
+	result := e.Check("AGENT-01", 999999)
+	if !result.Allowed {
+		t.Fatal("disabled enforcer should always allow")
+	}
+}
+
+func TestEnforcer_RecordDisabledNoop(t *testing.T) {
+	e := &Enforcer{enabled: false}
+	// Should not panic
+	e.Record("claude", 1000, 500)
+}
+
+func TestEnforcer_E2E_RateLimitAndFallback(t *testing.T) {
+	// AC-5: 25 calls at limit 20 → some rate-limited or fallback
+	cfg := newTestConfig()
+	cfg.RateLimitPerAgent = 60 // 1/sec per agent
+	cfg.RateLimitGlobal = 600  // 10/sec global (burst=2 → 20 tokens initially)
+	cfg.BurstMultiple = 2
+	e := New(cfg)
+
+	now := time.Now()
+	e.rateLimiter.nowFunc = func() time.Time { return now }
+
+	allowed := 0
+	denied := 0
+	for i := 0; i < 25; i++ {
+		agentID := "AGENT-01"
+		if i%5 == 0 {
+			agentID = "AGENT-02" // spread across agents
+		}
+		result := e.Check(agentID, 100)
+		if result.Allowed && !result.RateLimited {
+			allowed++
+		} else {
+			denied++
+		}
+	}
+
+	if denied == 0 {
+		t.Fatal("AC-5: expected some calls to be rate-limited with 25 calls")
+	}
+	if allowed == 0 {
+		t.Fatal("AC-5: expected some calls to be allowed")
+	}
+}
+
+func TestEnforcer_StatusRateInfo(t *testing.T) {
+	e := New(newTestConfig())
+	status := e.Status()
+
+	if status.RateInfo.PerAgentRPM != 20 {
+		t.Fatalf("expected per_agent_rpm=20, got %d", status.RateInfo.PerAgentRPM)
+	}
+	if status.RateInfo.GlobalRPM != 300 {
+		t.Fatalf("expected global_rpm=300, got %d", status.RateInfo.GlobalRPM)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/fallback.go
+++ b/cmd/cortex-gateway/internal/guardrails/fallback.go
@@ -1,0 +1,23 @@
+package guardrails
+
+// FallbackHandler decides which provider to use when budget is exhausted.
+type FallbackHandler struct {
+	fallbackProvider string
+}
+
+// NewFallbackHandler creates a handler that falls back to the given provider.
+func NewFallbackHandler(fallbackProvider string) *FallbackHandler {
+	if fallbackProvider == "" {
+		fallbackProvider = "ollama"
+	}
+	return &FallbackHandler{fallbackProvider: fallbackProvider}
+}
+
+// ShouldFallback returns the fallback provider name if budget is exhausted.
+// Returns ("", false) if no fallback is needed.
+func (fh *FallbackHandler) ShouldFallback(budgetExhausted bool) (string, bool) {
+	if !budgetExhausted {
+		return "", false
+	}
+	return fh.fallbackProvider, true
+}

--- a/cmd/cortex-gateway/internal/guardrails/handler.go
+++ b/cmd/cortex-gateway/internal/guardrails/handler.go
@@ -1,0 +1,27 @@
+package guardrails
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Handler exposes guardrails status via HTTP.
+type Handler struct {
+	enforcer *Enforcer
+}
+
+// NewHandler creates an HTTP handler for guardrails status.
+func NewHandler(enforcer *Enforcer) *Handler {
+	return &Handler{enforcer: enforcer}
+}
+
+// RegisterRoutes registers guardrails endpoints on the given mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/guardrails/status", h.handleStatus)
+}
+
+func (h *Handler) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	status := h.enforcer.Status()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status)
+}

--- a/cmd/cortex-gateway/internal/guardrails/handler_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/handler_test.go
@@ -1,0 +1,49 @@
+package guardrails
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_StatusEndpoint(t *testing.T) {
+	cfg := newTestConfig()
+	e := New(cfg)
+	e.Record("claude", 1000, 500)
+
+	h := NewHandler(e)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/guardrails/status", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+
+	var status GuardrailsStatus
+	if err := json.NewDecoder(w.Body).Decode(&status); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if status.Budget.HourlyUsed != 1500 {
+		t.Fatalf("expected hourly used 1500, got %d", status.Budget.HourlyUsed)
+	}
+	if status.Budget.HourlyLimit != 10000 {
+		t.Fatalf("expected hourly limit 10000, got %d", status.Budget.HourlyLimit)
+	}
+	if status.Cost.Total == 0 {
+		t.Fatal("expected non-zero cost")
+	}
+	if status.RateInfo.PerAgentRPM != 20 {
+		t.Fatalf("expected per_agent_rpm 20, got %d", status.RateInfo.PerAgentRPM)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/metrics.go
+++ b/cmd/cortex-gateway/internal/guardrails/metrics.go
@@ -1,0 +1,55 @@
+package guardrails
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	tokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sentinel_tokens_total",
+		Help: "Total tokens processed by provider and direction",
+	}, []string{"provider", "direction"})
+
+	costUSDTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sentinel_cost_usd_total",
+		Help: "Total accumulated cost in USD by provider",
+	}, []string{"provider"})
+
+	rateLimitedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sentinel_rate_limited_total",
+		Help: "Total rate-limited requests by agent and reason",
+	}, []string{"agent_id", "reason"})
+
+	budgetUsedGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "sentinel_budget_used_tokens",
+		Help: "Current token budget usage by time window",
+	}, []string{"window"})
+
+	budgetExhaustedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "sentinel_budget_exhausted_total",
+		Help: "Total times budget was exhausted triggering fallback",
+	})
+)
+
+// recordTokenMetrics updates prometheus counters for a provider call.
+func recordTokenMetrics(provider string, inputTokens, outputTokens int) {
+	tokensTotal.WithLabelValues(provider, "input").Add(float64(inputTokens))
+	tokensTotal.WithLabelValues(provider, "output").Add(float64(outputTokens))
+}
+
+// recordCostMetric updates the cost counter for a provider.
+func recordCostMetric(provider string, cost float64) {
+	costUSDTotal.WithLabelValues(provider).Add(cost)
+}
+
+// recordRateLimited increments the rate-limited counter.
+func recordRateLimited(agentID, reason string) {
+	rateLimitedTotal.WithLabelValues(agentID, reason).Inc()
+}
+
+// updateBudgetGauges sets the current budget usage gauges.
+func updateBudgetGauges(status BudgetStatus) {
+	budgetUsedGauge.WithLabelValues("hourly").Set(float64(status.HourlyUsed))
+	budgetUsedGauge.WithLabelValues("daily").Set(float64(status.DailyUsed))
+}

--- a/cmd/cortex-gateway/internal/guardrails/metrics_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/metrics_test.go
@@ -1,0 +1,91 @@
+package guardrails
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func getCounterValue(cv *prometheus.CounterVec, labels ...string) float64 {
+	m := &dto.Metric{}
+	c, err := cv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	_ = c.(prometheus.Metric).Write(m)
+	if m.Counter != nil {
+		return m.Counter.GetValue()
+	}
+	return 0
+}
+
+func getGaugeValue(gv *prometheus.GaugeVec, labels ...string) float64 {
+	m := &dto.Metric{}
+	g, err := gv.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	_ = g.(prometheus.Metric).Write(m)
+	if m.Gauge != nil {
+		return m.Gauge.GetValue()
+	}
+	return 0
+}
+
+func TestMetrics_RecordTokens(t *testing.T) {
+	// AC-4: Token metrics
+	before := getCounterValue(tokensTotal, "test-provider", "input")
+	recordTokenMetrics("test-provider", 1000, 500)
+	after := getCounterValue(tokensTotal, "test-provider", "input")
+
+	if after-before != 1000 {
+		t.Fatalf("AC-4: expected input tokens increase of 1000, got %.0f", after-before)
+	}
+
+	outputAfter := getCounterValue(tokensTotal, "test-provider", "output")
+	if outputAfter < 500 {
+		t.Fatalf("AC-4: expected output tokens >= 500, got %.0f", outputAfter)
+	}
+}
+
+func TestMetrics_RecordCost(t *testing.T) {
+	// AC-4: Cost metrics
+	before := getCounterValue(costUSDTotal, "test-cost-provider")
+	recordCostMetric("test-cost-provider", 1.23)
+	after := getCounterValue(costUSDTotal, "test-cost-provider")
+
+	diff := after - before
+	if diff < 1.22 || diff > 1.24 {
+		t.Fatalf("AC-4: expected cost increase ~1.23, got %.4f", diff)
+	}
+}
+
+func TestMetrics_RecordRateLimited(t *testing.T) {
+	// AC-4: Rate limit metrics
+	before := getCounterValue(rateLimitedTotal, "AGENT-TEST", "per_agent")
+	recordRateLimited("AGENT-TEST", "per_agent")
+	after := getCounterValue(rateLimitedTotal, "AGENT-TEST", "per_agent")
+
+	if after-before != 1 {
+		t.Fatalf("AC-4: expected rate limited counter increase of 1, got %.0f", after-before)
+	}
+}
+
+func TestMetrics_UpdateBudgetGauges(t *testing.T) {
+	// AC-4: Budget gauges
+	updateBudgetGauges(BudgetStatus{
+		HourlyUsed: 5000,
+		DailyUsed:  40000,
+	})
+
+	hourly := getGaugeValue(budgetUsedGauge, "hourly")
+	if hourly != 5000 {
+		t.Fatalf("AC-4: expected hourly gauge 5000, got %.0f", hourly)
+	}
+
+	daily := getGaugeValue(budgetUsedGauge, "daily")
+	if daily != 40000 {
+		t.Fatalf("AC-4: expected daily gauge 40000, got %.0f", daily)
+	}
+}

--- a/cmd/cortex-gateway/internal/guardrails/ratelimit.go
+++ b/cmd/cortex-gateway/internal/guardrails/ratelimit.go
@@ -1,0 +1,108 @@
+package guardrails
+
+import (
+	"sync"
+	"time"
+)
+
+// bucket implements a token-bucket rate limiter.
+type bucket struct {
+	tokens    float64
+	max       float64
+	rate      float64   // tokens/sec refill
+	lastCheck time.Time
+}
+
+func newBucket(callsPerMin int, burstMultiple int, now time.Time) *bucket {
+	rate := float64(callsPerMin) / 60.0
+	max := rate * float64(burstMultiple)
+	if max < 1 {
+		max = 1
+	}
+	return &bucket{
+		tokens:    max,
+		max:       max,
+		rate:      rate,
+		lastCheck: now,
+	}
+}
+
+func (b *bucket) allow(now time.Time) bool {
+	elapsed := now.Sub(b.lastCheck).Seconds()
+	b.lastCheck = now
+	b.tokens += elapsed * b.rate
+	if b.tokens > b.max {
+		b.tokens = b.max
+	}
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// RateLimiter enforces per-agent and global call rate limits using token buckets.
+type RateLimiter struct {
+	mu            sync.Mutex
+	perAgent      map[string]*bucket
+	global        *bucket
+	agentRPM      int
+	globalRPM     int
+	burstMultiple int
+	nowFunc       func() time.Time
+}
+
+// NewRateLimiter creates a rate limiter with the given calls-per-minute limits.
+// A burstMultiple of 0 defaults to 2.
+func NewRateLimiter(agentCallsPerMin, globalCallsPerMin, burstMultiple int) *RateLimiter {
+	if burstMultiple <= 0 {
+		burstMultiple = 2
+	}
+	now := time.Now()
+	return &RateLimiter{
+		perAgent:      make(map[string]*bucket),
+		global:        newBucket(globalCallsPerMin, burstMultiple, now),
+		agentRPM:      agentCallsPerMin,
+		globalRPM:     globalCallsPerMin,
+		burstMultiple: burstMultiple,
+		nowFunc:       time.Now,
+	}
+}
+
+// Allow checks whether a request from agentID is allowed.
+// Returns true if allowed, false if rate-limited.
+// The second return value indicates the reason: "per_agent" or "global".
+func (rl *RateLimiter) Allow(agentID string) (bool, string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.nowFunc()
+
+	// Check global limit first
+	if !rl.global.allow(now) {
+		return false, "global"
+	}
+
+	// Check per-agent limit
+	if agentID != "" && rl.agentRPM > 0 {
+		ab, ok := rl.perAgent[agentID]
+		if !ok {
+			ab = newBucket(rl.agentRPM, rl.burstMultiple, now)
+			rl.perAgent[agentID] = ab
+		}
+		if !ab.allow(now) {
+			return false, "per_agent"
+		}
+	}
+
+	return true, ""
+}
+
+// Reset clears all state (for testing).
+func (rl *RateLimiter) Reset() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := rl.nowFunc()
+	rl.perAgent = make(map[string]*bucket)
+	rl.global = newBucket(rl.globalRPM, rl.burstMultiple, now)
+}

--- a/cmd/cortex-gateway/internal/guardrails/ratelimit_test.go
+++ b/cmd/cortex-gateway/internal/guardrails/ratelimit_test.go
@@ -1,0 +1,167 @@
+package guardrails
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_AllowBasic(t *testing.T) {
+	rl := NewRateLimiter(60, 600, 2) // 60/min per agent, 600/min global
+	ok, reason := rl.Allow("AGENT-01")
+	if !ok {
+		t.Fatalf("expected allowed, got denied: %s", reason)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestRateLimiter_PerAgentLimit(t *testing.T) {
+	// 20 calls/min = ~0.333/sec, burst=2 → max=0.666 tokens
+	// So with burst=2 the bucket starts with max=0.666 which rounds to allow 0 burst calls after initial.
+	// Use higher limit to make test deterministic.
+	rl := NewRateLimiter(60, 6000, 1) // 1 call/sec, burst=1 → max=1
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	// First call: consumes the 1 token
+	ok, _ := rl.Allow("AGENT-01")
+	if !ok {
+		t.Fatal("first call should be allowed")
+	}
+
+	// Second call at same instant: should be denied (per_agent)
+	ok, reason := rl.Allow("AGENT-01")
+	if ok {
+		t.Fatal("second call at same time should be rate-limited")
+	}
+	if reason != "per_agent" {
+		t.Fatalf("expected per_agent reason, got %q", reason)
+	}
+
+	// Different agent should still be allowed
+	ok, _ = rl.Allow("AGENT-02")
+	if !ok {
+		t.Fatal("different agent should be allowed")
+	}
+}
+
+func TestRateLimiter_GlobalLimit(t *testing.T) {
+	rl := NewRateLimiter(600, 60, 1) // per-agent high, global 1/sec, burst=1
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	// First call: allowed (consumes global token)
+	ok, _ := rl.Allow("AGENT-01")
+	if !ok {
+		t.Fatal("first call should be allowed")
+	}
+
+	// Second call: global depleted
+	ok, reason := rl.Allow("AGENT-02")
+	if ok {
+		t.Fatal("second call should be globally rate-limited")
+	}
+	if reason != "global" {
+		t.Fatalf("expected global reason, got %q", reason)
+	}
+}
+
+func TestRateLimiter_TokenRefill(t *testing.T) {
+	rl := NewRateLimiter(60, 6000, 1) // 1/sec, burst=1
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	// Exhaust
+	rl.Allow("AGENT-01")
+	ok, _ := rl.Allow("AGENT-01")
+	if ok {
+		t.Fatal("should be rate-limited after exhaustion")
+	}
+
+	// Advance time by 1.5 seconds → refill > 1 token
+	now = now.Add(1500 * time.Millisecond)
+	ok, _ = rl.Allow("AGENT-01")
+	if !ok {
+		t.Fatal("should be allowed after token refill")
+	}
+}
+
+func TestRateLimiter_BurstMultiple(t *testing.T) {
+	rl := NewRateLimiter(60, 6000, 3) // 1/sec, burst=3 → max=3
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	// Should allow 3 calls (burst=3)
+	for i := 0; i < 3; i++ {
+		ok, _ := rl.Allow("AGENT-01")
+		if !ok {
+			t.Fatalf("call %d should be allowed with burst=3", i+1)
+		}
+	}
+
+	// 4th should be denied
+	ok, _ := rl.Allow("AGENT-01")
+	if ok {
+		t.Fatal("4th call should be denied")
+	}
+}
+
+func TestRateLimiter_EmptyAgentID(t *testing.T) {
+	rl := NewRateLimiter(60, 6000, 2)
+	// Empty agent ID should skip per-agent check, only global applies
+	ok, _ := rl.Allow("")
+	if !ok {
+		t.Fatal("empty agent ID should be allowed (global only)")
+	}
+}
+
+func TestRateLimiter_Reset(t *testing.T) {
+	rl := NewRateLimiter(60, 6000, 1)
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	rl.Allow("AGENT-01")
+	rl.Allow("AGENT-01") // depleted
+
+	rl.Reset()
+
+	ok, _ := rl.Allow("AGENT-01")
+	if !ok {
+		t.Fatal("should be allowed after reset")
+	}
+}
+
+func TestRateLimiter_Concurrent(t *testing.T) {
+	rl := NewRateLimiter(600, 6000, 10)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rl.Allow("AGENT-01")
+		}()
+	}
+	wg.Wait()
+	// No race conditions = pass
+}
+
+func TestRateLimiter_DefaultBurstMultiple(t *testing.T) {
+	rl := NewRateLimiter(60, 6000, 0) // 0 should default to 2
+	now := time.Now()
+	rl.nowFunc = func() time.Time { return now }
+
+	// burst=2 → max=2
+	ok1, _ := rl.Allow("AGENT-01")
+	ok2, _ := rl.Allow("AGENT-01")
+	if !ok1 || !ok2 {
+		t.Fatal("both calls should be allowed with default burst=2")
+	}
+
+	ok3, _ := rl.Allow("AGENT-01")
+	if ok3 {
+		t.Fatal("3rd call should be denied with burst=2")
+	}
+}

--- a/cmd/cortex-gateway/internal/proxy/claude.go
+++ b/cmd/cortex-gateway/internal/proxy/claude.go
@@ -163,6 +163,8 @@ func (p *ClaudeProvider) Send(ctx context.Context, req *LLMRequest) (*LLMRespons
 		Content:      content,
 		Model:        cResp.Model,
 		TokensUsed:   cResp.Usage.InputTokens + cResp.Usage.OutputTokens,
+		InputTokens:  cResp.Usage.InputTokens,
+		OutputTokens: cResp.Usage.OutputTokens,
 		FinishReason: cResp.StopReason,
 	}, nil
 }

--- a/cmd/cortex-gateway/internal/proxy/ollama.go
+++ b/cmd/cortex-gateway/internal/proxy/ollama.go
@@ -139,6 +139,8 @@ func (p *OllamaProvider) Send(ctx context.Context, req *LLMRequest) (*LLMRespons
 		Content:      oResp.Message.Content,
 		Model:        oResp.Model,
 		TokensUsed:   oResp.PromptEvalCount + oResp.EvalCount,
+		InputTokens:  oResp.PromptEvalCount,
+		OutputTokens: oResp.EvalCount,
 		FinishReason: oResp.DoneReason,
 	}, nil
 }

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -223,12 +223,10 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ph.updateBreakerGauge(providerName, breaker)
 
 	// --- Step 3b: Guardrails Check ---
-	if ph.guardrails != nil {
-		var rejected bool
-		provider, providerName, rejected = ph.applyGuardrails(w, &req, snap.MaxTokens, provider, providerName)
-		if rejected {
-			return
-		}
+	var guardrailsRejected bool
+	provider, providerName, guardrailsRejected = ph.applyGuardrails(w, &req, snap.MaxTokens, provider, providerName)
+	if guardrailsRejected {
+		return
 	}
 
 	// --- Step 4: Config-Werte anwenden ---
@@ -348,7 +346,11 @@ func (ph *PipelineHandler) buildSystemPrompt(req *LLMRequest, agentName, agentRo
 
 // applyGuardrails runs rate-limit and budget checks. Returns the (possibly replaced)
 // provider/name and whether the request was rejected (HTTP 429 already sent).
+// Safe to call when guardrails is nil (returns inputs unchanged).
 func (ph *PipelineHandler) applyGuardrails(w http.ResponseWriter, req *LLMRequest, maxTokens int, provider Provider, providerName string) (Provider, string, bool) {
+	if ph.guardrails == nil {
+		return provider, providerName, false
+	}
 	agentID := req.Metadata["agent_id"]
 	result := ph.guardrails.Check(agentID, maxTokens)
 	if result.RateLimited {

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/capability"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/compiler"
+	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/guardrails"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/detection"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/eventstore"
@@ -64,8 +65,9 @@ type PipelineConfig struct {
 	Capabilities     *capability.ProviderCapabilities
 	Logger           *slog.Logger
 	BreakerCfg       BreakerConfig
-	EventStore       *eventstore.Store // optional: nil disables event persistence
-	ProviderDeadline time.Duration     // 0 = defaultProviderDeadline (20s)
+	EventStore       *eventstore.Store    // optional: nil disables event persistence
+	Guardrails       *guardrails.Enforcer // optional: nil disables guardrails
+	ProviderDeadline time.Duration        // 0 = defaultProviderDeadline (20s)
 }
 
 // ProviderDeadlineFromEnv liest die Provider-Deadline aus ENV.
@@ -92,6 +94,7 @@ type PipelineHandler struct {
 	caps             *capability.ProviderCapabilities
 	logger           *slog.Logger
 	eventStore       *eventstore.Store
+	guardrails       *guardrails.Enforcer
 	providerDeadline time.Duration
 
 	breakerMu  sync.RWMutex
@@ -125,6 +128,7 @@ func NewPipelineHandler(cfg PipelineConfig) *PipelineHandler {
 		caps:             cfg.Capabilities,
 		logger:           cfg.Logger,
 		eventStore:       cfg.EventStore,
+		guardrails:       cfg.Guardrails,
 		providerDeadline: deadline,
 		breakers:         make(map[string]*CircuitBreaker),
 		breakerCfg:       cfg.BreakerCfg,
@@ -218,6 +222,22 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ph.updateBreakerGauge(providerName, breaker)
 
+	// --- Step 3b: Guardrails Check ---
+	if ph.guardrails != nil {
+		agentID := req.Metadata["agent_id"]
+		result := ph.guardrails.Check(agentID, snap.MaxTokens)
+		if result.RateLimited {
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		if result.BudgetExhausted && result.FallbackProvider != "" {
+			if fbProvider, ok := ph.registry.Get(result.FallbackProvider); ok {
+				provider = fbProvider
+				providerName = result.FallbackProvider
+			}
+		}
+	}
+
 	// --- Step 4: Config-Werte anwenden ---
 	req.Temperature = snap.Temperature
 	if snap.MaxTokens > 0 {
@@ -259,6 +279,11 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 		http.Error(w, "provider request failed", http.StatusBadGateway)
 		return
+	}
+
+	// --- Step 6b: Guardrails Record ---
+	if ph.guardrails != nil {
+		ph.guardrails.Record(providerName, resp.InputTokens, resp.OutputTokens)
 	}
 
 	// --- Step 7: Fourth-Wall Detection ---

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -224,17 +224,10 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// --- Step 3b: Guardrails Check ---
 	if ph.guardrails != nil {
-		agentID := req.Metadata["agent_id"]
-		result := ph.guardrails.Check(agentID, snap.MaxTokens)
-		if result.RateLimited {
-			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		var rejected bool
+		provider, providerName, rejected = ph.applyGuardrails(w, &req, snap.MaxTokens, provider, providerName)
+		if rejected {
 			return
-		}
-		if result.BudgetExhausted && result.FallbackProvider != "" {
-			if fbProvider, ok := ph.registry.Get(result.FallbackProvider); ok {
-				provider = fbProvider
-				providerName = result.FallbackProvider
-			}
 		}
 	}
 
@@ -351,6 +344,23 @@ func (ph *PipelineHandler) buildSystemPrompt(req *LLMRequest, agentName, agentRo
 		return ph.compiler.Compile(modelKey, agentName, agentRole, perception)
 	}
 	return ""
+}
+
+// applyGuardrails runs rate-limit and budget checks. Returns the (possibly replaced)
+// provider/name and whether the request was rejected (HTTP 429 already sent).
+func (ph *PipelineHandler) applyGuardrails(w http.ResponseWriter, req *LLMRequest, maxTokens int, provider Provider, providerName string) (Provider, string, bool) {
+	agentID := req.Metadata["agent_id"]
+	result := ph.guardrails.Check(agentID, maxTokens)
+	if result.RateLimited {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return nil, "", true
+	}
+	if result.BudgetExhausted && result.FallbackProvider != "" {
+		if fbProvider, ok := ph.registry.Get(result.FallbackProvider); ok {
+			return fbProvider, result.FallbackProvider, false
+		}
+	}
+	return provider, providerName, false
 }
 
 // resolveProvider holt den Provider nach Name, mit Fallback auf Primary.

--- a/cmd/cortex-gateway/internal/proxy/provider.go
+++ b/cmd/cortex-gateway/internal/proxy/provider.go
@@ -26,6 +26,8 @@ type LLMResponse struct {
 	Content      string `json:"content"`
 	Model        string `json:"model"`
 	TokensUsed   int    `json:"tokens_used"`
+	InputTokens  int    `json:"input_tokens"`
+	OutputTokens int    `json:"output_tokens"`
 	FinishReason string `json:"finish_reason"`
 }
 

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/capability"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/compiler"
+	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/guardrails"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/eventstore"
 	"github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/extraction"
@@ -94,7 +95,22 @@ func main() {
 		logger.Info("event store disabled (SENTINEL_CORTEX_EVENT_STORE_PATH not set)")
 	}
 
-	// 4c. Observatory (optional, enabled via config or SENTINEL_OBSERVATORY env)
+	// 4c. Guardrails (optional, enabled via SENTINEL_GUARDRAILS_ENABLED)
+	var guardrailsEnforcer *guardrails.Enforcer
+	guardrailsCfg := guardrails.ConfigFromEnv()
+	if guardrailsCfg.Enabled {
+		guardrailsEnforcer = guardrails.New(guardrailsCfg)
+		logger.Info("guardrails enabled",
+			"rate_agent_rpm", guardrailsCfg.RateLimitPerAgent,
+			"rate_global_rpm", guardrailsCfg.RateLimitGlobal,
+			"budget_hourly", guardrailsCfg.BudgetHourlyTokens,
+			"budget_daily", guardrailsCfg.BudgetDailyTokens,
+		)
+	} else {
+		logger.Info("guardrails disabled (SENTINEL_GUARDRAILS_ENABLED not set)")
+	}
+
+	// 4d. Observatory (optional, enabled via config or SENTINEL_OBSERVATORY env)
 	var obsHandler *observatory.Handler
 	obsConfigPath := envOrDefault("SENTINEL_OBSERVATORY_CONFIG", "config/observatory.toml")
 	obsCfg, obsErr := observatory.LoadConfig(obsConfigPath)
@@ -126,6 +142,7 @@ func main() {
 		Logger:           logger,
 		BreakerCfg:       proxy.BreakerConfigFromEnv(),
 		EventStore:       evStore,
+		Guardrails:       guardrailsEnforcer,
 		ProviderDeadline: providerDeadline,
 	})
 
@@ -148,7 +165,13 @@ func main() {
 	controlPlane := control.NewPlane(controlConfig, logger)
 	controlMux := controlPlane.Handler()
 
-	// 7b. Register observatory routes on control plane (if enabled)
+	// 7b. Register guardrails routes on control plane (if enabled)
+	if guardrailsEnforcer != nil {
+		guardrailsHandler := guardrails.NewHandler(guardrailsEnforcer)
+		guardrailsHandler.RegisterRoutes(controlMux)
+	}
+
+	// 7c. Register observatory routes on control plane (if enabled)
 	if obsHandler != nil {
 		obsHandler.RegisterRoutes(controlMux)
 	}

--- a/config/cortex-gateway.toml
+++ b/config/cortex-gateway.toml
@@ -34,6 +34,24 @@ enable_cache_ordering = true
 enable_distillation = true
 distillation_max_tokens = 2000
 
+[guardrails]
+# Enable via SENTINEL_GUARDRAILS_ENABLED=true env var
+enabled = false
+budget_hourly_tokens = 5000000   # 5M tokens/hour
+budget_daily_tokens = 50000000   # 50M tokens/day
+rate_limit_per_agent_rpm = 20    # 20 calls/min per agent
+rate_limit_global_rpm = 300      # 300 calls/min global
+burst_multiple = 2
+fallback_provider = "ollama"
+
+[guardrails.provider_prices.claude]
+input_price_per_m_token = 3.0    # USD per 1M input tokens
+output_price_per_m_token = 15.0  # USD per 1M output tokens
+
+[guardrails.provider_prices.ollama]
+input_price_per_m_token = 0.0
+output_price_per_m_token = 0.0
+
 [metrics]
 enabled = true
 path = "/metrics"


### PR DESCRIPTION
## Summary

Add cost and throughput guardrails to the Cortex Gateway to prevent runaway LLM expenses when 54 agents generate 75-300 calls/min. Token-bucket rate limiter, hourly/daily budget tracker, per-provider cost accumulator, and automatic fallback to Ollama when cloud budget is exhausted.

## Changes

- **New `guardrails` package** (8 production files, ~610 lines):
  - `ratelimit.go` — Token-bucket rate limiter with per-agent and global RPM limits
  - `budget.go` — Hourly/daily token budget tracker with automatic window reset
  - `cost.go` — Per-provider cost accumulator (USD per 1M tokens pricing)
  - `fallback.go` — Budget-exhaustion fallback handler (→ Ollama)
  - `enforcer.go` — Facade combining all guardrails: Check() + Record() + Status()
  - `metrics.go` — 5 Prometheus metrics (tokens, cost, rate-limited, budget)
  - `handler.go` — Dashboard endpoint: GET /api/guardrails/status
  - `config.go` — Config with env-based loading (SENTINEL_GUARDRAILS_*)
- **Pipeline integration** (`pipeline.go`): Step 3b (pre-flight Check) + Step 6b (post-call Record)
- **LLMResponse** extended with `InputTokens`/`OutputTokens` for accurate cost tracking
- **main.go**: Guardrails initialization, PipelineConfig wiring, control plane handler registration
- **config/cortex-gateway.toml**: Added [guardrails] section with defaults

## Linked Issues

Closes #59

## Test Plan

- **Static:** `go vet ./...` — 0 issues
- **Unit:** `go test ./internal/guardrails/... -v -count=1` — 46 tests PASS
- **Integration:** `go test ./... -count=1` — all packages PASS (no regressions)
- **Benchmarks:** `go test ./internal/guardrails/... -bench=. -benchmem`

## Benchmarks

| Benchmark | ns/op | B/op | allocs/op |
|-----------|-------|------|-----------|
| BenchmarkRateLimitCheck | 270 | 8 | 1 |
| BenchmarkBudgetCheck | 117 | 0 | 0 |
| BenchmarkCostRecord | 51 | 0 | 0 |
| BenchmarkEnforcerCheck | 464 | 8 | 1 |
| BenchmarkEnforcerRecord | 778 | 0 | 0 |

AC-N1: RateLimitCheck 270ns << 200µs ✅, BudgetCheck 117ns << 500µs ✅, EnforcerCheck 464ns << 500µs ✅

## Evidence (AC Mapping)

| AC | Description | Evidence | Status |
|----|-------------|----------|--------|
| AC-1 | Budget exhaustion triggers fallback | `TestEnforcer_CheckBudgetExhaustedWithFallback`, `TestBudgetTracker_BudgetExhaustionFallback` | ✅ |
| AC-2 | Per-agent + global rate limiting | `TestRateLimiter_PerAgentLimit`, `TestRateLimiter_GlobalLimit`, `TestEnforcer_CheckRateLimited` | ✅ |
| AC-3 | Accurate cost tracking per provider | `TestCostTracker_RecordClaude` ($0.0105), `TestCostTracker_RecordOllamaFree` ($0) | ✅ |
| AC-4 | Prometheus metrics for tokens/cost/rate | `TestMetrics_RecordTokens`, `TestMetrics_RecordCost`, `TestMetrics_RecordRateLimited`, `TestMetrics_UpdateBudgetGauges` | ✅ |
| AC-5 | E2E: 25 calls at limit → some denied | `TestEnforcer_E2E_RateLimitAndFallback` | ✅ |
| AC-N1 | Benchmarks under target latency | RateLimit <200µs, Budget <500µs, Enforcer <500µs | ✅ |

## Checklist

- [x] `go build ./...` compiles without errors
- [x] `go test ./... -count=1` all tests pass (46 new + existing)
- [x] `go vet ./...` no issues
- [x] Benchmarks meet AC-N1 latency targets
- [x] CHANGELOG.md updated
- [x] No breaking changes (Guardrails is optional, nil = disabled)
- [x] No new external dependencies
- [x] LLMResponse InputTokens/OutputTokens populated by both providers