### PR TITLE
fix: safe-merge checks only latest run per workflow

### DIFF
--- a/scripts/safe-merge.sh
+++ b/scripts/safe-merge.sh
@@ -81,7 +81,7 @@ for ISSUE in "${LINKED_ISSUES[@]}"; do
   fi
 done
 
-RUNS_JSON="$(gh run list -R "$REPO" --commit "$PR_SHA" --json name,status,conclusion,event --limit 100)"
+RUNS_JSON="$(gh run list -R "$REPO" --commit "$PR_SHA" --json name,status,conclusion,event,databaseId --limit 100)"
 
 required_workflows=(
   "CI"
@@ -90,15 +90,18 @@ required_workflows=(
 )
 
 for WORKFLOW in "${required_workflows[@]}"; do
-  COUNT="$(printf '%s' "$RUNS_JSON" | jq --arg n "$WORKFLOW" '[.[] | select(.name == $n and .event == "pull_request")] | length')"
-  if [[ "$COUNT" -eq 0 ]]; then
+  # Pick only the most recent run per workflow (highest databaseId = newest)
+  LATEST="$(printf '%s' "$RUNS_JSON" | jq --arg n "$WORKFLOW" \
+    '[.[] | select(.name == $n and .event == "pull_request")] | sort_by(.databaseId) | last')"
+
+  if [[ "$LATEST" == "null" || -z "$LATEST" ]]; then
     echo "ERROR: Required workflow '$WORKFLOW' has no run for this PR head commit."
     exit 1
   fi
 
-  BAD_COUNT="$(printf '%s' "$RUNS_JSON" | jq --arg n "$WORKFLOW" '[.[] | select(.name == $n and .event == "pull_request" and .conclusion != "success")] | length')"
-  if [[ "$BAD_COUNT" -gt 0 ]]; then
-    echo "ERROR: Required workflow '$WORKFLOW' is not successful."
+  CONCLUSION="$(printf '%s' "$LATEST" | jq -r '.conclusion')"
+  if [[ "$CONCLUSION" != "success" ]]; then
+    echo "ERROR: Required workflow '$WORKFLOW' latest run is not successful (conclusion: $CONCLUSION)."
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
Fixes false-negative in `safe-merge.sh` where an older failed workflow run blocked the merge even though the latest run succeeded.

## Changes
- `scripts/safe-merge.sh`: Instead of checking ALL runs per workflow for non-success, now picks only the most recent run (highest `databaseId`) and checks that single run's conclusion.
- Added `databaseId` to the `gh run list` JSON fields for sorting.

## Linked Issues
Closes #162

## Test Plan
- [x] jq logic tested with mock data (old=failure, new=success → passes correctly)
- [x] Edge case: single run per workflow still works (sort+last on array of 1)
- [x] Edge case: no runs → proper error message

## Benchmarks
N/A — shell script, no performance-sensitive code.

## Evidence (AC Mapping)
| AC | Description | Evidence |
|----|-------------|----------|
| AC-1 | Newest run picked | `echo '[{"name":"PQG","event":"pull_request","conclusion":"failure","databaseId":100},{"name":"PQG","event":"pull_request","conclusion":"success","databaseId":200}]' \| jq '[.[] \| select(.name == "PQG")] \| sort_by(.databaseId) \| last \| .conclusion'` → `"success"` |
| AC-2 | Old failure ignored | Same as AC-1: old run (databaseId 100, failure) not checked, only newest (databaseId 200, success) |

```bash
# AC-1 + AC-2: jq picks newest run, ignores old failure
$ echo '[{"name":"PR Quality Gate","event":"pull_request","conclusion":"failure","databaseId":100},{"name":"PR Quality Gate","event":"pull_request","conclusion":"success","databaseId":200}]' | jq --arg n "PR Quality Gate" '[.[] | select(.name == $n and .event == "pull_request")] | sort_by(.databaseId) | last | .conclusion'
"success"
```

## Checklist
- [x] Conventional commit message
- [x] No secrets exposed
- [x] Script tested with mock data