### PR TITLE
feat: closed-loop personality evolution E2E integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Closed-Loop Personality Evolution E2E Integration** (#138)
+  - **NATS Consumer Silent-Failure:** `get_stream("SENTINEL_JUDGE")` durch
+    `get_or_create_stream()` mit vollstaendiger Stream-Config ersetzt — Daemon
+    empfaengt jetzt zuverlaessig Judge-Alerts auch wenn Stream noch nicht existiert
+  - **DomainEvent-Persistierung bei Alerts:** Judge-Alerts (drift, quality, fatigue, swap)
+    erzeugen jetzt `JudgeAlertReceived` DomainEvents in Limbo + Prometheus Counter
+    `sentinel_daemon_judge_alerts_total`
+  - **nmda_score in Evolution-DB:** Judge schreibt `max(drift, fatigue)` als
+    NMDA-Relevanz-Proxy in `personality_evolution` Tabelle
+
+### Added
+
+- **LLM-basierte Voice-Style und Behavioral-Notes Generierung** (#138)
+  - Bei Schichtwechsel-Konsolidierung: LLM-Call an Cortex Gateway fuer
+    `voice_style` und `behavioral_notes` pro Agent
+  - Fail-safe: Bei Gateway-Fehler laeuft Konsolidierung ohne voice/behavioral weiter
+  - `reqwest::blocking` Feature fuer HTTP-Calls im ECS std::thread
+
 ### Dependencies
 
 - **fuser 0.16 → 0.17** (#136)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -199,6 +199,14 @@ pub enum DomainEventPayload {
         agent_name: String,
         error: String,
     },
+    /// Judge-Alert empfangen (drift, quality, fatigue, swap)
+    JudgeAlertReceived {
+        agent_id: AgentId,
+        alert_type: String,
+        severity: String,
+        score: f64,
+        details: String,
+    },
 }
 
 impl DomainEventPayload {
@@ -226,6 +234,7 @@ impl DomainEventPayload {
             Self::NightRunCompleted { .. } => "nightrun_completed",
             Self::AgentConsolidated { .. } => "agent_consolidated",
             Self::AgentConsolidationFailed { .. } => "agent_consolidation_failed",
+            Self::JudgeAlertReceived { .. } => "judge_alert_received",
         }
     }
 }

--- a/services/sentinel-daemon/Cargo.toml
+++ b/services/sentinel-daemon/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false, optional = true }
 uuid = { workspace = true }
 async-nats = { workspace = true, optional = true }
 futures = { version = "0.3", optional = true }

--- a/services/sentinel-daemon/src/nats_consumer.rs
+++ b/services/sentinel-daemon/src/nats_consumer.rs
@@ -50,9 +50,9 @@ pub async fn run(nats_url: &str, alert_tx: mpsc::Sender<JudgeAlert>) {
             storage: async_nats::jetstream::stream::StorageType::File,
             retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
             max_age: std::time::Duration::from_secs(30 * 24 * 60 * 60), // 30 days
-            max_bytes: 100 * 1024 * 1024,                                // 100 MB
+            max_bytes: 100 * 1024 * 1024,                               // 100 MB
             num_replicas: 1,
-            duplicate_window: std::time::Duration::from_secs(600),       // 10 min
+            duplicate_window: std::time::Duration::from_secs(600), // 10 min
             ..Default::default()
         })
         .await

--- a/services/sentinel-daemon/src/nats_consumer.rs
+++ b/services/sentinel-daemon/src/nats_consumer.rs
@@ -41,11 +41,28 @@ pub async fn run(nats_url: &str, alert_tx: mpsc::Sender<JudgeAlert>) {
 
     let jetstream = async_nats::jetstream::new(client);
 
-    // Stream holen
-    let stream = match jetstream.get_stream("SENTINEL_JUDGE").await {
-        Ok(s) => s,
+    // Stream erstellen oder holen (idempotent, verhindert silent-fail wenn Stream noch nicht existiert)
+    let stream = match jetstream
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: "SENTINEL_JUDGE".to_string(),
+            description: Some("Sentinel judge alerts and results".to_string()),
+            subjects: vec!["sentinel.judge.>".to_string()],
+            storage: async_nats::jetstream::stream::StorageType::File,
+            retention: async_nats::jetstream::stream::RetentionPolicy::Limits,
+            max_age: std::time::Duration::from_secs(30 * 24 * 60 * 60), // 30 days
+            max_bytes: 100 * 1024 * 1024,                                // 100 MB
+            num_replicas: 1,
+            duplicate_window: std::time::Duration::from_secs(600),       // 10 min
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(s) => {
+            info!("NATS Stream SENTINEL_JUDGE ready");
+            s
+        }
         Err(e) => {
-            error!(error = %e, "NATS Stream SENTINEL_JUDGE nicht gefunden");
+            error!(error = %e, "NATS Stream SENTINEL_JUDGE konnte nicht erstellt/geholt werden");
             return;
         }
     };

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1069,8 +1069,8 @@ fn generate_evolution_fields(
     agent_role: &str,
     narrative: &str,
 ) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-    let gateway_url = std::env::var("CORTEX_GATEWAY_URL")
-        .unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let gateway_url =
+        std::env::var("CORTEX_GATEWAY_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
     let url = format!("{gateway_url}/v1/chat/completions");
 
     let client = match reqwest::blocking::Client::builder()

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -20,6 +20,7 @@ use tracing::{error, info, warn};
 
 use sentinel_common::agent_config::{load_all_agents, AgentConfig};
 use sentinel_common::components::{AgentIdentity, ShiftInfo};
+use sentinel_common::events::{DomainEvent, DomainEventPayload};
 use sentinel_common::{AgentId, Perception};
 use sentinel_ebpf::collector::MetricsSnapshot;
 use sentinel_ebpf::EbpfCollector;
@@ -334,6 +335,10 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let agent_command_cfg = config.agent_command.clone();
     let all_agents_clone = all_agents.clone();
 
+    // -- Arc::clone fuer Alert-Handler (NATS) bevor event_store in ECS-Thread moved wird --
+    #[cfg(feature = "nats")]
+    let alert_event_store = Arc::clone(&event_store);
+
     // -- ECS Tick Loop (dedizierter Thread, bevy_ecs World ist Send+Sync) --
     let ecs_state_store = Arc::clone(&state_store);
     let ecs_handle = std::thread::Builder::new()
@@ -404,17 +409,50 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
             crate::nats_consumer::run(&nats_url, alert_tx).await;
         });
 
-        // Alert-Receiver im Hintergrund: Alerts loggen und Model-Swap-Praeferenzen speichern
+        // Alert-Receiver: DomainEvent persistieren + Prometheus Counter + Log
+        let es = Arc::clone(&alert_event_store);
         tokio::spawn(async move {
+            let counter = sentinel_telemetry::MetricsRegistry::global()
+                .counter("sentinel_daemon_judge_alerts_total");
+
             while let Some(alert) = alert_rx.recv().await {
+                counter.increment();
+
+                // DomainEvent in Limbo persistieren
+                // Parse "AGENT-XX" → u16 → AgentId
+                let agent_num: u16 = alert
+                    .agent_id
+                    .strip_prefix("AGENT-")
+                    .and_then(|n| n.parse().ok())
+                    .unwrap_or(0);
+                let agent_id = AgentId::new(agent_num).unwrap_or(AgentId(1));
+                let payload = DomainEventPayload::JudgeAlertReceived {
+                    agent_id,
+                    alert_type: alert.alert_type.clone(),
+                    severity: alert.severity.clone(),
+                    score: alert.score,
+                    details: alert.details.clone(),
+                };
+                let event = DomainEvent::new(
+                    payload.event_type_str(),
+                    &alert.agent_id,
+                    &payload.to_json(),
+                    &format!("judge_alert_{}", alert.agent_id),
+                    0, // kein Simulations-Tick im async Context
+                );
+
+                if let Err(e) = es.append_event(&event) {
+                    warn!(error = %e, agent = %alert.agent_id, "Judge Alert DomainEvent speichern fehlgeschlagen");
+                }
+
                 match alert.alert_type.as_str() {
                     "swap" => {
                         info!(
                             agent_id = %alert.agent_id,
                             severity = %alert.severity,
                             details = %alert.details,
-                            alert_ref = "judge_swap_alert",
-                            "Model-Swap Alert empfangen"
+                            alert_ref = "model_swap_requested",
+                            "Model-Swap Alert empfangen — DomainEvent persistiert"
                         );
                     }
                     "drift" => {
@@ -422,7 +460,17 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                             agent_id = %alert.agent_id,
                             score = alert.score,
                             severity = %alert.severity,
-                            "Drift Alert empfangen"
+                            alert_ref = "judge_alert_received",
+                            "Drift Alert empfangen — DomainEvent persistiert"
+                        );
+                    }
+                    "fatigue" => {
+                        info!(
+                            agent_id = %alert.agent_id,
+                            score = alert.score,
+                            severity = %alert.severity,
+                            alert_ref = "judge_alert_received",
+                            "Fatigue Alert empfangen — DomainEvent persistiert"
                         );
                     }
                     _ => {
@@ -430,7 +478,8 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                             agent_id = %alert.agent_id,
                             alert_type = %alert.alert_type,
                             score = alert.score,
-                            "Judge Alert empfangen"
+                            alert_ref = "judge_alert_received",
+                            "Judge Alert empfangen — DomainEvent persistiert"
                         );
                     }
                 }
@@ -819,16 +868,28 @@ fn ecs_tick_loop(
                                             .map(|(s, _score)| s.as_str())
                                             .collect::<Vec<_>>()
                                             .join("; ");
+
+                                        // LLM-basierte Voice-Style + Behavioral-Notes Generierung
+                                        let agent_role = all_agents
+                                            .iter()
+                                            .find(|a| AgentId(a.identity.id) == *agent_id)
+                                            .map(|a| a.identity.role.as_str())
+                                            .unwrap_or("Mitarbeiter");
+                                        let (voice_style, behavioral_notes) =
+                                            generate_evolution_fields(name, agent_role, &narrative);
+
                                         match store.set_evolution_batch(
                                             *agent_id,
-                                            None, // voice_style: wird von LLM-Analyse gesetzt
-                                            None, // behavioral_notes: wird von LLM-Analyse gesetzt
+                                            voice_style.as_deref(),
+                                            behavioral_notes.as_deref(),
                                             Some(narrative.as_bytes()),
                                         ) {
                                             Ok(version) => {
                                                 info!(
                                                     agent = name,
                                                     version,
+                                                    voice_style = voice_style.is_some(),
+                                                    behavioral_notes = behavioral_notes.is_some(),
                                                     "Evolution nach redb geschrieben, EVOLUTION_VERSION = {version}"
                                                 );
                                             }
@@ -995,6 +1056,136 @@ fn ecs_tick_loop(
     }
 
     Ok(tick_count)
+}
+
+/// Generiert voice_style und behavioral_notes via LLM (Cortex Gateway).
+///
+/// Laeuft im ECS std::thread — nutzt `reqwest::blocking` (kein Tokio).
+/// Fail-safe: Bei jedem Fehler wird `(None, None)` zurueckgegeben,
+/// die Konsolidierung laeuft trotzdem durch.
+#[cfg(feature = "llm")]
+fn generate_evolution_fields(
+    agent_name: &str,
+    agent_role: &str,
+    narrative: &str,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+    let gateway_url = std::env::var("CORTEX_GATEWAY_URL")
+        .unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let url = format!("{gateway_url}/v1/chat/completions");
+
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "Evolution LLM Client erstellen fehlgeschlagen");
+            return (None, None);
+        }
+    };
+
+    // Voice-Style Analyse
+    let voice_style = llm_evolution_call(
+        &client,
+        &url,
+        agent_name,
+        "Du bist ein linguistischer Analyst fuer eine Firmen-Simulation. \
+         Analysiere den Sprachstil des Agenten basierend auf seiner Schicht-Zusammenfassung. \
+         Antworte AUSSCHLIESSLICH als valides JSON.",
+        &format!(
+            "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
+             {narrative}\n\n\
+             Analysiere den Sprachstil. Antwort als JSON:\n\
+             {{\"phrases\": [\"phrase1\"], \"sentence_style\": \"kurz|mittel|lang\", \"formality\": 0.X}}"
+        ),
+    );
+
+    // Behavioral-Notes Analyse
+    let behavioral_notes = llm_evolution_call(
+        &client,
+        &url,
+        agent_name,
+        "Du bist ein Verhaltensanalyst fuer eine Firmen-Simulation. \
+         Analysiere Verhaltensmuster des Agenten basierend auf seiner Schicht-Zusammenfassung. \
+         Antworte AUSSCHLIESSLICH als valides JSON.",
+        &format!(
+            "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
+             {narrative}\n\n\
+             Identifiziere Verhaltensmuster. Antwort als JSON:\n\
+             {{\"habits\": [\"habit1\"], \"interaction_style\": \"proaktiv|reaktiv|gemischt\", \
+             \"decision_style\": \"schnell|zoegerlich|ausgewogen\", \"anomalies\": []}}"
+        ),
+    );
+
+    (voice_style, behavioral_notes)
+}
+
+/// Einzelner LLM-Call fuer Evolution-Feld-Generierung.
+#[cfg(feature = "llm")]
+fn llm_evolution_call(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    agent_name: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Option<Vec<u8>> {
+    let body = serde_json::json!({
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ],
+        "temperature": 0.3,
+        "max_tokens": 500,
+        "model": "default",
+        "metadata": {
+            "agent_id": agent_name,
+            "request_type": "evolution_analysis"
+        }
+    });
+
+    match client.post(url).json(&body).send() {
+        Ok(resp) => {
+            if !resp.status().is_success() {
+                warn!(
+                    agent = agent_name,
+                    status = %resp.status(),
+                    "Evolution LLM Call fehlgeschlagen (HTTP)"
+                );
+                return None;
+            }
+            match resp.json::<serde_json::Value>() {
+                Ok(json) => {
+                    let content = json
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    if content.is_empty() {
+                        warn!(agent = agent_name, "Evolution LLM Response leer");
+                        return None;
+                    }
+                    Some(content.as_bytes().to_vec())
+                }
+                Err(e) => {
+                    warn!(agent = agent_name, error = %e, "Evolution LLM Response parse fehlgeschlagen");
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            warn!(agent = agent_name, error = %e, "Evolution LLM Call fehlgeschlagen");
+            None
+        }
+    }
+}
+
+/// Fallback wenn LLM-Feature deaktiviert ist.
+#[cfg(not(feature = "llm"))]
+fn generate_evolution_fields(
+    _agent_name: &str,
+    _agent_role: &str,
+    _narrative: &str,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+    (None, None)
 }
 
 #[cfg(test)]

--- a/services/sentinel-judge/internal/service/stream.go
+++ b/services/sentinel-judge/internal/service/stream.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -242,6 +243,21 @@ func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMes
 		Source:     "realtime_judge",
 	}); err != nil {
 		sc.logger.Warn("failed to write fatigue evolution", "agent", agentID, "error", err)
+	}
+
+	// Write NMDA relevance score (max of drift + fatigue as proxy)
+	nmdaVal := math.Max(driftResult.DriftScore, fatigueResult.FatigueScore)
+	if err := sc.evol.Write(persistence.EvolutionEntry{
+		AgentID:    agentID,
+		Tick:       now,
+		Field:      "nmda_score",
+		ChangeType: "nmda_relevance",
+		NewValue:   fmt.Sprintf("%.4f", nmdaVal),
+		Reason:     "max(drift, fatigue) as NMDA relevance proxy",
+		Source:     "realtime_judge",
+		NMDAScore:  &nmdaVal,
+	}); err != nil {
+		sc.logger.Warn("failed to write nmda_score", "agent", agentID, "error", err)
 	}
 
 	// 4. Swap Decision


### PR DESCRIPTION
## Summary

Fix the broken TOGAF Closed-Loop Personality Evolution pipeline. Judge alerts now flow end-to-end: heuristic analysis → NATS alert → Daemon DomainEvent persistence → LLM-based personality evolution (voice_style + behavioral_notes) at shift changes → Gateway 3-Source Assembly injection.

## Changes

- **nats_consumer.rs**: `get_stream` → `get_or_create_stream` with full stream config (fixes silent-failure when SENTINEL_JUDGE stream doesn't exist)
- **events.rs**: New `JudgeAlertReceived` variant in `DomainEventPayload`
- **orchestrator.rs**: Alert handler persists DomainEvents + Prometheus counter; LLM-based `generate_evolution_fields()` for voice_style/behavioral_notes at shift consolidation
- **Cargo.toml**: Added `blocking` to reqwest features for ECS thread HTTP calls
- **stream.go**: nmda_score write (`max(drift, fatigue)` as NMDA relevance proxy)

## Linked Issues

Closes #138

## Test Plan

- [x] `cargo remote -- test --workspace` green
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` green
- [x] `go test ./services/sentinel-judge/...` green
- [x] `go vet ./services/sentinel-judge/...` green
- [x] Deploy to VM and verify via journalctl
- [x] Publish test alert via `nats pub` and verify DomainEvent persistence
- [x] Trigger shift change (time manipulation) and verify LLM evolution generation

## Benchmarks

No benchmark changes — this is an integration fix, not a performance change.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | NATS consumer delivered 40,861+ judge alerts |
| AC-2 | PASS | evolution DB: drift 24,250 / quality 24,250 / fatigue 24,250 |
| AC-2b | PASS | nmda_score: 92 entries in evolution.db |
| AC-3 | PASS | AGENT-31 drift_score 0.84 (critical severity) |
| AC-5 | PASS | 9 agents: voice_style=true behavioral_notes=true after shift 3→1 |
| AC-6 | PASS | EVOLUTION_VERSION = 4 for consolidated agents |
| AC-7 | PASS | assembly failed count = 0 in gateway logs |
| AC-8 | PASS | Gateway: evolution injected has_voice:true has_notes:true has_narrative:true |
| AC-10 | PASS | SENTINEL_EVENTS: 826k+ messages, +26/30s |
| AC-11 | PASS | Judge: 54 agent profiles loaded |
| AC-12 | PASS | Daemon: NATS Stream SENTINEL_JUDGE ready + Subscribed |
| AC-N1 | PASS | 185+ judge_alert_received DomainEvents in Limbo |

### Concrete Evidence

**AC-1: Judge alert DomainEvent persistence**
```
$ ssh ubuntu@10.0.0.240 "nats consumer info SENTINEL_JUDGE sentinel-daemon"
Delivered:   40,861
Ack Pending: 0
```

**AC-2b: nmda_score in evolution.db**
```
$ ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/evolution.db \"SELECT COUNT(*) FROM evolution WHERE key LIKE '%nmda_score%'\""
92
```

**AC-5: LLM voice_style + behavioral_notes at shift change**
```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2026-03-02 22:00' --no-pager" | grep 'voice_style=true'
voice_style=true behavioral_notes=true  (9 agents consolidated)
```

**AC-8: Gateway 3-Source Assembly**
```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-cortex --since '2026-03-02 22:00' --no-pager" | grep 'evolution injected'
evolution injected has_voice:true has_notes:true has_narrative:true
```

**AC-12: NATS stream created successfully**
```
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon -n 50 --no-pager" | grep 'SENTINEL_JUDGE'
NATS Stream SENTINEL_JUDGE ready
Subscribed to sentinel.judge.alert.>
```

**AC-N1: DomainEvents in Limbo**
```
$ ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \"SELECT COUNT(*) FROM events WHERE event_type='judge_alert_received'\""
185
```

## Checklist

- [x] Code compiles without warnings (`clippy -D warnings`)
- [x] All existing tests pass
- [x] Go tests and vet pass
- [x] CHANGELOG.md updated
- [x] Deployed to VM and verified end-to-end
- [x] All ACs verified with evidence
- [x] No secrets committed