### PR TITLE
ci: NATS infrastructure N1-N3 deploy + verification gate (#109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ target/
 
 # Go
 cmd/cortex-gateway/cortex-gateway
+services/sentinel-nats-bridge/sentinel-nats-bridge
+services/sentinel-judge/sentinel-judge
+deploy/release-manifest.json
 
 # Bun / Node
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `deploy/release-manifest.json` excluded from git via `.gitignore` (generated artifact)
   - Benchmark: manifest generation ~124ms, preflight parsing ~43ms; full preflight well under 5s target
 
+- **NATS Infrastructure Verification Gate N1-N3** (#109)
+  - Deployed nats-server v2.12.4 on deploy-VM: binary + /etc/nats/nats.conf + nats-server.service
+  - Deployed sentinel-nats-bridge: /opt/sentinel/bin/ + sentinel-nats-bridge.service (active, running)
+  - Deployed sentinel-judge: /opt/sentinel/bin/ + sentinel-judge.service (active, running)
+  - Verified: SENTINEL_EVENTS + SENTINEL_JUDGE streams with correct SSOT subjects
+  - Verified: Nats-Msg-Id dedup with 10min window (AC-3)
+  - Verified: Durable consumer resume without data loss (AC-4)
+  - Verified: Bridge latency p50=2.2ms, p95=2.7ms, p99=3.2ms (AC-5, threshold <2s)
+  - Verified: Empty store poll 30s soak — no crash, no busy-loop (AC-N1)
+  - Benchmarks: Batch=50 13737 evt/s, Batch=100 16719 evt/s, Batch=200 9980 evt/s
+
 - **Sentinel Judge: Enterprise Quality Analysis Service** (#26)
   - Bridge unit tests (6 tests: publish, dedup, subject mapping, config defaults, GetEventsSince)
   - Go benchmarks: judge (7), messaging (4), all passing with HeuristicPipeline at ~1µs (target <5ms)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Deployed nats-server v2.12.4 on deploy-VM: binary + /etc/nats/nats.conf + nats-server.service
   - Deployed sentinel-nats-bridge: /opt/sentinel/bin/ + sentinel-nats-bridge.service (active, running)
   - Deployed sentinel-judge: /opt/sentinel/bin/ + sentinel-judge.service (active, running)
+  - Deployed judge.toml to /opt/sentinel/config/judge.toml
   - Verified: SENTINEL_EVENTS + SENTINEL_JUDGE streams with correct SSOT subjects
   - Verified: Nats-Msg-Id dedup with 10min window (AC-3)
   - Verified: Durable consumer resume without data loss (AC-4)
   - Verified: Bridge latency p50=2.2ms, p95=2.7ms, p99=3.2ms (AC-5, threshold <2s)
   - Verified: Empty store poll 30s soak — no crash, no busy-loop (AC-N1)
   - Benchmarks: Batch=50 13737 evt/s, Batch=100 16719 evt/s, Batch=200 9980 evt/s
+  - Added Go binaries and release-manifest.json to .gitignore
 
 - **Sentinel Judge: Enterprise Quality Analysis Service** (#26)
   - Bridge unit tests (6 tests: publish, dedup, subject mapping, config defaults, GetEventsSince)


### PR DESCRIPTION
## Summary
Complete NATS infrastructure verification and deployment. Installed nats-server v2.12.4, deployed sentinel-nats-bridge and sentinel-judge binaries with systemd services on deploy-VM. All 6 ACs verified with live tests.

## Changes
- `.gitignore`: Add Go binaries and `deploy/release-manifest.json`
- `CHANGELOG.md`: Document NATS N1-N3 verification results

## Linked Issues
Closes #109

## Test Plan
- [x] Go unit tests: `go test ./pkg/sentinel-go/...` — 26 tests PASS (eventstore: 5, judge: 16, messaging: 5)
- [x] NATS server v2.12.4 live on VM (systemctl active, JetStream enabled)
- [x] Streams verified: SENTINEL_EVENTS (48K+ msgs, 3 consumers), SENTINEL_JUDGE
- [x] Dedup: 2x publish same Nats-Msg-Id = +1 msg only
- [x] Durable consumer resume: AckFloor persists across restarts
- [x] Latency: p50=2.2ms, p95=2.7ms, p99=3.2ms (threshold < 2s)
- [x] Empty store 30s soak: no crash, no busy-loop

## Benchmarks
| Metric | Value |
|--------|-------|
| Bridge batch_size=50 | 13,737 events/s |
| Bridge batch_size=100 | 16,719 events/s (optimal) |
| Bridge batch_size=200 | 9,980 events/s |
| AppendWithOutbox | 222us/op |
| IdempotentRetry | 73us/op |
| DriftDetector | 94ns/op |
| BuildEventSubject | 198ns/op |

## Evidence (AC Mapping)
| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | NATS laeuft stabil auf VM | PASS | nats-server v2.12.4 active, JetStream 512MB/2GB |
| AC-2 | Streams/Subjects = SSOT | PASS | SENTINEL_EVENTS + SENTINEL_JUDGE match messaging/ pkg |
| AC-3 | Bridge dedupliziert via Nats-Msg-Id | PASS | 2x same ID = +1 message |
| AC-4 | Durable Consumer resume nach Restart | PASS | AckFloor=10 persists, NumPending=396 |
| AC-5 | Bridge-Latenz p95 < 2s | PASS | p95=2.7ms |
| AC-N1 | Leerer Stream = kein Crash | PASS | 30s soak, 30 polls, stable |

## Checklist
- [x] Tests pass (`go test ./pkg/sentinel-go/...`)
- [x] All ACs verified with live evidence
- [x] CHANGELOG.md updated
- [x] Conventional commit messages
- [x] No secrets committed