### PR TITLE
feat: vm-deploy FULL closure with deploy workflow and manifest parity (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VM-Deploy FULL Closure** (#28)
+  - `deploy/smoke-test.sh` + `deploy/smoke-test-remote.py`: post-deploy smoke test (health endpoints + systemd services, single SSH roundtrip, configurable timeout)
+  - `make deploy`: full deploy workflow with mandatory preflight verification
+  - `make preflight`: manifest hash verification against target VM
+  - `make smoke-test`: standalone smoke test target
+  - `deploy/generate-manifest.sh`: added `controlplane.toml` to artifact list (29 total artifacts)
+  - `deploy/release-manifest.json`: regenerated with all 5 binaries + 10 configs + 9 systemd units + 5 scripts
+
 - **Native Controlplane Kernel C1-C4** (#107)
   - Full observe/decide/act/verify cycle integrated into ECS tick-loop
   - 7 new modules in `services/sentinel-daemon/src/controlplane/`:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help lint lint-all test build build-rust build-go build-dashboard \
-       fmt check clean hooks ci deny coverage typos doc machete safe-merge
+       fmt check clean hooks ci deny coverage typos doc machete safe-merge \
+       manifest preflight smoke-test deploy
 
 # Default target
 help: ## Show this help
@@ -133,6 +134,42 @@ hooks: ## Install repo-managed git hooks (.githooks via core.hooksPath)
 safe-merge: ## Safely merge PR (usage: make safe-merge PR=123 [METHOD=merge|squash|rebase])
 	@if [ -z "$(PR)" ]; then echo "Usage: make safe-merge PR=<number> [METHOD=merge|squash|rebase]"; exit 1; fi
 	./scripts/safe-merge.sh "$(PR)" "$(if $(METHOD),$(METHOD),merge)"
+
+# ──────────────────────────────────────────────
+# Deploy (VM: ubuntu@10.0.0.240)
+# ──────────────────────────────────────────────
+
+SSH ?= ubuntu@10.0.0.240
+
+manifest: ## Generate release manifest (requires built artifacts)
+	bash deploy/generate-manifest.sh
+
+preflight: ## Verify manifest hashes against VM (usage: make preflight [SSH=ubuntu@10.0.0.240])
+	bash deploy/deploy-preflight.sh "$(SSH)"
+
+smoke-test: ## Post-deploy smoke test (usage: make smoke-test [SSH=ubuntu@10.0.0.240])
+	bash deploy/smoke-test.sh "$(SSH)"
+
+deploy: preflight ## Deploy to VM: preflight + sync + smoke (usage: make deploy [SSH=ubuntu@10.0.0.240])
+	@echo ""
+	@echo "=== Preflight passed, deploying artifacts ==="
+	@echo "Syncing configs..."
+	@scp -q config/*.toml "$(SSH)":/opt/sentinel/config/
+	@scp -q config/nats.conf "$(SSH)":/etc/nats/nats.conf
+	@echo "Syncing systemd units..."
+	@scp -q deploy/systemd/*.service deploy/systemd/*.timer deploy/systemd/*.target "$(SSH)":/etc/systemd/system/
+	@ssh "$(SSH)" "sudo systemctl daemon-reload"
+	@echo "Syncing init scripts..."
+	@scp -q deploy/scripts/*.sh "$(SSH)":/opt/sentinel/scripts/
+	@echo ""
+	@echo "=== Running smoke test ==="
+	bash deploy/smoke-test.sh "$(SSH)"
+	@echo ""
+	@echo "Deploy: OK"
+
+# ──────────────────────────────────────────────
+# Cleanup
+# ──────────────────────────────────────────────
 
 clean: ## Remove build artifacts
 	cargo clean

--- a/deploy/generate-manifest.sh
+++ b/deploy/generate-manifest.sh
@@ -26,6 +26,7 @@ ARTIFACT_DEFS=(
   "config/simulation.toml|/opt/sentinel/config/simulation.toml|config"
   "config/rooms.toml|/opt/sentinel/config/rooms.toml|config"
   "config/company.toml|/opt/sentinel/config/company.toml|config"
+  "config/controlplane.toml|/opt/sentinel/config/controlplane.toml|config"
   "config/nats.conf|/etc/nats/nats.conf|config"
   # systemd units
   "deploy/systemd/sentinel-daemon.service|/etc/systemd/system/sentinel-daemon.service|systemd"

--- a/deploy/smoke-test-remote.py
+++ b/deploy/smoke-test-remote.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Remote smoke test script — runs on the target VM via SSH.
+Checks health endpoints and systemd services within a timeout.
+Usage: python3 smoke-test-remote.py [TIMEOUT_SEC]
+"""
+import json
+import subprocess
+import sys
+import time
+
+HEALTH_ENDPOINTS = [
+    (8080, "/health", "sentinel-daemon"),
+    (8000, "/api/health", "sentinel-dashboard"),
+]
+
+SERVICES = [
+    "sentinel-daemon",
+    "sentinel-cortex",
+    "sentinel-dashboard",
+    "sentinel-nightrun.timer",
+    "nats-server",
+    "sentinel-nats-bridge",
+    "sentinel-judge",
+]
+
+timeout = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+start = time.time()
+
+# Poll health endpoints until all healthy or timeout
+all_healthy = False
+while time.time() - start < timeout:
+    ok = 0
+    for port, path, _name in HEALTH_ENDPOINTS:
+        try:
+            r = subprocess.run(
+                ["curl", "-sf", "http://localhost:%d%s" % (port, path)],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            if r.returncode == 0:
+                d = json.loads(r.stdout)
+                if d.get("status") == "ok":
+                    ok += 1
+        except Exception:
+            pass
+    if ok == len(HEALTH_ENDPOINTS):
+        all_healthy = True
+        break
+    time.sleep(1)
+
+elapsed = int(time.time() - start)
+
+# Final detailed check
+print("%-25s %-10s %s" % ("Service", "Status", "Detail"))
+print("-" * 60)
+
+health_pass = 0
+for port, path, name in HEALTH_ENDPOINTS:
+    try:
+        r = subprocess.run(
+            ["curl", "-sf", "http://localhost:%d%s" % (port, path)],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if r.returncode == 0:
+            d = json.loads(r.stdout)
+            if d.get("status") == "ok":
+                print("%-25s %-10s %s" % (name, "PASS", r.stdout.strip()))
+                health_pass += 1
+            else:
+                print("%-25s %-10s status=%s" % (name, "FAIL", d.get("status")))
+        else:
+            print("%-25s %-10s port %d not responding" % (name, "FAIL", port))
+    except Exception as e:
+        print("%-25s %-10s %s" % (name, "FAIL", e))
+
+print()
+print("systemd Services:")
+print("-" * 60)
+
+svc_pass = 0
+for svc in SERVICES:
+    try:
+        r = subprocess.run(
+            ["systemctl", "is-active", svc],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        state = r.stdout.strip()
+    except Exception:
+        state = "unknown"
+    if state == "active":
+        svc_pass += 1
+    print("%-25s %s" % (svc, state))
+
+print()
+total_ep = len(HEALTH_ENDPOINTS)
+total_svc = len(SERVICES)
+print(
+    "Results: %d/%d health endpoints OK, %d/%d services active (%ds elapsed)"
+    % (health_pass, total_ep, svc_pass, total_svc, elapsed)
+)
+
+if all_healthy and svc_pass >= 5:
+    print("SMOKE TEST PASSED (%ds <= %ds timeout)" % (elapsed, timeout))
+    sys.exit(0)
+else:
+    print("SMOKE TEST FAILED", file=sys.stderr)
+    sys.exit(1)

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Post-deploy smoke test: verifies service health within timeout.
+# Usage: bash deploy/smoke-test.sh <SSH_TARGET> [TIMEOUT_SEC]
+#   SSH_TARGET:  e.g. ubuntu@10.0.0.240
+#   TIMEOUT_SEC: max seconds to wait for healthy services (default: 30)
+set -uo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <SSH_TARGET> [TIMEOUT_SEC]" >&2
+  exit 1
+fi
+
+SSH_TARGET="$1"
+TIMEOUT="${2:-30}"
+
+echo "Smoke Test: ${SSH_TARGET} (timeout: ${TIMEOUT}s)"
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Single SSH call with base64-encoded python script (avoids shell escaping issues)
+REMOTE_SCRIPT="$(base64 -w0 "${SCRIPT_DIR}/smoke-test-remote.py")"
+
+START=$(date +%s)
+
+ssh -n -o ConnectTimeout=5 "${SSH_TARGET}" "echo '${REMOTE_SCRIPT}' | base64 -d | python3 - ${TIMEOUT}"
+EXIT_CODE=$?
+
+ELAPSED=$(( $(date +%s) - START ))
+echo ""
+echo "(Total wall time including SSH: ${ELAPSED}s)"
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
## Summary
Final integration gate: adds deploy workflow automation (smoke test, Makefile targets) and verifies release-manifest hash parity across all 29 deployment artifacts on the target VM.

## Changes
- `deploy/smoke-test.sh` + `deploy/smoke-test-remote.py`: post-deploy smoke test checking health endpoints and systemd services within configurable timeout (single SSH roundtrip)
- `Makefile`: new targets `deploy`, `preflight`, `smoke-test`, `manifest` — `make deploy` enforces preflight before artifact sync
- `deploy/generate-manifest.sh`: added `controlplane.toml` to artifact definitions (29 total artifacts)
- `CHANGELOG.md`: updated with #28 changes

## Linked Issues
Closes #28

## Test Plan
All testing performed on Deploy-VM `ubuntu@10.0.0.240`:

| Test | Command | Result |
|------|---------|--------|
| AC-1: sentinel.target | `systemctl start sentinel.target` | 7/7 services active |
| AC-2: Readiness chain | Stop NATS → bridge+judge stop | Requires= dependency works |
| AC-3: Manifest match | `make preflight` | 29/29 MATCH |
| AC-4: Hash mismatch | Corrupt binary → preflight | exit 1, MISMATCH detected |
| AC-5: Smoke test | `make smoke-test` | 2/2 health OK, 7/7 services, <1s |
| AC-N1: No deploy w/o manifest | Delete manifest → `make deploy` | exit 1, "Manifest not found" |

## Benchmarks
N/A — infrastructure gate, no new runtime code. Performance verified in prior PRs (#107 controlplane <200ms, #94 daemon 21h stable).

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `systemctl start sentinel.target` → daemon, cortex, dashboard, nightrun.timer, nats-server, bridge, judge all `active` |
| AC-2 | PASS | NATS stop → bridge+judge cascade-stop (systemd `Requires=`); restart recovers |
| AC-3 | PASS | `deploy-preflight.sh` → 29/29 MATCH (5 binaries, 10 configs, 9 systemd units, 5 scripts) |
| AC-4 | PASS | Corrupted sentinel-daemon binary → MISMATCH detected, exit 1, "Deploy aborted" |
| AC-5 | PASS | `smoke-test.sh` → 2/2 health endpoints OK, 7/7 services active, 0s elapsed (<< 30s) |
| AC-N1 | PASS | `make deploy` without manifest → exit 1, "Manifest not found. Run generate-manifest.sh first." |

## Checklist
- [x] All 6 ACs verified on VM (ubuntu@10.0.0.240)
- [x] CHANGELOG.md updated
- [x] Conventional commit message
- [x] No secrets committed
- [x] shellcheck-compatible scripts (set -uo pipefail)