### PR TITLE
fix: correct snapshot last_event_id and add periodic snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Periodischer Runtime-Snapshot alle 600 Ticks (~10 Minuten) im Daemon Tick-Loop
   - Vorher: 2.9M Events, alle 11 Snapshots mit `last_event_id = 0` → Full-Replay bei Recovery
   - Nachher: Snapshots referenzieren korrekte Event-Position, Recovery ab letztem Snapshot
+  - Projection Worker: Legacy-Event-Fallback fuer Events ohne `"type"` Discriminator-Tag
+  - Alte Events mit abweichenden Feldnamen (`target` → `target_room`) werden korrekt remapped
 
 - **eBPF Kernel-Modus Regression** (#139)
   - Daemon-Binary wird jetzt mit `--features ebpf` gebaut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Event Snapshots: last_event_id Fix + periodischer Snapshot** (#150)
+  - `save_state()` speichert jetzt `max_event_rowid()` statt hardcoded `0` als `last_event_id`
+  - Periodischer Runtime-Snapshot alle 600 Ticks (~10 Minuten) im Daemon Tick-Loop
+  - Vorher: 2.9M Events, alle 11 Snapshots mit `last_event_id = 0` → Full-Replay bei Recovery
+  - Nachher: Snapshots referenzieren korrekte Event-Position, Recovery ab letztem Snapshot
+
 - **eBPF Kernel-Modus Regression** (#139)
   - Daemon-Binary wird jetzt mit `--features ebpf` gebaut
   - CI prueft eBPF-Feature-Kompilierung (Clippy + Tests)

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -148,6 +148,8 @@ pub enum DomainEventPayload {
         name: String,
         role: String,
         shift_set: u8,
+        /// Raum-ID bei Spawn. Alte Events (vor room_id-Einfuehrung) haben Default "".
+        #[serde(default)]
         room_id: String,
     },
     /// Agent wurde aus der Runtime entfernt

--- a/crates/sentinel-projection/src/worker.rs
+++ b/crates/sentinel-projection/src/worker.rs
@@ -175,17 +175,24 @@ impl ProjectionWorker {
         let mut processed = 0usize;
 
         for (row_id, event) in batch {
-            // Payload deserialisieren
+            // Payload deserialisieren (mit Fallback fuer alte Events ohne "type" Tag)
             let payload: DomainEventPayload = match serde_json::from_str(&event.payload) {
                 Ok(p) => p,
-                Err(e) => {
-                    warn!(
-                        row_id,
-                        event_type = event.event_type,
-                        error = %e,
-                        "Unknown or malformed event payload, skipping"
-                    );
-                    continue;
+                Err(_first_err) => {
+                    // Fallback: Alte Events (vor serde tag="type") haben kein "type" Feld.
+                    // Wir injizieren den Tag aus event.event_type (DB-Spalte).
+                    match deserialize_legacy_payload(&event.event_type, &event.payload) {
+                        Some(p) => p,
+                        None => {
+                            warn!(
+                                row_id,
+                                event_type = event.event_type,
+                                error = %_first_err,
+                                "Unknown or malformed event payload, skipping"
+                            );
+                            continue;
+                        }
+                    }
                 }
             };
 
@@ -208,4 +215,48 @@ impl ProjectionWorker {
         txn.commit()?;
         Ok(processed)
     }
+}
+
+/// Fallback-Deserializer fuer Legacy-Events (vor `serde(tag = "type")` Einfuehrung).
+///
+/// Alte Events haben kein `"type"` Discriminator-Feld im JSON-Payload.
+/// Diese Funktion mappt `event_type` (DB-Spalte) auf den serde-Tag und
+/// konvertiert abweichende Feldnamen (z.B. `"target"` → `"target_room"`).
+fn deserialize_legacy_payload(event_type: &str, payload: &str) -> Option<DomainEventPayload> {
+    // event_type (DB) → serde tag name Mapping
+    let serde_tag = match event_type {
+        "agent_action_received" => "AgentActionReceived",
+        "transit_started" => "TransitStarted",
+        "transit_completed" => "TransitCompleted",
+        "chaos_triggered" => "ChaosTriggered",
+        "bio_action_performed" => "BioActionPerformed",
+        "bio_state_updated" => "BioStateUpdated",
+        "room_physics_updated" => "RoomPhysicsUpdated",
+        "tick_snapshot" => "TickSnapshot",
+        "agent_spawned" => "AgentSpawned",
+        "agent_despawned" => "AgentDespawned",
+        _ => return None,
+    };
+
+    // JSON parsen, Tag injizieren, Legacy-Felder remappen
+    let mut value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let obj = value.as_object_mut()?;
+
+    // Discriminator-Tag setzen
+    obj.insert("type".to_string(), serde_json::Value::String(serde_tag.to_string()));
+
+    // Legacy-Feld-Remapping fuer agent_action_received
+    if event_type == "agent_action_received" {
+        // "target" → "target_room"
+        if let Some(target) = obj.remove("target") {
+            obj.entry("target_room".to_string()).or_insert(target);
+        }
+        // "emotion" existierte in alten Events, wird ignoriert (nicht im Struct)
+        obj.remove("emotion");
+        // agent_id fehlte in alten Events → Default 0
+        obj.entry("agent_id".to_string())
+            .or_insert(serde_json::Value::Number(0.into()));
+    }
+
+    serde_json::from_value(value).ok()
 }

--- a/crates/sentinel-projection/src/worker.rs
+++ b/crates/sentinel-projection/src/worker.rs
@@ -243,7 +243,10 @@ fn deserialize_legacy_payload(event_type: &str, payload: &str) -> Option<DomainE
     let obj = value.as_object_mut()?;
 
     // Discriminator-Tag setzen
-    obj.insert("type".to_string(), serde_json::Value::String(serde_tag.to_string()));
+    obj.insert(
+        "type".to_string(),
+        serde_json::Value::String(serde_tag.to_string()),
+    );
 
     // Legacy-Feld-Remapping fuer agent_action_received
     if event_type == "agent_action_received" {

--- a/crates/sentinel-runtime/src/lib.rs
+++ b/crates/sentinel-runtime/src/lib.rs
@@ -423,10 +423,12 @@ impl RuntimeOrchestrator {
 
         let json = serde_json::to_string(&snapshot)?;
 
-        store.save_snapshot(RUNTIME_AGGREGATE, RUNTIME_SNAPSHOT_TYPE, &json, 0)?;
+        let last_event_id = store.max_event_rowid().unwrap_or(0);
+        store.save_snapshot(RUNTIME_AGGREGATE, RUNTIME_SNAPSHOT_TYPE, &json, last_event_id)?;
 
         tracing::info!(
             agent_count = self.agents.len(),
+            last_event_id,
             "Runtime state snapshot saved"
         );
 

--- a/crates/sentinel-runtime/src/lib.rs
+++ b/crates/sentinel-runtime/src/lib.rs
@@ -424,7 +424,12 @@ impl RuntimeOrchestrator {
         let json = serde_json::to_string(&snapshot)?;
 
         let last_event_id = store.max_event_rowid().unwrap_or(0);
-        store.save_snapshot(RUNTIME_AGGREGATE, RUNTIME_SNAPSHOT_TYPE, &json, last_event_id)?;
+        store.save_snapshot(
+            RUNTIME_AGGREGATE,
+            RUNTIME_SNAPSHOT_TYPE,
+            &json,
+            last_event_id,
+        )?;
 
         tracing::info!(
             agent_count = self.agents.len(),

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -603,7 +603,10 @@ fn ecs_tick_loop(
             if let Err(e) = runtime_orch.save_state() {
                 warn!(error = %e, tick = tick_count, "Periodischer Snapshot fehlgeschlagen");
             } else {
-                info!(tick = tick_count, "Periodischer Runtime-Snapshot gespeichert");
+                info!(
+                    tick = tick_count,
+                    "Periodischer Runtime-Snapshot gespeichert"
+                );
             }
         }
 

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -598,6 +598,15 @@ fn ecs_tick_loop(
             episode_producer.tick(&event_store_for_episodes, tick_count, tick_rate_s);
         }
 
+        // Periodischer Runtime-Snapshot (alle 600 Ticks = ~10 Minuten bei 1s Tick-Rate)
+        if tick_count > 0 && tick_count.is_multiple_of(600) {
+            if let Err(e) = runtime_orch.save_state() {
+                warn!(error = %e, tick = tick_count, "Periodischer Snapshot fehlgeschlagen");
+            } else {
+                info!(tick = tick_count, "Periodischer Runtime-Snapshot gespeichert");
+            }
+        }
+
         tick_count += 1;
 
         if tick_count.is_multiple_of(60) {


### PR DESCRIPTION
## Summary

Fixes hardcoded `last_event_id = 0` in `save_state()`, adds periodic runtime snapshots every 10 minutes, and adds a legacy event fallback deserializer + serde defaults in the Projection Worker. Previously all snapshots had `last_event_id = 0`, forcing full replay of 2.9M events. The Projection Worker was also skipping legacy events due to missing `"type"` discriminator tag and missing fields.

## Changes

- **`crates/sentinel-runtime/src/lib.rs`**: `save_state()` now calls `max_event_rowid()` instead of hardcoding `0`
- **`services/sentinel-daemon/src/orchestrator.rs`**: Added periodic snapshot every 600 ticks (~10 min) in daemon tick loop
- **`crates/sentinel-projection/src/worker.rs`**: Added `deserialize_legacy_payload()` fallback for events without `"type"` tag, with field remapping (`target` → `target_room`, `emotion` removed, `agent_id` defaulted)
- **`crates/sentinel-common/src/events.rs`**: Added `#[serde(default)]` on `AgentSpawned.room_id` for backwards compatibility
- **`CHANGELOG.md`**: Added entry for #150

## Linked Issues

Closes #150

## Test Plan

| Ebene | Command | Ergebnis |
|-------|---------|----------|
| Unit | `cargo remote -- test -p sentinel-runtime` | 21 passed, 8 acceptance |
| Unit | `cargo remote -- test -p sentinel-projection` | 4 unit, 5 acceptance |
| Clippy | `cargo remote -- clippy --workspace --all-targets -- -D warnings` | 0 warnings |
| System | Deploy Daemon + Projection auf VM | Snapshot korrekt, 0 Skips |
| Full Rebuild | Projection Offset 0 → 2.9M Events | 0 Skips |

## Benchmarks

Kein Performance-Impact:
- `max_event_rowid()`: Single `SELECT COALESCE(MAX(id), 0) FROM events` (indexed, <1ms)
- Periodischer Snapshot: Serialisiert 24 Agents (~1ms), alle 10 Minuten
- Legacy Fallback: Nur bei Deserialize-Fehler (erster Versuch scheitert → Fallback), O(1) JSON-Manipulation

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `SELECT id, last_event_id FROM snapshots ORDER BY id DESC LIMIT 1` → `23\|2923962` (korrekte Event-Position statt hardcoded 0) |
| AC-2 | PASS | Full Rebuild von Offset 0: 2.9M Events verarbeitet, `grep -icE 'skip\|mismatch'` → **0 Treffer** |
| AC-3 | PASS | Daemon Restart Recovery: 16:25:00.820 → 16:25:01.174 = **~1s** (Requirement: <30s) |
| AC-4 | PASS | `journalctl grep "Periodischer Runtime-Snapshot"` → tick=600, `last_event_id=2923962` |
| AC-5 | PASS | Projection Offset 0 → 2925152 (2.9M Events), 0 Skips. Root Causes: (1) Legacy events ohne `"type"` Tag → Fallback-Deserializer, (2) alte `AgentSpawned` ohne `room_id` → `serde(default)` |
| AC-N1 | PASS | Event count vor/nach Snapshot: nur natuerlicher Zuwachs, kein Verlust |

## Checklist

- [x] Code kompiliert ohne Warnings
- [x] Tests bestehen
- [x] Clippy clean
- [x] CHANGELOG aktualisiert
- [x] Daemon auf VM deployed und verifiziert
- [x] Projection auf VM deployed und verifiziert
- [x] AC-1: Snapshot mit korrekter last_event_id
- [x] AC-2: 0 Skips bei Full Rebuild (2.9M Events)
- [x] AC-3: Recovery ~1s (<30s)
- [x] AC-4: Periodischer Snapshot feuert bei tick=600
- [x] AC-5: Full Rebuild ab Offset 0 ohne Skips
- [x] AC-N1: Kein Datenverlust

🤖 Generated with [Claude Code](https://claude.com/claude-code)