### PR TITLE
fix: make flaky tick-loop tests deterministic (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flaky Test `test_ecs_tick_loop_runs_ticks` deterministisch gemacht** (#135)
+  - `sleep(500ms)` durch `perception_rx.recv_timeout(30s)` ersetzt
+  - Wartet auf tatsaechlichen Tick-Abschluss statt blindem Timer
+  - Gleiches Fix fuer `test_save_state_on_shutdown`
+
 - **eBPF Functional Fixes — Ende-zu-Ende Datenkette repariert** (#139)
   - **Stall-Detection false positives:** BPF Map enthielt ALLE System-cgroups (sshd,
     systemd etc.), nur registrierte Sentinel-Agents werden jetzt getrackt

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1079,15 +1079,15 @@ mod tests {
         let state_store = Arc::new(StateStore::open(state_path.to_str().unwrap()).unwrap());
 
         let (_tx, rx) = mpsc::channel();
-        let (ptx, _prx) = mpsc::sync_channel(64);
+        let (ptx, prx) = mpsc::sync_channel(64);
 
         let controlplane = test_controlplane(&tmp);
         let runtime_orch = RuntimeOrchestrator::new(10).with_event_store(Arc::clone(&event_store));
         let all_agents = vec![test_agent_config(1, "Test Agent", "Tester", 1)];
 
-        // Shutdown nach 500ms (genug Spielraum fuer Build-Server unter Last)
+        // Deterministisch: Warte auf erste Perception (= mindestens 1 Tick abgeschlossen)
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(500));
+            let _ = prx.recv_timeout(Duration::from_secs(30));
             shutdown_clone.store(true, Ordering::SeqCst);
         });
 
@@ -1131,7 +1131,7 @@ mod tests {
         let state_store = Arc::new(StateStore::open(state_path.to_str().unwrap()).unwrap());
 
         let (_tx, rx) = mpsc::channel();
-        let (ptx, _prx) = mpsc::sync_channel(64);
+        let (ptx, prx) = mpsc::sync_channel(64);
 
         let controlplane = test_controlplane(&tmp);
         let runtime_orch = RuntimeOrchestrator::new(10).with_event_store(Arc::clone(&event_store));
@@ -1140,9 +1140,9 @@ mod tests {
             test_agent_config(2, "Lisa", "Designer", 1),
         ];
 
-        // Shutdown nach 500ms (genug Spielraum fuer CI-Runner unter Last)
+        // Deterministisch: Warte auf erste Perception (= mindestens 1 Tick abgeschlossen)
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(500));
+            let _ = prx.recv_timeout(Duration::from_secs(30));
             shutdown_clone.store(true, Ordering::SeqCst);
         });
 


### PR DESCRIPTION
## Summary

Ersetzt timing-abhaengige `sleep(500ms)` Shutdown-Timer in zwei Tests durch deterministische Perception-Channel-Signalisierung. Tests warten jetzt auf tatsaechlichen Tick-Abschluss statt auf einen blinden Timer.

## Changes

- `test_ecs_tick_loop_runs_ticks`: `_prx` → `prx`, `sleep(500ms)` → `prx.recv_timeout(30s)`
- `test_save_state_on_shutdown`: Gleiches Pattern
- CHANGELOG.md: Eintrag hinzugefuegt

## Linked Issues

Closes #135

## Test Plan

| Ebene | Command | Ergebnis |
|-------|---------|----------|
| Unit (10x) | `cargo remote -- test -p sentinel-daemon -- test_ecs_tick_loop_runs_ticks` (10 Laeufe) | 10/10 PASS |
| Unit (alle) | `cargo remote -- test -p sentinel-daemon` | 60/60 PASS |
| Clippy | `cargo remote -- clippy -p sentinel-daemon -- -D warnings` | 0 Warnings |
| Format | `make fmt` | OK |

## Benchmarks

Nicht anwendbar (reiner Test-Code-Fix, kein Produktionscode).

## Evidence (AC Mapping)

| AC | Beschreibung | Ergebnis | Evidence |
|----|-------------|----------|----------|
| AC-1 | Deterministisches Warten statt Sleep | PASS | `recv_timeout()` statt `sleep()`, 10/10 Laeufe gruen (0.22s - 3.56s) |
| AC-2 | Bestehende Tests gruen | PASS | `cargo remote -- test -p sentinel-daemon` → 60 passed, 0 failed |
| AC-3 | Kein Timeout > 30s, Test < 5s | PASS | Max-Laufzeit 3.56s (unter Last), Normal ~0.3s |

**Hinweis:** `test_save_state_on_shutdown` hat dasselbe flaky Pattern und wurde mitgefixt.

## Checklist

- [x] Code aendert NUR Test-Code (kein Produktionscode)
- [x] Clippy clean (0 Warnings)
- [x] Format OK (`make fmt`)
- [x] CHANGELOG.md aktualisiert
- [x] 10/10 deterministic runs bestanden
- [x] Conventional Commit Format

🤖 Generated with [Claude Code](https://claude.com/claude-code)