### PR TITLE
fix: NMDA score persistence + evolution injection logging (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     EVOLUTION_VERSION Tabellen mit get/set Methoden
   - **Gateway 3-Source Assembly Fix:** `compiler.NewWithAssembler()` statt `compiler.New()`,
     TOML DNA + Evolution + Perception korrekt verdrahtet, 0 Fallback-Warnings
+  - **NMDA Scores in redb:** Neue NMDA_SCORES Tabelle, Daemon schreibt Scores waehrend
+    Schichtwechsel-Konsolidierung (set_nmda_scores/get_nmda_scores mit JSON-Serialisierung)
+  - **Gateway "evolution injected" Logging:** Info-Log wenn Evolution-Daten (Voice, Notes,
+    Narrative) in Agent-Prompt injiziert werden (AC-8 Observability)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     TOML DNA + Evolution + Perception korrekt verdrahtet, 0 Fallback-Warnings
   - **NMDA Scores in redb:** Neue NMDA_SCORES Tabelle, Daemon schreibt Scores waehrend
     Schichtwechsel-Konsolidierung (set_nmda_scores/get_nmda_scores mit JSON-Serialisierung)
+  - **NMDA Consolidation Threshold gesenkt (0.1 → 0.05):** Autonomie-generierte Actions
+    (move, emote) scoren 0.06 via classify_action() Default. Mit Threshold 0.1 wurden
+    diese nie konsolidiert. Threshold 0.05 ermoeglicht realistische Konsolidierung.
   - **Gateway "evolution injected" Logging:** Info-Log wenn Evolution-Daten (Voice, Notes,
     Narrative) in Agent-Prompt injiziert werden (AC-8 Observability)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "sentinel-common",
  "sentinel-telemetry",
  "serde",
+ "serde_json",
  "tempfile",
  "tracing",
 ]

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -365,6 +365,14 @@ func (ph *PipelineHandler) buildSystemPrompt(req *LLMRequest, agentName, agentRo
 			modelKey := ph.modelKey(providerName)
 			return ph.compiler.Compile(modelKey, agentName, agentRole, perception)
 		}
+		if !evolution.IsEmpty() {
+			ph.logger.Info("evolution injected",
+				"agent_id", agentID,
+				"has_voice", evolution.VoiceStyle != "",
+				"has_notes", evolution.BehavioralNotes != "",
+				"has_narrative", evolution.NarrativeSummary != "",
+			)
+		}
 		return compiled
 	}
 

--- a/crates/sentinel-hippocampus/src/sleep.rs
+++ b/crates/sentinel-hippocampus/src/sleep.rs
@@ -47,7 +47,7 @@ impl SleepCycle {
             phase: SleepPhase::Awake,
             episodes: Vec::new(),
             selected: Vec::new(),
-            consolidation_threshold: 0.1,
+            consolidation_threshold: 0.05,
             max_consolidation_episodes: 10,
             consolidated_narrative: None,
         }

--- a/crates/sentinel-redb/Cargo.toml
+++ b/crates/sentinel-redb/Cargo.toml
@@ -12,6 +12,7 @@ telemetry = ["sentinel-telemetry/telemetry"]
 [dependencies]
 redb = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 sentinel-common = { path = "../sentinel-common" }

--- a/crates/sentinel-redb/src/lib.rs
+++ b/crates/sentinel-redb/src/lib.rs
@@ -18,6 +18,8 @@ const VOICE_STYLE: TableDefinition<u16, &[u8]> = TableDefinition::new("voice_sty
 const BEHAVIORAL_NOTES: TableDefinition<u16, &[u8]> = TableDefinition::new("behavioral_notes");
 const NARRATIVE_SUMMARY: TableDefinition<u16, &[u8]> = TableDefinition::new("narrative_summary");
 const EVOLUTION_VERSION: TableDefinition<u16, u64> = TableDefinition::new("evolution_version");
+// NMDA scores from last consolidation — JSON-serialized Vec<f64>
+const NMDA_SCORES: TableDefinition<u16, &[u8]> = TableDefinition::new("nmda_scores");
 
 // Simulation metadata (sim_hour persistence, time virtualization)
 const SIM_META: TableDefinition<&str, &[u8]> = TableDefinition::new("sim_meta");
@@ -45,6 +47,7 @@ impl StateStore {
             write_txn.open_table(BEHAVIORAL_NOTES)?;
             write_txn.open_table(NARRATIVE_SUMMARY)?;
             write_txn.open_table(EVOLUTION_VERSION)?;
+            write_txn.open_table(NMDA_SCORES)?;
             write_txn.open_table(SIM_META)?;
         }
         write_txn.commit()?;
@@ -395,6 +398,29 @@ impl StateStore {
         }
         write_txn.commit()?;
         Ok(new_version)
+    }
+
+    /// Store NMDA scores from consolidation for an agent.
+    /// Scores are serialized as JSON array of f64.
+    pub fn set_nmda_scores(&self, agent_id: AgentId, scores: &[f64]) -> anyhow::Result<()> {
+        let json = serde_json::to_vec(scores)?;
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(NMDA_SCORES)?;
+            table.insert(agent_id.0, json.as_slice())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    /// Get NMDA scores from last consolidation for an agent.
+    pub fn get_nmda_scores(&self, agent_id: AgentId) -> anyhow::Result<Vec<f64>> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(NMDA_SCORES)?;
+        match table.get(agent_id.0)? {
+            Some(guard) => Ok(serde_json::from_slice(guard.value())?),
+            None => Ok(Vec::new()),
+        }
     }
 
     // === SIMULATION METADATA ===

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -795,6 +795,34 @@ fn ecs_tick_loop(
                                                 );
                                             }
                                         }
+
+                                        // NMDA scores nach redb schreiben
+                                        let scores: Vec<f64> = result
+                                            .consolidated_summaries
+                                            .iter()
+                                            .map(|(_s, score)| *score)
+                                            .collect();
+                                        if !scores.is_empty() {
+                                            let avg_score: f64 =
+                                                scores.iter().sum::<f64>() / scores.len() as f64;
+                                            match store.set_nmda_scores(*agent_id, &scores) {
+                                                Ok(()) => {
+                                                    info!(
+                                                        agent = name,
+                                                        nmda_count = scores.len(),
+                                                        nmda_avg = format!("{avg_score:.4}"),
+                                                        "NMDA scores nach redb geschrieben"
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    warn!(
+                                                        agent = name,
+                                                        error = %e,
+                                                        "NMDA scores redb-Write fehlgeschlagen"
+                                                    );
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

Fixes remaining gaps in the closed-loop personality evolution pipeline (#138):
- **AC-2**: NMDA scores now persisted during daemon shift-change consolidation
- **AC-8**: Gateway logs "evolution injected" when evolution data is non-empty
- **NMDA threshold**: Lowered from 0.1 to 0.05 to enable consolidation of autonomy-generated episodes

## Changes

- **sentinel-redb**: Added `NMDA_SCORES` table with `set_nmda_scores()`/`get_nmda_scores()` methods (JSON-serialized `Vec<f64>`)
- **sentinel-daemon orchestrator**: Writes NMDA scores to redb during shift-change consolidation, logs agent name + score count + average
- **cortex-gateway pipeline**: Added "evolution injected" Info log when evolution data (voice/notes/narrative) is non-empty
- **sentinel-hippocampus sleep**: Lowered `consolidation_threshold` from 0.1 to 0.05 — autonomy-generated actions (move, emote) score 0.06 via `classify_action()` default, previously filtered out

## Linked Issues

Partially addresses #138

## Test Plan

- [x] `cargo remote -- test -p sentinel-redb` — 18/18 passed
- [x] `cargo remote -- test -p sentinel-hippocampus` — 63/63 passed
- [x] `cargo remote -- clippy -p sentinel-redb -p sentinel-daemon -p sentinel-hippocampus -- -D warnings` — 0 warnings
- [x] `go vet ./cmd/cortex-gateway/...` — clean
- [x] `make fmt` — no changes needed
- [x] Deployed daemon + gateway binaries to VM 10.0.0.240
- [x] Live shift-change triggered: all 15 agents consolidated with episodes_consolidated > 0
- [x] Live "evolution injected" log verified in gateway for AGENT-01

## Benchmarks

No performance-critical changes. NMDA score write is a single redb insert during consolidation (sub-millisecond per agent). Threshold change only affects episode selection during consolidation, no runtime impact.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-2 | PASS | See AC-2 output below |
| AC-8 | PASS | See AC-8 output below |

### AC-2: NMDA Scores persisted during consolidation

```
$ ssh ubuntu@10.0.0.240 "sudo journalctl -u sentinel-daemon | grep 'NMDA scores'"
NMDA scores nach redb geschrieben agent=Sandra nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Jens nmda_count=2 nmda_avg="0.0600"
NMDA scores nach redb geschrieben agent=Kevin nmda_count=4 nmda_avg="0.0558"
NMDA scores nach redb geschrieben agent=Martina nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Robert nmda_count=2 nmda_avg="0.0600"
NMDA scores nach redb geschrieben agent=Silke nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Tobias nmda_count=2 nmda_avg="0.0600"
NMDA scores nach redb geschrieben agent=Diana nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Mario nmda_count=4 nmda_avg="0.0558"
NMDA scores nach redb geschrieben agent=Nadine nmda_count=2 nmda_avg="0.0600"
NMDA scores nach redb geschrieben agent=Patrick nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Eva nmda_count=2 nmda_avg="0.0600"
NMDA scores nach redb geschrieben agent=Steffen nmda_count=4 nmda_avg="0.0558"
NMDA scores nach redb geschrieben agent=Nicole nmda_count=3 nmda_avg="0.0576"
NMDA scores nach redb geschrieben agent=Christoph nmda_count=2 nmda_avg="0.0600"
```

All 15 shift-3 agents had NMDA scores written during shift 3→1 transition at 06:00 UTC.

### AC-8: Gateway "evolution injected" log

```
$ ssh ubuntu@10.0.0.240 "sudo journalctl -u sentinel-cortex | grep 'evolution injected'"
{"time":"2026-03-02T11:44:54.114254743Z","level":"INFO","msg":"evolution injected","agent_id":1,"has_voice":false,"has_notes":false,"has_narrative":true}
```

Gateway received `evolution_narrative` via metadata from daemon LLM Bridge for AGENT-01.

## Checklist

- [x] Code compiles without warnings (`clippy -D warnings`)
- [x] All existing tests pass (hippocampus: 63, redb: 18)
- [x] CHANGELOG.md updated
- [x] Binaries deployed to VM and live-verified
- [x] No secrets or credentials committed