### PR TITLE
fix: include --features ebpf in Makefile release build (#139)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ build-rust: ## Build Rust workspace
 build-rust-remote: ## Build Rust on remote build server
 	cargo remote -- build --workspace
 
-build-rust-release: ## Build Rust release (remote)
-	cargo remote -- build --workspace --release
+build-rust-release: ## Build Rust release (remote, includes eBPF kernel probes)
+	cargo remote -- build --workspace --release --features ebpf
 
 build-go: ## Build Cortex Gateway
 	cd cmd/cortex-gateway && go build -o cortex-gateway ./...

--- a/services/sentinel-daemon/Cargo.toml
+++ b/services/sentinel-daemon/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 uuid = { workspace = true }
 
 [features]
-default = ["llm"]
+default = ["llm", "ebpf"]
 telemetry = ["sentinel-telemetry/telemetry"]
 llm = ["reqwest"]
 ebpf = ["sentinel-ebpf/ebpf"]


### PR DESCRIPTION
## Summary

Two fixes to ensure eBPF kernel probes are always active in deployed binaries:
1. `build-rust-release` Makefile target was missing `--features ebpf`
2. `ebpf` is now a default feature — no manual flag needed anymore

## Changes

- `Makefile`: Added `--features ebpf` to `build-rust-release` target (belt)
- `services/sentinel-daemon/Cargo.toml`: `default = ["llm", "ebpf"]` (suspenders)

## Linked Issues

Closes #139

## Test Plan

| Ebene | Command | Ergebnis |
|-------|---------|----------|
| Build | `cargo remote -- build -p sentinel-daemon --release` (no explicit --features) | OK — ebpf included via default |
| Clippy | `cargo remote -- clippy -p sentinel-daemon -p sentinel-ebpf --all-targets -- -D warnings` | 0 warnings |
| Deploy | Binary deployed to VM 10.0.0.240 | OK |
| System | `journalctl -u sentinel-daemon \| grep ebpf` | Kernel probes loaded |

## Benchmarks

N/A — no performance-critical code changed. eBPF probe overhead was measured in PR #156 (~540ns/hit).

## Evidence (AC Mapping)

| AC | Status | Command | Output |
|----|--------|---------|--------|
| AC-1 | PASS | `ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' \| grep -i 'ebpf mode=kernel\|monitoring mode: kernel'"` | See below |
| AC-2 | PASS | `ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' \| grep -i 'probes loaded\|Attached'"` | See below |
| AC-3 | PASS | `grep 'features ebpf' Makefile services/sentinel-daemon/Cargo.toml` | See below |
| AC-N1 | PASS | `ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' \| grep -ci 'userspace\|fallback'"` | See below |

### AC-1: eBPF Kernel Mode

```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' | grep -i 'monitoring mode: kernel'"
eBPF monitoring mode: kernel (probes loaded) btf=true cap_bpf=true kernel=6.17.0-14-generic
```

### AC-2: Kernel Probes Loaded

```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' | grep -i 'Attached\|probes loaded'"
Attached fentry/vfs_write probe (agent health)
Attached tracepoint/block:block_rq_complete probe (I/O profiling)
Attached fentry/tcp_connect probe (network)
Attached fentry/tcp_close probe (network)
eBPF probes loaded successfully (kernel mode)
```

### AC-3: Build Config

```
$ grep 'features ebpf\|default.*ebpf' Makefile services/sentinel-daemon/Cargo.toml
Makefile: cargo remote -- build --workspace --release --features ebpf
services/sentinel-daemon/Cargo.toml: default = ["llm", "ebpf"]
```

### AC-N1: No Userspace Fallback

```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' | grep -ci 'userspace\|fallback'"
0
```

## Checklist

- [x] Code compiles without warnings
- [x] Binary deployed and verified on VM
- [x] All ACs verified with evidence
- [x] CHANGELOG already updated (PR #156)
- [x] No regression in existing functionality