### PR TITLE
fix: Cortex Control Plane + Guardrails + Token Tracking (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cortex Control Plane + Guardrails + Token Tracking** (#145)
+  - `pipeline.go`: Standalone `sentinel_pipeline_tokens_total` Prometheus counter (fires regardless of guardrails config)
+  - `main.go`: Health endpoint includes `guardrails_enabled` field, wired to enforcer presence
+  - VM systemd unit: Guardrails env vars added (rate limits, budget caps)
+
 - **Health Endpoint zeigt Circuit Breaker State** (#143)
   - `main.go`: Health endpoint (`/health`) includes `circuit_breakers` map with per-provider state
   - `pipeline.go`: New `BreakerStates()` method exposes CB states (closed/open/half-open)

--- a/cmd/cortex-gateway/internal/proxy/claude_code.go
+++ b/cmd/cortex-gateway/internal/proxy/claude_code.go
@@ -24,6 +24,14 @@ const (
 	claudeCodeHealthTimeout = 10 * time.Second
 )
 
+// claudeCodeUsage holds token usage from claude CLI result events.
+type claudeCodeUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+}
+
 // claudeCodeEvent is a single NDJSON event from the claude subprocess output.
 type claudeCodeEvent struct {
 	Type      string `json:"type"`
@@ -32,10 +40,11 @@ type claudeCodeEvent struct {
 	// For assistant messages
 	Message *claudeCodeAssistantMsg `json:"message,omitempty"`
 	// For result events
-	Result     string  `json:"result,omitempty"`
-	CostUSD    float64 `json:"total_cost_usd,omitempty"`
-	DurationMs int     `json:"duration_ms,omitempty"`
-	IsError    bool    `json:"is_error,omitempty"`
+	Result     string           `json:"result,omitempty"`
+	CostUSD    float64          `json:"total_cost_usd,omitempty"`
+	DurationMs int              `json:"duration_ms,omitempty"`
+	IsError    bool             `json:"is_error,omitempty"`
+	Usage      *claudeCodeUsage `json:"usage,omitempty"`
 }
 
 // claudeCodeContentBlock represents a content block in a claude assistant message.
@@ -225,10 +234,19 @@ func (p *ClaudeCodeProvider) parseOutputStream(r io.Reader) (*LLMResponse, error
 			if event.IsError {
 				return nil, fmt.Errorf("claude-code result error: %s", event.Result)
 			}
+			// Extract token usage from the result event
+			var inputTokens, outputTokens int
+			if event.Usage != nil {
+				inputTokens = event.Usage.InputTokens + event.Usage.CacheReadInputTokens + event.Usage.CacheCreationInputTokens
+				outputTokens = event.Usage.OutputTokens
+			}
 			// Result is the final event, stop reading
 			return &LLMResponse{
 				Content:      strings.Join(contentParts, ""),
 				FinishReason: finishReason,
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+				TokensUsed:   inputTokens + outputTokens,
 			}, nil
 		}
 	}

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -160,6 +160,14 @@ func NewPipelineHandler(cfg PipelineConfig) *PipelineHandler {
 	if deadline == 0 {
 		deadline = defaultProviderDeadline
 	}
+
+	// Pre-initialize token counter for all registered providers so the metric
+	// appears in /metrics immediately (not only after the first successful call).
+	for _, name := range cfg.Registry.List() {
+		pipelineTokensTotal.WithLabelValues(name, "input")
+		pipelineTokensTotal.WithLabelValues(name, "output")
+	}
+
 	return &PipelineHandler{
 		registry:         cfg.Registry,
 		config:           cfg.Config,

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -71,6 +71,11 @@ var (
 		Help:    "Quality gate scores by agent",
 		Buckets: []float64{1, 2, 3, 4, 5},
 	}, []string{"agent"})
+
+	pipelineTokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "sentinel_pipeline_tokens_total",
+		Help: "Total tokens consumed per provider and direction (always emitted)",
+	}, []string{"provider", "direction"})
 )
 
 // PipelineConfig haelt alle Abhaengigkeiten fuer den PipelineHandler.
@@ -339,7 +344,9 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// --- Step 6c: Guardrails Record ---
+	// --- Step 6c: Token Tracking + Guardrails Record ---
+	pipelineTokensTotal.WithLabelValues(providerName, "input").Add(float64(resp.InputTokens))
+	pipelineTokensTotal.WithLabelValues(providerName, "output").Add(float64(resp.OutputTokens))
 	if ph.guardrails != nil {
 		ph.guardrails.Record(providerName, resp.InputTokens, resp.OutputTokens)
 	}

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -196,7 +196,7 @@ func main() {
 	// 6. HTTP proxy server
 	proxyMux := http.NewServeMux()
 	proxyMux.Handle("POST /v1/chat/completions", pipelineHandler)
-	proxyMux.HandleFunc("GET /health", handleHealth(pipelineHandler))
+	proxyMux.HandleFunc("GET /health", handleHealth(pipelineHandler, guardrailsEnforcer != nil))
 	proxyMux.HandleFunc("GET /ready", handleReady)
 	proxyMux.Handle("GET /metrics", promhttp.Handler())
 
@@ -268,19 +268,21 @@ func main() {
 	logger.Info("cortex-gateway stopped")
 }
 
-func handleHealth(pipeline *proxy.PipelineHandler) http.HandlerFunc {
+func handleHealth(pipeline *proxy.PipelineHandler, guardrailsEnabled bool) http.HandlerFunc {
 	type healthResponse struct {
-		Status          string            `json:"status"`
-		Version         string            `json:"version"`
-		CircuitBreakers map[string]string `json:"circuit_breakers"`
+		Status            string            `json:"status"`
+		Version           string            `json:"version"`
+		CircuitBreakers   map[string]string `json:"circuit_breakers"`
+		GuardrailsEnabled bool              `json:"guardrails_enabled"`
 	}
 
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		resp := healthResponse{
-			Status:          "ok",
-			Version:         version,
-			CircuitBreakers: pipeline.BreakerStates(),
+			Status:            "ok",
+			Version:           version,
+			CircuitBreakers:   pipeline.BreakerStates(),
+			GuardrailsEnabled: guardrailsEnabled,
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	}


### PR DESCRIPTION
## Summary

Closes #145 — Enables guardrails feature-flag on VM, adds standalone pipeline token counter, exposes guardrails status in health endpoint, and fixes Claude Code provider token extraction. 3 of 5 audit problems (P-8, P-10, P-12) were already solved by prior sprints; this PR addresses the remaining 2 (P-9: guardrails disabled, P-11: token tracking gap).

## Changes

- **`claude_code.go`**: Add `claudeCodeUsage` struct; parse `usage` field from `result` events to extract `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`. Previously all token values were 0.
- **`pipeline.go`**: New `sentinel_pipeline_tokens_total` Prometheus CounterVec (labels: provider, direction) that fires on every provider call regardless of guardrails config. Pre-initialized in `NewPipelineHandler` for all registered providers so metric appears immediately in `/metrics`.
- **`main.go`**: `handleHealth()` now accepts `guardrailsEnabled bool` param; health response includes `guardrails_enabled` field wired to enforcer presence.
- **`CHANGELOG.md`**: #145 entry under Fixed.
- **VM systemd unit** (10.0.0.240): Added 5 environment variables: `SENTINEL_GUARDRAILS_ENABLED=true`, rate limits (20 agent RPM, 300 global RPM), budget caps (5M hourly, 50M daily tokens).

## Linked Issues

Closes #145

## Test Plan

- `go test ./cmd/cortex-gateway/... ./pkg/sentinel-go/...` — all 14 packages pass
- `go vet ./cmd/cortex-gateway/...` — clean
- Live VM verification of all 4 ACs via SSH with real LLM request

## Benchmarks

No performance-sensitive changes. Token counter is atomic increment (O(1) per request). No benchmark needed.

## Evidence (AC Mapping)

| AC | Command | Output | Status |
|----|---------|--------|--------|
| AC-1 | `curl -s localhost:8081/control/config` | `{"primary_provider":"claude-code","temperature":0.7,...}` 200 OK | PASS |
| AC-2a | `curl -s localhost:8080/health` | `{"status":"ok","version":"0.1.0","circuit_breakers":{},"guardrails_enabled":true}` | PASS |
| AC-2b | `curl -s localhost:8081/api/guardrails/status` | `{"budget":{"hourly_used":0,"hourly_limit":5000000,...},"cost":{"by_provider":{},"total_usd":0},"rate_limit":{"per_agent_rpm":20,"global_rpm":300}}` | PASS |
| AC-3a | `curl -s -X POST localhost:8080/v1/chat/completions -d '{"agent_id":1,"messages":[{"role":"user","content":"Sag Hallo"}]}'` | `{"content":"Hallo!","provider":"claude-code","tokens_used":21512,...}` | PASS |
| AC-3b | `curl -s localhost:8080/metrics \| grep sentinel_pipeline_tokens` | `sentinel_pipeline_tokens_total{direction="input",provider="claude-code"} 21492` + `{direction="output",provider="claude-code"} 20` | PASS |
| AC-N1 | `journalctl -u cortex-gateway \| grep 'assembler not configured' \| wc -l` | `0` | PASS |
| AC-N1b | `journalctl -u cortex-gateway \| grep '3-source assembly'` | `"3-source assembly enabled"` | PASS |
| Startup | `journalctl -u cortex-gateway --since '2 min ago'` | `"guardrails enabled" rate_agent_rpm=20 rate_global_rpm=300 budget_hourly=5000000 budget_daily=50000000` | PASS |

## Checklist

- [x] Code compiles without warnings
- [x] All existing tests pass (14/14 packages)
- [x] CHANGELOG.md updated
- [x] Conventional commit messages
- [x] No secrets committed
- [x] Live VM verification on 10.0.0.240 with real LLM request
- [x] All ACs verified with evidence (token values > 0 confirmed)