### PR TITLE
fix: bio-engine dynamics with time virtualization and sim_hour persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - sim_hour Fortschritt: Daemon aktualisiert jetzt SimulationTime.sim_hour korrekt
     (vorher war sim_hour=8.0 statisch, jetzt schreitet mit Echtzeit voran und wraps 0-24)
 
+- **sim_hour Zeitvirtualisierung + Persistenz** (#148)
+  - Root Cause: `sim_hour = (8.0 + tick_count/3600.0) % 24.0` — tick_count startete bei 0
+    nach jedem Restart, sim_hour war de facto immer ~8.0, Deadline-Druck [14,17) unerreichbar
+  - Fix: sim_hour wird inkrementell berechnet und in redb SIM_META Table persistiert
+  - Neuer `time_scale` Config-Parameter (default 1.0 = Echtzeit, 60.0 = 60x Speedup)
+  - `delta_seconds = tick_rate * time_scale` — entkoppelt Simulationsgeschwindigkeit von Tick-Rate
+  - work_context_system von Phase::Transit nach Phase::Input verschoben (vor bio_system)
+  - sim_hour in Tick Checkpoint Log fuer Observability
+  - `drink_water` Bio-Action hinzugefuegt (+5 Energy, -10 Bladder)
+
 - **Episoden-Pipeline im Daemon reaktiviert** (#137)
   - Root Cause: Cortex Gateway war seit 27.02. inaktiv → keine `agent_action_received` Events
   - Episode Producer Starvation-Diagnostik: Warnt alle 10 leeren Laeufe (~5 Min) wenn keine

--- a/config/daemon.toml
+++ b/config/daemon.toml
@@ -2,6 +2,7 @@
 config_dir = "/opt/sentinel/config"
 data_dir = "/opt/sentinel/data"
 tick_rate_ms = 1000
+time_scale = 1.0
 max_agents = 30
 zenoh_prefix = "sentinel"
 

--- a/crates/sentinel-bio/src/lib.rs
+++ b/crates/sentinel-bio/src/lib.rs
@@ -206,6 +206,12 @@ pub fn eat_meal(bio: &mut BioState) {
     bio.energy = (bio.energy + 15.0).min(100.0);
 }
 
+/// Agent trinkt Wasser: +5 Energie, -10 Blasendrang
+pub fn drink_water(bio: &mut BioState) {
+    bio.energy = (bio.energy + 5.0).min(100.0);
+    bio.bladder = (bio.bladder - 10.0).max(0.0);
+}
+
 /// Agent geht auf Toilette: Blasendrang auf 0
 pub fn use_bathroom(bio: &mut BioState) {
     bio.bladder = 0.0;
@@ -314,6 +320,26 @@ mod tests {
 
         // +10/h → 50 + 10 = 60
         assert_relative_eq!(bio.social_need, 60.0, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_drink_water() {
+        let mut bio = default_bio();
+        bio.energy = 70.0;
+        bio.bladder = 30.0;
+        drink_water(&mut bio);
+        assert_relative_eq!(bio.energy, 75.0, epsilon = 0.01);
+        assert_relative_eq!(bio.bladder, 20.0, epsilon = 0.01);
+    }
+
+    #[test]
+    fn test_drink_water_clamps() {
+        let mut bio = default_bio();
+        bio.energy = 98.0;
+        bio.bladder = 5.0;
+        drink_water(&mut bio);
+        assert_relative_eq!(bio.energy, 100.0, epsilon = 0.01); // Clamped
+        assert_relative_eq!(bio.bladder, 0.0, epsilon = 0.01); // Clamped to 0
     }
 
     #[test]

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -123,6 +123,10 @@ pub fn input_system(
                                 sentinel_bio::use_bathroom(&mut bio);
                                 bio_action = Some("use_bathroom");
                             }
+                            "drink_water" => {
+                                sentinel_bio::drink_water(&mut bio);
+                                bio_action = Some("drink_water");
+                            }
                             _ => {
                                 work_ctx.current_task = Some(content.clone());
                             }

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -177,15 +177,17 @@ pub fn create_simulation_world() -> (World, Schedule) {
     );
 
     // Systems in ihre Sets einsortieren
+    // work_context_system in Input-Phase (VOR Biology), damit bio_system
+    // aktuelle WorkContext-Werte (has_deadline, in_meeting) sieht.
     schedule.add_systems(input_system.in_set(SimulationPhase::Input));
+    schedule.add_systems(
+        work_context_system
+            .in_set(SimulationPhase::Input)
+            .after(input_system),
+    );
     schedule.add_systems(bio_system.in_set(SimulationPhase::Biology));
     schedule.add_systems(physics_system.in_set(SimulationPhase::Physics));
     schedule.add_systems(transit_system.in_set(SimulationPhase::Transit));
-    schedule.add_systems(
-        work_context_system
-            .in_set(SimulationPhase::Transit)
-            .after(transit_system),
-    );
     schedule.add_systems(chaos_system.in_set(SimulationPhase::Chaos));
     schedule.add_systems(mood_system.in_set(SimulationPhase::Mood));
     schedule.add_systems(perception_system.in_set(SimulationPhase::Perception));

--- a/crates/sentinel-redb/src/lib.rs
+++ b/crates/sentinel-redb/src/lib.rs
@@ -19,6 +19,9 @@ const BEHAVIORAL_NOTES: TableDefinition<u16, &[u8]> = TableDefinition::new("beha
 const NARRATIVE_SUMMARY: TableDefinition<u16, &[u8]> = TableDefinition::new("narrative_summary");
 const EVOLUTION_VERSION: TableDefinition<u16, u64> = TableDefinition::new("evolution_version");
 
+// Simulation metadata (sim_hour persistence, time virtualization)
+const SIM_META: TableDefinition<&str, &[u8]> = TableDefinition::new("sim_meta");
+
 pub struct StateStore {
     db: Database,
 }
@@ -42,6 +45,7 @@ impl StateStore {
             write_txn.open_table(BEHAVIORAL_NOTES)?;
             write_txn.open_table(NARRATIVE_SUMMARY)?;
             write_txn.open_table(EVOLUTION_VERSION)?;
+            write_txn.open_table(SIM_META)?;
         }
         write_txn.commit()?;
 
@@ -393,6 +397,41 @@ impl StateStore {
         Ok(new_version)
     }
 
+    // === SIMULATION METADATA ===
+
+    /// Get persisted sim_hour. Returns None on first start.
+    pub fn get_sim_hour(&self) -> anyhow::Result<Option<f32>> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(SIM_META)?;
+        match table.get("sim_hour")? {
+            Some(guard) => {
+                let bytes: &[u8] = guard.value();
+                if bytes.len() == 4 {
+                    let hour = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                    if (0.0..24.0).contains(&hour) {
+                        Ok(Some(hour))
+                    } else {
+                        Ok(None) // Corrupted value, treat as missing
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Persist sim_hour for restart recovery.
+    pub fn set_sim_hour(&self, hour: f32) -> anyhow::Result<()> {
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(SIM_META)?;
+            table.insert("sim_hour", hour.to_le_bytes().as_slice())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
     /// Batch set for room states in a single write transaction.
     #[instrument(skip(self, entries), level = "trace", fields(batch_size = entries.len()))]
     pub fn set_room_states_batch(&self, entries: &[(RoomId, Vec<u8>)]) -> anyhow::Result<()> {
@@ -608,6 +647,38 @@ mod tests {
             store.get_behavioral_notes(agent(5)).unwrap().unwrap(),
             b"reliable worker"
         );
+    }
+
+    #[test]
+    fn test_sim_hour_crud() {
+        let (store, _dir) = temp_store();
+
+        // Initially None
+        assert!(store.get_sim_hour().unwrap().is_none());
+
+        // Set
+        store.set_sim_hour(14.5).unwrap();
+        let hour = store.get_sim_hour().unwrap().unwrap();
+        assert!((hour - 14.5).abs() < f32::EPSILON);
+
+        // Overwrite
+        store.set_sim_hour(22.75).unwrap();
+        let hour = store.get_sim_hour().unwrap().unwrap();
+        assert!((hour - 22.75).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_sim_hour_invalid_returns_none() {
+        let (store, _dir) = temp_store();
+
+        // Write an out-of-range value directly (simulating corruption)
+        store.set_sim_hour(25.0).unwrap();
+        // get_sim_hour validates range [0, 24) — corrupted returns None
+        assert!(store.get_sim_hour().unwrap().is_none());
+
+        // Negative value
+        store.set_sim_hour(-1.0).unwrap();
+        assert!(store.get_sim_hour().unwrap().is_none());
     }
 
     #[test]

--- a/services/sentinel-daemon/src/config.rs
+++ b/services/sentinel-daemon/src/config.rs
@@ -32,6 +32,11 @@ pub struct DaemonConfig {
     #[serde(default = "default_zenoh_prefix")]
     pub zenoh_prefix: String,
 
+    /// Simulations-Zeitskala (default: 1.0 = Echtzeit).
+    /// 60.0 = 1 Sim-Minute pro Echtzeit-Sekunde, 0.5 = halbe Geschwindigkeit.
+    #[serde(default = "default_time_scale")]
+    pub time_scale: f32,
+
     /// NATS-Konfiguration fuer Judge-Alert-Consumption.
     #[serde(default)]
     pub nats: NatsConfig,
@@ -63,6 +68,10 @@ fn default_tick_rate() -> u64 {
 
 fn default_max_agents() -> usize {
     30
+}
+
+fn default_time_scale() -> f32 {
+    1.0
 }
 
 fn default_zenoh_prefix() -> String {
@@ -111,5 +120,18 @@ data_dir = "/tmp/data"
         assert_eq!(file.daemon.tick_rate_ms, 1000);
         assert_eq!(file.daemon.max_agents, 30);
         assert_eq!(file.daemon.zenoh_prefix, "sentinel");
+        assert_eq!(file.daemon.time_scale, 1.0);
+    }
+
+    #[test]
+    fn test_time_scale_custom() {
+        let toml_str = r#"
+[daemon]
+config_dir = "/tmp/cfg"
+data_dir = "/tmp/data"
+time_scale = 60.0
+"#;
+        let file: DaemonConfigFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(file.daemon.time_scale, 60.0);
     }
 }

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -557,8 +557,7 @@ fn ecs_tick_loop(
         .unwrap_or(8.0);
     info!(
         restored_sim_hour = format!("{:.2}", sim_hour),
-        time_scale,
-        "sim_hour initialisiert"
+        time_scale, "sim_hour initialisiert"
     );
 
     loop {
@@ -755,7 +754,11 @@ fn ecs_tick_loop(
             if let Err(e) = state_store_for_sim.set_sim_hour(sim_hour) {
                 warn!(error = %e, "sim_hour persist fehlgeschlagen");
             }
-            info!(tick = tick_count, sim_hour = format!("{:.2}", sim_hour), "Tick Checkpoint");
+            info!(
+                tick = tick_count,
+                sim_hour = format!("{:.2}", sim_hour),
+                "Tick Checkpoint"
+            );
         }
 
         std::thread::sleep(tick_rate);

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -264,6 +264,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
 
     // Werte fuer den ECS-Thread
     let tick_rate = Duration::from_millis(config.tick_rate_ms);
+    let time_scale = config.time_scale;
     let all_agents_clone = all_agents.clone();
 
     // -- ECS Tick Loop (dedizierter Thread, bevy_ecs World ist Send+Sync) --
@@ -279,6 +280,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 all_agents_clone,
                 current_shift,
                 tick_rate,
+                time_scale,
                 shutdown_ecs,
                 controlplane,
                 runtime_orch,
@@ -415,6 +417,7 @@ fn ecs_tick_loop(
     all_agents: Vec<AgentConfig>,
     initial_shift: u8,
     tick_rate: Duration,
+    time_scale: f32,
     shutdown: Arc<AtomicBool>,
     mut controlplane: ControlplaneKernel,
     mut runtime_orch: RuntimeOrchestrator,
@@ -427,6 +430,7 @@ fn ecs_tick_loop(
     let (mut world, mut schedule) = create_simulation_world();
 
     // Stores als Resources einfuegen (Arc<StateStore> direkt verwenden)
+    let state_store_for_sim = Arc::clone(&state_store);
     world.insert_resource(sentinel_ecs::RedbStateStore {
         store: state_store,
         persist_every_n_ticks: 20,
@@ -545,19 +549,32 @@ fn ecs_tick_loop(
     let mut tick_count: u64 = 0;
     let mut current_shift = initial_shift;
 
+    // sim_hour aus redb restaurieren (Fallback: 8.0 fuer Erststart)
+    let mut sim_hour: f32 = state_store_for_sim
+        .get_sim_hour()
+        .ok()
+        .flatten()
+        .unwrap_or(8.0);
+    info!(
+        restored_sim_hour = format!("{:.2}", sim_hour),
+        time_scale,
+        "sim_hour initialisiert"
+    );
+
     loop {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
 
-        // SimulationTime aktualisieren
+        // SimulationTime aktualisieren (Zeitvirtualisierung via time_scale)
         if let Some(mut time) = world.get_resource_mut::<SimulationTime>() {
             time.tick = sentinel_common::Tick(tick_count);
             time.tick_count = tick_count;
-            time.delta_seconds = tick_rate.as_secs_f32();
-            // sim_hour: Startet bei 08:00, schreitet mit Echtzeit voran,
-            // wraps um 0-24 fuer korrekten Circadian-Rhythmus.
-            time.sim_hour = (8.0 + tick_count as f32 * tick_rate.as_secs_f32() / 3600.0) % 24.0;
+            // delta_seconds = echte Tick-Dauer * time_scale (Zeitvirtualisierung)
+            time.delta_seconds = tick_rate.as_secs_f32() * time_scale;
+            // sim_hour inkrementell (persistiert in redb, ueberlebt Restart)
+            sim_hour = (sim_hour + time.delta_seconds / 3600.0) % 24.0;
+            time.sim_hour = sim_hour;
         }
 
         // RuntimeOrchestrator Tick synchronisieren
@@ -734,7 +751,11 @@ fn ecs_tick_loop(
         tick_count += 1;
 
         if tick_count.is_multiple_of(60) {
-            info!(tick = tick_count, "Tick Checkpoint");
+            // sim_hour periodisch persistieren
+            if let Err(e) = state_store_for_sim.set_sim_hour(sim_hour) {
+                warn!(error = %e, "sim_hour persist fehlgeschlagen");
+            }
+            info!(tick = tick_count, sim_hour = format!("{:.2}", sim_hour), "Tick Checkpoint");
         }
 
         std::thread::sleep(tick_rate);
@@ -749,6 +770,11 @@ fn ecs_tick_loop(
     }
     if teardown_count > 0 {
         info!(count = teardown_count, "Sandbox teardown abgeschlossen");
+    }
+
+    // sim_hour vor Shutdown persistieren
+    if let Err(e) = state_store_for_sim.set_sim_hour(sim_hour) {
+        warn!(error = %e, "sim_hour Shutdown-Persist fehlgeschlagen");
     }
 
     // -- Graceful Shutdown: Runtime-Snapshot speichern (AC-4 Issue #15) --
@@ -862,6 +888,7 @@ mod tests {
             vec![],
             1,
             Duration::from_millis(100),
+            1.0, // time_scale
             shutdown,
             controlplane,
             runtime_orch,
@@ -911,6 +938,7 @@ mod tests {
             all_agents,
             1,
             Duration::from_millis(50),
+            1.0, // time_scale
             shutdown,
             controlplane,
             runtime_orch,
@@ -965,6 +993,7 @@ mod tests {
             all_agents,
             1,
             Duration::from_millis(50),
+            1.0, // time_scale
             shutdown,
             controlplane,
             runtime_orch,


### PR DESCRIPTION
## Summary

Bio-Engine Dynamics waren flach (Stress=0, Energy~90, Caffeine=0 bei ALLEN Agents). Root Causes: sim_hour reset auf 8.0 bei jedem Restart (tick_count nicht persistiert), work_context_system lief nach bio_system (1-Tick Delay). Zusaetzlich fehlte die TOGAF-spezifizierte Zeitvirtualisierung.

## Changes

- **time_scale Config** (`config.rs`, `daemon.toml`): Konfigurierbarer Zeitskala-Parameter (default 1.0 = Echtzeit, 60.0 = 1 Sim-Minute/Sekunde) — TOGAF-konforme Zeitvirtualisierung
- **sim_hour Persistenz** (`sentinel-redb`): Neue SIM_META Table, `get_sim_hour()`/`set_sim_hour()` mit Validierung [0,24)
- **Inkrementelles sim_hour** (`orchestrator.rs`): sim_hour aus redb restauriert, inkrementell via `delta_seconds / 3600.0`, periodisch + bei Shutdown persistiert
- **System-Ordering Fix** (`world.rs`): `work_context_system` von Transit nach Input Phase verschoben (vor bio_system)
- **drink_water Action** (`sentinel-bio`, `systems.rs`): Neue Bio-Action (+5 Energy, -10 Bladder)
- **sim_hour Logging** (`orchestrator.rs`): sim_hour in Tick Checkpoint Logs

## Linked Issues

Closes #148

## Test Plan

- `cargo remote -- test -p sentinel-redb` — 18/18 pass (inkl. neue sim_hour CRUD + Validation Tests)
- `cargo remote -- test -p sentinel-bio` — alle pass (inkl. neue drink_water Tests)
- `cargo remote -- test -p sentinel-ecs` — alle pass
- `cargo remote -- test -p sentinel-daemon` — 59/59 pass
- `cargo remote -- clippy --workspace --all-targets -- -D warnings` — 0 Warnings
- Deploy auf 10.0.0.240, systemctl restart, 14 ACs verifiziert

## Benchmarks

Keine Performance-relevanten Aenderungen (sim_hour float-Ops + 1 redb Write/60 Ticks). Bestehende Benchmarks nicht betroffen.

## Evidence (AC Mapping)

| AC | Kriterium | Command | Output | Status |
|----|-----------|---------|--------|--------|
| AC-1 | Stress variiert | `curl .../api/agents \| jq stress` | 12.6 - 17.9 (vorher: 0.0) | PASS |
| AC-2 | Energy sinkt | `curl .../api/agents \| jq energy` | 32.6 - 52.2 (vorher: 79-90) | PASS |
| AC-3 | Caffeine > 0 nach Auto-Coffee | `curl .../api/agents \| jq caffeine_mg` | AGENT-19: caffeine=22.6 | PASS |
| AC-4 | sim_hour ueberlebt Restart | `journalctl \| grep sim_hour` | restored_sim_hour="10.85" (nicht 8.0) | PASS |
| AC-5 | time_scale Config wirkt | `journalctl \| grep time_scale` | time_scale=60.0/180.0/3600.0 getestet | PASS |
| AC-6 | work_context vor bio | Code: world.rs Zeile 183 | Input Phase, after(input_system) | PASS |
| AC-7 | Hunger steigt | `curl .../api/agents \| jq hunger` | 32.9 - 62.5 (Start-Default: 20) | PASS |
| AC-8 | Bladder steigt | `curl .../api/agents \| jq bladder` | 22.4 - 100.0 (Start-Default: 10) | PASS |
| AC-9 | Social Need variiert | `curl .../api/agents \| jq social_need` | 44.8 vs 60.3 (Extraversion) | PASS |
| AC-10 | Circadian Energy | Agent-Vergleich | Energy 32.6-52.2 Range | PASS |
| AC-11 | Big Five messbar | AGENT-19 vs AGENT-24 | stress=3.8 vs 0.0 (Neuroticism) | PASS |
| AC-N1 | Bio [0,100] Range | Python Validator | 24 Agents, 0 Violations | PASS |
| AC-N2 | Keine Errors | `journalctl -p err` | No entries | PASS |
| AC-N3 | sim_hour monoton | `journalctl Tick Checkpoint` | 8.02→8.03→8.05→10.05→17.30→... | PASS |

## Checklist

- [x] Tests gruen (`cargo remote -- test --workspace`)
- [x] Clippy clean (`cargo remote -- clippy ... -D warnings`)
- [x] CHANGELOG.md aktualisiert
- [x] Deployed auf VM (10.0.0.240)
- [x] Alle 14 ACs mit Evidence verifiziert
- [x] Keine Errors/Panics im Journal
- [x] time_scale zurueck auf 1.0 (Echtzeit)