### PR TITLE
fix: projection worker auto-restart + legacy deserializer (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Nachher: Snapshots referenzieren korrekte Event-Position, Recovery ab letztem Snapshot
   - Projection Worker: Legacy-Event-Fallback fuer Events ohne `"type"` Discriminator-Tag
   - Alte Events mit abweichenden Feldnamen (`target` → `target_room`) werden korrekt remapped
+  - Projection Worker systemd Unit: `Restart=always` statt `on-failure` (Auto-Restart nach SIGTERM)
+  - Legacy-Deserializer: 6 fehlende Event-Typen hinzugefuegt (ShiftTransitionCompleted,
+    AgentStatusChanged, NightRunStarted/Completed, AgentConsolidated/ConsolidationFailed)
 
 - **eBPF Kernel-Modus Regression** (#139)
   - Daemon-Binary wird jetzt mit `--features ebpf` gebaut

--- a/crates/sentinel-projection/src/worker.rs
+++ b/crates/sentinel-projection/src/worker.rs
@@ -235,6 +235,12 @@ fn deserialize_legacy_payload(event_type: &str, payload: &str) -> Option<DomainE
         "tick_snapshot" => "TickSnapshot",
         "agent_spawned" => "AgentSpawned",
         "agent_despawned" => "AgentDespawned",
+        "shift_transition_completed" => "ShiftTransitionCompleted",
+        "agent_status_changed" => "AgentStatusChanged",
+        "nightrun_started" => "NightRunStarted",
+        "nightrun_completed" => "NightRunCompleted",
+        "agent_consolidated" => "AgentConsolidated",
+        "agent_consolidation_failed" => "AgentConsolidationFailed",
         _ => return None,
     };
 

--- a/deploy/systemd/sentinel-projection.service
+++ b/deploy/systemd/sentinel-projection.service
@@ -10,7 +10,7 @@ WorkingDirectory=/opt/sentinel
 ExecStart=/opt/sentinel/bin/sentinel-projection \
   --event-store /opt/sentinel/data/events.db \
   --projection-db /opt/sentinel/data/projection.db
-Restart=on-failure
+Restart=always
 RestartSec=5
 MemoryMax=512M
 


### PR DESCRIPTION
## Summary
- Projection Worker startet automatisch nach Daemon-Restart (vorher: blieb tot nach SIGTERM)
- Legacy-Deserializer vervollstaendigt mit 6 fehlenden Event-Typen

## Changes
- `deploy/systemd/sentinel-projection.service`: `Restart=on-failure` → `Restart=always`
- `crates/sentinel-projection/src/worker.rs`: 6 fehlende Event-Typen im Legacy-Deserializer
  (ShiftTransitionCompleted, AgentStatusChanged, NightRunStarted/Completed, AgentConsolidated/ConsolidationFailed)
- `CHANGELOG.md`: Eintrag aktualisiert

## Linked Issues
Partially addresses #150

## Test Plan
- `cargo remote -- test -p sentinel-projection` — 5/5 Tests gruen
- `cargo remote -- clippy --workspace --all-targets -- -D warnings` — 0 Warnings
- VM-Deploy + Daemon-Restart-Test (AC-3)
- Projection-Lag auf 0 nach Worker-Restart

## Benchmarks
Kein Performance-Impact — nur Restart-Policy und Deserialisierungs-Coverage.

## Evidence (AC Mapping)

| AC | Kommando | Ergebnis |
|----|----------|----------|
| AC-1 | `sqlite3 events.db 'SELECT count(*) FROM snapshots'` | 144 Snapshots (PASS) |
| AC-2 | `journalctl -u sentinel-projection \| grep -ic 'skip\|mismatch\|unknown'` | 0 (PASS) |
| AC-3 | Daemon restart → Worker auto-restart in 1s, Startup 30ms | < 30s (PASS) |
| AC-N1 | Projection Offset 3,032,383 >= Events 3,032,295 | Lag=0 (PASS) |

## Checklist
- [x] Tests gruen (`cargo remote -- test`)
- [x] Clippy clean (`-D warnings`)
- [x] CHANGELOG aktualisiert
- [x] Auf VM deployed + verifiziert (10.0.0.240)
- [x] Keine Errors/Warnings im Worker-Log nach Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)