### PR TITLE
fix: load TOML personality into ECS for individualized bio dynamics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Personality aus TOML-Dateien ins ECS laden** (#148)
+  - Root Cause: `spawn_agent()` haertete Default-Personality ein (alle Big Five = 0.5),
+    individuelle TOML-Werte (Conscientiousness, Neuroticism, Caffeine Tolerance etc.)
+    wurden ignoriert — alle Agents im selben Schicht-Set hatten identische Bio-Werte
+  - Neue `apply_personality()` Funktion ueberschreibt Defaults mit TOML-Werten nach Spawn
+  - TOGAF-Konformitaet: TOML = readonly SSOT ("DNA"), Big Five individualisieren Bio-Engine
+
 - **Bio-Engine Dynamics: Stress, Energy, Caffeine reagieren dynamisch** (#148)
   - Root Cause: WorkContext-Flags (`in_meeting`, `has_deadline`, `has_conflict`) wurden NIRGENDS gesetzt,
     Energy hatte keinen Arbeitsdrain, Kaffee wurde nie automatisch getrunken

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -18,8 +18,8 @@ pub use decision::format_impulse_from_queue;
 pub use perception::{format_injection, generate_perception, PerceptionTexts, SmellEvent};
 pub use systems::SimulationPhase;
 pub use world::{
-    attach_redb_store, create_simulation_world, despawn_agent_from_world, spawn_agent,
-    ActionReceiver, EventBuffer, LimboEventStore, PerceptionSender, PersistTelemetry,
+    apply_personality, attach_redb_store, create_simulation_world, despawn_agent_from_world,
+    spawn_agent, ActionReceiver, EventBuffer, LimboEventStore, PerceptionSender, PersistTelemetry,
     RedbStateStore, SimulationTime,
 };
 

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -8,7 +8,8 @@ use super::components::*;
 use super::systems::*;
 use bevy_ecs::prelude::*;
 use sentinel_common::{
-    AgentAction, AgentId, DomainEvent, DomainEventPayload, Emotion, Perception, Tick,
+    agent_config::PersonalityConfig, AgentAction, AgentId, DomainEvent, DomainEventPayload,
+    Emotion, Perception, Tick,
 };
 use sentinel_limbo::EventStore;
 use sentinel_redb::StateStore;
@@ -313,6 +314,22 @@ pub fn spawn_agent(
     }
 
     entity
+}
+
+/// Ueberschreibt die Default-Personality eines gespawnten Agents mit TOML-Werten.
+///
+/// Muss nach `spawn_agent()` aufgerufen werden. Aendert NUR die ECS Personality-Component,
+/// nicht die TOML-Datei (readonly SSOT / "DNA" laut TOGAF-Guide).
+pub fn apply_personality(world: &mut World, entity: Entity, cfg: &PersonalityConfig) {
+    if let Some(mut p) = world.get_mut::<Personality>(entity) {
+        p.openness = cfg.openness;
+        p.conscientiousness = cfg.conscientiousness;
+        p.extraversion = cfg.extraversion;
+        p.agreeableness = cfg.agreeableness;
+        p.neuroticism = cfg.neuroticism;
+        p.caffeine_tolerance = cfg.caffeine_tolerance;
+        p.is_morning_person = cfg.morning_person;
+    }
 }
 
 /// Entfernt einen Agenten aus der ECS World anhand seiner AgentId.

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -24,8 +24,8 @@ use sentinel_common::{AgentId, Perception};
 use sentinel_ebpf::collector::MetricsSnapshot;
 use sentinel_ebpf::EbpfCollector;
 use sentinel_ecs::{
-    attach_redb_store, create_simulation_world, despawn_agent_from_world, spawn_agent,
-    ActionReceiver, EventBuffer, LimboEventStore, PerceptionSender, SimulationTime,
+    apply_personality, attach_redb_store, create_simulation_world, despawn_agent_from_world,
+    spawn_agent, ActionReceiver, EventBuffer, LimboEventStore, PerceptionSender, SimulationTime,
 };
 use sentinel_limbo::EventStore;
 use sentinel_redb::StateStore;
@@ -108,13 +108,14 @@ fn spawn_agent_full(
         }
     }
 
-    spawn_agent(
+    let entity = spawn_agent(
         world,
         agent_id,
         &agent_cfg.identity.name,
         &agent_cfg.identity.role,
         agent_cfg.identity.shift_set,
     );
+    apply_personality(world, entity, &agent_cfg.personality);
     true
 }
 
@@ -462,13 +463,14 @@ fn ecs_tick_loop(
         }
 
         // ECS Entity erstellen
-        spawn_agent(
+        let entity = spawn_agent(
             &mut world,
             agent_id,
             &agent_cfg.identity.name,
             &agent_cfg.identity.role,
             agent_cfg.identity.shift_set,
         );
+        apply_personality(&mut world, entity, &agent_cfg.personality);
     }
 
     // EventBuffer leeren: ECS spawn_agent emittiert eigene Events, aber der


### PR DESCRIPTION
## Summary
Agents within the same shift set had identical bio values because `spawn_agent()` hardcoded default Personality (all Big Five = 0.5). Now loads individual values from AGENT-*.toml files.

## Changes
- `crates/sentinel-ecs/src/world.rs`: New `apply_personality()` helper, overwrites defaults with TOML values
- `crates/sentinel-ecs/src/lib.rs`: Re-export `apply_personality`
- `services/sentinel-daemon/src/orchestrator.rs`: Call `apply_personality()` at both spawn sites
- `CHANGELOG.md`: New entry

## Linked Issues
Partially addresses #148

## Test Plan
- [x] `cargo remote -- test --workspace` — all tests pass (no signature changes, zero breakage)
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — clean
- [x] Deploy + verify on VM 10.0.0.240

## Benchmarks
N/A — no performance-sensitive changes (one-time personality copy at agent spawn)

## Evidence (AC Mapping)
| AC | Description | Evidence |
|----|-------------|----------|
| AC-1 | Individual bio values per agent | Before: all agents in set had energy=24.7. After: Thomas=90.73, Lisa=83.79, Max=91.34, Sophie=81.96, Andreas=84.40 |

```bash
# Before fix (all identical within set):
# agent 1-5: energy=24.7, stress=0.0, caffeine=0.0, hunger=39.6

# After fix (individualized):
$ ssh ubuntu@10.0.0.240 "sqlite3 -header -column /opt/sentinel/data/projection.db \
  \"SELECT agent_id, name, printf('%.2f', energy) as energy FROM agent_live_view \
  WHERE agent_id BETWEEN 1 AND 5 ORDER BY agent_id\""
# agent_id  name            energy
# 1         Thomas Mueller  90.73
# 2         Lisa Brenner    83.79
# 3         Max Richter     91.34
# 4         Sophie Klein    81.96
# 5         Andreas Wolff   84.40
```

## Checklist
- [x] Conventional commit message
- [x] Tests pass
- [x] Clippy clean
- [x] CHANGELOG updated
- [x] Deployed and verified on VM
- [x] TOGAF conformance: TOML = readonly SSOT ("DNA"), Big Five individualize Bio-Engine