### PR TITLE
docs: correct eBPF probe overhead with measured benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Daemon-Binary wird jetzt mit `--features ebpf` gebaut
   - CI prueft eBPF-Feature-Kompilierung (Clippy + Tests)
   - Kernel-Probes (fentry/vfs_write, tcp_connect, tcp_close) wieder aktiv
+  - Probe-Overhead gemessen: ~540ns/hit (vorher unbelegte ~50ns Behauptung korrigiert)
+  - Collection Cycle: ~333us fuer 109 Cgroups, 0 Ring Buffer Drops, 0.007% CPU
 
 ### Added
 

--- a/crates/sentinel-ebpf/src/lib.rs
+++ b/crates/sentinel-ebpf/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Monitoring Modes
 //!
 //! - **Kernel mode** (`ebpf` feature + `CAP_BPF`): fentry probes, Per-CPU Hash Maps,
-//!   Ring Buffer. Near-zero overhead (~50ns per probe hit).
+//!   Ring Buffer. Near-zero overhead (~540ns per probe hit, measured on 6.17 kernel).
 //! - **Userspace mode** (fallback): /proc/{pid}/io polling, cgroup io.stat,
 //!   Cortex Gateway metrics scraping. Higher overhead (~10ms per cycle).
 //!

--- a/crates/sentinel-ebpf/src/loader.rs
+++ b/crates/sentinel-ebpf/src/loader.rs
@@ -10,9 +10,9 @@ use tracing::{info, warn};
 /// Monitoring mode determined at startup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum MonitoringMode {
-    /// eBPF probes loaded in kernel. Near-zero overhead.
+    /// eBPF probes loaded in kernel. ~540ns per probe hit, ~333us collection cycle.
     Kernel,
-    /// Userspace fallback. Reads /proc and cgroup files. Higher overhead (~10ms).
+    /// Userspace fallback. Reads /proc and cgroup files. ~10ms per collection cycle.
     Userspace,
 }
 


### PR DESCRIPTION
## Summary

Corrects unbacked ~50ns/hit performance claim in sentinel-ebpf docs with measured values from production VM.

## Changes

- `crates/sentinel-ebpf/src/lib.rs`: ~50ns → ~540ns (measured median)
- `crates/sentinel-ebpf/src/loader.rs`: Added measured cycle time to doc comment
- `CHANGELOG.md`: Added benchmark results to #139 entry

## Linked Issues

Closes #139

## Test Plan

- [x] `cargo clippy --workspace` green
- [x] `cargo clippy -p sentinel-daemon -p sentinel-ebpf --features ebpf` green
- [x] Doc-only change, no behavioral impact

## Benchmarks

**30s measurement on production VM, kernel 6.17.0-14-generic, 109 tracked cgroups:**

```
Probe                                      Runs/s   ns/hit    JIT     Total ns
---------------------------------------------------------------------------
agent_health (fentry/vfs_write)              86.0    673.6   73B    1,737,802
io_profile (tracepoint/block_rq)             36.6    229.2  388B      251,923
tcp_connect (fentry/tcp_connect)              0.1   1476.0  131B        2,952
tcp_close (fentry/tcp_close)                  0.7    445.5   77B        9,801
---------------------------------------------------------------------------
TOTAL                                       123.4    540.8          2,002,478

Collection Cycle:     312-350 us (Median: ~333 us)
Ring Buffer Drops:    0
Tracked Cgroups:      109
Daemon CPU:           2.6% (stable, no increase)
Total probe CPU:      0.007% (66.7 us/sec)
vs. userspace:        ~150x less overhead
```

**Method:** `sysctl kernel.bpf_stats_enabled=1`, `bpftool prog show -j` (run_cnt, run_time_ns delta over 30s)

## Evidence (AC Mapping)

| AC-1 | Kernel mode active | `journalctl -u sentinel-daemon \| grep ebpf` |
|------|-------------------|----------------------------------------------|
| | | `eBPF monitoring mode: kernel (probes loaded) btf=true cap_bpf=true kernel=6.17.0-14-generic` |

| AC-2 | Probes loaded | `journalctl -u sentinel-daemon \| grep fentry` |
|------|--------------|------------------------------------------------|
| | | `Attached fentry/vfs_write`, `Attached tracepoint/block:block_rq_complete`, `Attached fentry/tcp_connect`, `Attached fentry/tcp_close` |

| AC-3 | CI eBPF steps pass | PR #155 CI run |
|------|--------------------|----------------|
| | | `Clippy (eBPF feature)` PASS, `Tests (eBPF feature)` PASS |

```bash
# Benchmark method
ssh ubuntu@10.0.0.240 "sudo sysctl kernel.bpf_stats_enabled=1"
ssh ubuntu@10.0.0.240 "sudo bpftool prog show id 228 -j"  # run_cnt, run_time_ns
# Wait 30s
ssh ubuntu@10.0.0.240 "sudo bpftool prog show id 228 -j"  # delta = per-probe stats
ssh ubuntu@10.0.0.240 "sudo sysctl kernel.bpf_stats_enabled=0"
```

## Checklist

- [x] Doc comments updated with measured values
- [x] CHANGELOG updated
- [x] Clippy clean (workspace + ebpf feature)
- [x] No behavioral changes
- [x] Benchmark methodology documented