### PR TITLE
feat: Bio-Engine dynamics + active health monitoring (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bio-Engine Dynamics flach** (#148)
+  - `sentinel-bio/src/lib.rs`: Stress-Berechnung mit Traegheit (Exponential Smoothing: Anstieg alpha=0.3, Abfall alpha=0.1) + Baseline-Arbeitsstress der ueber den Tag akkumuliert (max 25)
+  - `sentinel-ecs/src/systems.rs`: Auto-Coffee Threshold von energy<50 auf energy<70 gesenkt, Frequenz von 300 auf 180 Ticks erhoehen — Agents trinken nun realistisch Kaffee am Vormittag
+  - `sentinel-ecs/src/autonomy.rs`: Return-to-Work nach P0-Notfaellen — Agents kehren automatisch zum Arbeitsraum zurueck wenn kein Notfall mehr aktiv ist (verhindert Deadlock auf Toilette/Kueche)
+  - `sentinel-common/src/events.rs`: BioStateUpdated Events enthalten nun Valence/Arousal Zahlenwerte (nicht nur kategorisches Mood-Label)
+  - 7 neue Tests (3 Stress-Traegheit, 4 Autonomy Return-to-Work)
+
 ### Added
+
+- **Service Health Monitor** — Aktive Ueberwachung aller Sentinel-Dienste
+  - `deploy/scripts/sentinel-health-monitor.sh`: Shell-Script prueft alle 60s via systemd-Timer: systemd-Status, HTTP /health Endpoints, NATS Health, Projection-Lag
+  - ntfy Alerts bei Statuswechsel (DOWN/RECOVERED), kein Spam durch State-File Deduplizierung
+  - Auto-Restart bei toten Services (max 3 Versuche pro Ausfall-Episode)
+  - Projection-Lag Monitoring: Warning >500, Critical >5000 Events
+  - `deploy/systemd/sentinel-health-monitor.timer`: 60s Intervall, persistent
+  - Alle 7 Service-Units gehaertet mit `StartLimitBurst=5` / `StartLimitIntervalSec=300`
+  - `sentinel.target` erweitert um Health-Monitor Timer
 
 - **PSI-basierte adaptive Tick-Rate** (#147)
   - `adaptive_tick.rs`: Neues Modul `AdaptiveTickRate` — liest `/proc/pressure/{cpu,memory,io}` und moduliert Tick-Rate dynamisch (TOGAF Adaptive Scheduling)

--- a/crates/sentinel-bio/src/lib.rs
+++ b/crates/sentinel-bio/src/lib.rs
@@ -36,6 +36,15 @@ const EXTROVERSION_THRESHOLD: f32 = 0.5;
 /// Arbeitsdrain pro Stunde seit Schichtbeginn (Energy-Penalty waehrend Arbeitszeit)
 const WORK_DRAIN_PER_HOUR: f32 = 3.0;
 
+/// Maximaler Baseline-Arbeitsstress am Ende eines vollen Arbeitstages
+const BASELINE_STRESS_MAX: f32 = 25.0;
+
+/// Stress-Anstiegs-Rate (Exponential Smoothing Alpha fuer steigende Tendenz)
+const STRESS_RISE_ALPHA: f32 = 0.3;
+
+/// Stress-Abfall-Rate (Exponential Smoothing Alpha fuer fallende Tendenz)
+const STRESS_FALL_ALPHA: f32 = 0.1;
+
 /// Aktualisiert alle Bio-Zustaende fuer einen Tick
 ///
 /// # Arguments
@@ -56,7 +65,7 @@ pub fn update_bio_state(
     update_hunger(bio, dt_hours);
     update_caffeine(bio, dt_seconds);
     update_bladder(bio, dt_hours);
-    update_stress(bio, personality, work);
+    update_stress(bio, personality, work, sim_hour);
     update_social_need(bio, personality, dt_hours);
     update_energy(bio, personality, sim_hour);
 }
@@ -88,8 +97,12 @@ fn update_bladder(bio: &mut BioState, dt_hours: f32) {
     bio.bladder = (bio.bladder + BLADDER_RATE_PER_HOUR * dt_hours * multiplier).clamp(0.0, 100.0);
 }
 
-/// Aktualisiert Stress (gewichteter Multi-Faktor)
-fn update_stress(bio: &mut BioState, personality: &Personality, work: &WorkContext) {
+/// Aktualisiert Stress (gewichteter Multi-Faktor mit Traegheit).
+///
+/// Stress wird als Exponential Smoothing berechnet: schneller Anstieg (alpha=0.3),
+/// langsamer Abfall (alpha=0.1). Zusaetzlich: Baseline-Arbeitsstress der ueber den
+/// Arbeitstag akkumuliert (max 25 bei Schichtende).
+fn update_stress(bio: &mut BioState, personality: &Personality, work: &WorkContext, sim_hour: f32) {
     // Meeting-Stress
     let meeting_stress = if work.in_meeting { 60.0 } else { 0.0 };
 
@@ -102,14 +115,32 @@ fn update_stress(bio: &mut BioState, personality: &Personality, work: &WorkConte
     // Bio-Stress (Hunger >50 erzeugt Stress)
     let bio_stress = (bio.hunger - 50.0).max(0.0) / 50.0 * 100.0;
 
-    // Gewichtete Summe
-    let raw =
-        0.3 * meeting_stress + 0.3 * deadline_stress + 0.2 * conflict_stress + 0.2 * bio_stress;
+    // Baseline-Arbeitsstress: Leichter Stress-Aufbau ueber den Arbeitstag (max 25)
+    let work_hours = if (6.0..22.0).contains(&sim_hour) {
+        sim_hour - 6.0
+    } else {
+        0.0
+    };
+    let baseline_stress = (work_hours / 16.0 * BASELINE_STRESS_MAX).min(BASELINE_STRESS_MAX);
+
+    // Gewichtete Summe (normalisiert auf 1.0)
+    let raw = 0.27 * meeting_stress
+        + 0.27 * deadline_stress
+        + 0.18 * conflict_stress
+        + 0.18 * bio_stress
+        + 0.10 * baseline_stress;
 
     // Neurotizismus skaliert Stress-Sensitivitaet
     let neuroticism_scale = 0.5 + personality.neuroticism * 0.5;
+    let target_stress = (raw * neuroticism_scale).clamp(0.0, 100.0);
 
-    bio.stress = (raw * neuroticism_scale).clamp(0.0, 100.0);
+    // Traegheit: Stress steigt schnell (alpha=0.3), faellt langsam ab (alpha=0.1)
+    let alpha = if target_stress > bio.stress {
+        STRESS_RISE_ALPHA
+    } else {
+        STRESS_FALL_ALPHA
+    };
+    bio.stress = (bio.stress + alpha * (target_stress - bio.stress)).clamp(0.0, 100.0);
 }
 
 /// Aktualisiert soziale Beduerfnisse (persoenlichkeitsabhaengig)
@@ -516,6 +547,82 @@ mod tests {
             bio.energy > 60.0,
             "Energy at 23:00 with no drain should be > 60 (got {})",
             bio.energy
+        );
+    }
+
+    #[test]
+    fn test_stress_inertia_rises_gradually() {
+        let mut bio = default_bio();
+        bio.stress = 0.0;
+        let personality = default_personality();
+        let mut work = default_work();
+        work.in_meeting = true;
+
+        // Erster Tick: Stress steigt, aber nicht sofort auf Maximum
+        update_stress(&mut bio, &personality, &work, 10.0);
+        let stress_after_1 = bio.stress;
+        assert!(
+            stress_after_1 > 0.0,
+            "Stress should rise above 0 with meeting: {}",
+            stress_after_1
+        );
+
+        // Mehrere Ticks: Stress naehert sich Target graduell an
+        for _ in 0..20 {
+            update_stress(&mut bio, &personality, &work, 10.0);
+        }
+        let stress_after_20 = bio.stress;
+        assert!(
+            stress_after_20 > stress_after_1,
+            "Stress should keep rising: {} > {}",
+            stress_after_20,
+            stress_after_1
+        );
+    }
+
+    #[test]
+    fn test_stress_inertia_falls_slowly() {
+        let mut bio = default_bio();
+        bio.stress = 30.0; // Startwert: vorher gestresst
+        let personality = default_personality();
+        let work = default_work(); // Kein Meeting, kein Stress-Treiber
+
+        // Stress soll langsam fallen, NICHT sofort auf 0
+        update_stress(&mut bio, &personality, &work, 10.0);
+        assert!(
+            bio.stress > 0.0,
+            "Stress should not drop to 0 instantly: {}",
+            bio.stress
+        );
+
+        // Nach vielen Ticks faellt Stress weiter aber langsam
+        let stress_before = bio.stress;
+        for _ in 0..10 {
+            update_stress(&mut bio, &personality, &work, 10.0);
+        }
+        assert!(
+            bio.stress < stress_before,
+            "Stress should decrease over time: {} < {}",
+            bio.stress,
+            stress_before
+        );
+    }
+
+    #[test]
+    fn test_baseline_work_stress() {
+        let mut bio = default_bio();
+        bio.stress = 0.0;
+        let personality = default_personality();
+        let work = default_work(); // Kein Meeting, kein Deadline
+
+        // Nachmittag (14h): 8h gearbeitet → Baseline-Stress > 0
+        for _ in 0..50 {
+            update_stress(&mut bio, &personality, &work, 14.0);
+        }
+        assert!(
+            bio.stress > 0.0,
+            "Baseline work stress at 14h should be > 0: {}",
+            bio.stress
         );
     }
 

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -131,6 +131,8 @@ pub enum DomainEventPayload {
         caffeine_mg: f32,
         room_id: String,
         mood: String,
+        valence: f32,
+        arousal: f32,
     },
     /// Periodischer Raum-Physik Snapshot (Temperatur, CO2, Laerm)
     RoomPhysicsUpdated {

--- a/crates/sentinel-ecs/src/autonomy.rs
+++ b/crates/sentinel-ecs/src/autonomy.rs
@@ -163,6 +163,24 @@ pub fn autonomy_system(
                 );
                 cooldown.last_action_tick = tick;
             }
+            continue;
+        }
+
+        // Kein P0-Notfall aktiv → zurueck zum Arbeitsraum wenn in Utility-Raum
+        // (Toilette, Kueche, Flur). Verhindert dass Agents nach Notfall stecken bleiben.
+        if is_utility_room(&position.room_id) {
+            let home_room = default_work_room(&identity.role, identity.agent_id.0);
+            if position.room_id != home_room {
+                start_transit(
+                    identity,
+                    &mut position,
+                    &home_room,
+                    &correlation_id,
+                    tick,
+                    &mut event_buffer,
+                );
+                cooldown.last_action_tick = tick;
+            }
         }
     }
 }
@@ -235,6 +253,38 @@ fn nearest_toilet(current_room: &str, agent_id: u32) -> String {
         format!("toilette-og-{}", gender_suffix)
     } else {
         format!("toilette-eg-{}", gender_suffix)
+    }
+}
+
+/// Prueft ob ein Raum ein Utility-Raum ist (Toilette, Kueche, Flur).
+/// Agents sollen nach P0-Notfaellen nicht in diesen Raeumen verweilen.
+fn is_utility_room(room_id: &str) -> bool {
+    room_id.starts_with("toilette")
+        || room_id.starts_with("flur")
+        || room_id == "kueche"
+        || room_id == "empfang"
+}
+
+/// Bestimmt den Standard-Arbeitsraum eines Agents basierend auf Rolle und ID.
+/// Deterministisch: gleiche Inputs → gleicher Raum.
+fn default_work_room(role: &str, agent_id: u16) -> String {
+    let role_lower = role.to_lowercase();
+    if role_lower.contains("ceo") || role_lower.contains("geschaeft") {
+        "buero-ceo".to_string()
+    } else if role_lower.contains("design") {
+        // Design-Agents: auf buero-design-1 und buero-design-2 verteilen
+        if agent_id.is_multiple_of(2) {
+            "buero-design-1".to_string()
+        } else {
+            "buero-design-2".to_string()
+        }
+    } else {
+        // Dev und alle anderen: auf buero-dev-1 und buero-dev-2 verteilen
+        if agent_id.is_multiple_of(2) {
+            "buero-dev-1".to_string()
+        } else {
+            "buero-dev-2".to_string()
+        }
     }
 }
 
@@ -372,5 +422,82 @@ mod tests {
             !bio_events.is_empty(),
             "BioActionPerformed Event sollte erzeugt werden"
         );
+    }
+
+    #[test]
+    fn test_return_to_work_from_toilet() {
+        let (mut world, _) = create_simulation_world();
+        let entity = spawn_agent(&mut world, AgentId(1), "Test", "Dev", 1);
+        world.entity_mut(entity).insert(AutonomyCooldown::default());
+
+        // Agent auf Toilette, KEIN P0-Notfall (bladder=10, hunger=20, energy=80, stress=0)
+        world.get_mut::<Position>(entity).unwrap().room_id = "toilette-eg-herren".to_string();
+        world.get_mut::<BioState>(entity).unwrap().bladder = 10.0;
+        world.get_mut::<BioState>(entity).unwrap().hunger = 20.0;
+
+        let mut schedule = bevy_ecs::schedule::Schedule::default();
+        schedule.add_systems(autonomy_system);
+
+        world.resource_mut::<SimulationTime>().tick = Tick(31);
+        schedule.run(&mut world);
+
+        // Agent sollte Transit zum Arbeitsraum starten
+        let pos = world.get::<Position>(entity).unwrap();
+        assert!(
+            pos.in_transit,
+            "Agent sollte nach P0-Abschluss zum Arbeitsraum zurueckkehren"
+        );
+        assert!(
+            pos.transit_target.as_ref().unwrap().starts_with("buero-"),
+            "Ziel sollte ein Buero sein, got: {:?}",
+            pos.transit_target
+        );
+    }
+
+    #[test]
+    fn test_no_return_during_p0() {
+        let (mut world, _) = create_simulation_world();
+        let entity = spawn_agent(&mut world, AgentId(1), "Test", "Dev", 1);
+        world.entity_mut(entity).insert(AutonomyCooldown::default());
+
+        // Agent auf Toilette MIT P0-Notfall (bladder=95)
+        world.get_mut::<Position>(entity).unwrap().room_id = "toilette-eg-herren".to_string();
+        world.get_mut::<BioState>(entity).unwrap().bladder = 95.0;
+
+        let mut schedule = bevy_ecs::schedule::Schedule::default();
+        schedule.add_systems(autonomy_system);
+
+        world.resource_mut::<SimulationTime>().tick = Tick(31);
+        schedule.run(&mut world);
+
+        // P0 hat Prioritaet: Agent bleibt (use_bathroom wird ausgefuehrt)
+        let bio = world.get::<BioState>(entity).unwrap();
+        assert!(
+            bio.bladder < 30.0,
+            "P0 sollte use_bathroom ausfuehren: bladder={}",
+            bio.bladder
+        );
+    }
+
+    #[test]
+    fn test_is_utility_room() {
+        assert!(is_utility_room("toilette-eg-herren"));
+        assert!(is_utility_room("toilette-og-damen"));
+        assert!(is_utility_room("kueche"));
+        assert!(is_utility_room("flur-eg"));
+        assert!(is_utility_room("empfang"));
+        assert!(!is_utility_room("buero-dev-1"));
+        assert!(!is_utility_room("buero-ceo"));
+        assert!(!is_utility_room("meetingraum-01"));
+    }
+
+    #[test]
+    fn test_default_work_room() {
+        assert_eq!(default_work_room("CEO", 1), "buero-ceo");
+        assert_eq!(default_work_room("Design", 2), "buero-design-1");
+        assert_eq!(default_work_room("Design", 3), "buero-design-2");
+        assert_eq!(default_work_room("Dev", 2), "buero-dev-1");
+        assert_eq!(default_work_room("Dev", 3), "buero-dev-2");
+        assert_eq!(default_work_room("HR", 1), "buero-dev-2"); // Default
     }
 }

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -250,13 +250,14 @@ pub fn bio_system(
             time.sim_hour,
         );
 
-        // Auto-Coffee: Agent trinkt automatisch Kaffee bei niedrigem Energy-Level
-        // Bedingungen: Energy < 50, Koffein < 10mg, Arbeitszeit (08-16h), max 1x/5min
-        if bio.energy < 50.0
+        // Auto-Coffee: Agent trinkt Kaffee bei moderater Muedigkeit
+        // Threshold: energy<70 (realistisch — Menschen trinken Kaffee bevor sie erschoepft sind)
+        // Frequenz: alle 3 Minuten (180 Ticks bei 1Hz)
+        if bio.energy < 70.0
             && bio.caffeine_mg < 10.0
             && (8.0..16.0).contains(&time.sim_hour)
             && tick > 0
-            && tick.is_multiple_of(300)
+            && tick.is_multiple_of(180)
         {
             sentinel_bio::drink_coffee(&mut bio);
             let bio_payload = DomainEventPayload::BioActionPerformed {
@@ -285,6 +286,8 @@ pub fn bio_system(
                 caffeine_mg: bio.caffeine_mg,
                 room_id: position.room_id.clone(),
                 mood: format!("{:?}", mood.dominant_emotion),
+                valence: mood.valence,
+                arousal: mood.arousal,
             };
             let event = DomainEvent::new(
                 payload.event_type_str(),

--- a/crates/sentinel-projection/src/handlers/agent_live_view.rs
+++ b/crates/sentinel-projection/src/handlers/agent_live_view.rs
@@ -126,6 +126,8 @@ impl ProjectionHandler for AgentLiveViewHandler {
                 caffeine_mg,
                 room_id,
                 mood,
+                valence: _,
+                arousal: _,
             } => {
                 debug!(
                     agent_id = agent_id.0,

--- a/deploy/scripts/sentinel-health-monitor.sh
+++ b/deploy/scripts/sentinel-health-monitor.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# sentinel-health-monitor.sh — Active health monitoring for all Sentinel services.
+#
+# Runs via systemd timer every 60s. Checks:
+#   - systemd service status (is-active)
+#   - HTTP /health endpoints (where available)
+#   - NATS monitoring endpoint (:8222/healthz)
+#   - Projection lag (events.db vs projection_offsets)
+#
+# Alerts via ntfy on state transitions only (no spam).
+# Attempts auto-restart for failed services (max 3 per episode).
+#
+# State file: /opt/sentinel/data/health-monitor.state
+# Config:     /opt/sentinel/config/health-monitor.env (optional overrides)
+set -uo pipefail
+
+readonly SCRIPT_NAME="sentinel-health-monitor"
+readonly STATE_FILE="/opt/sentinel/data/health-monitor.state"
+readonly EVENT_STORE_DB="/opt/sentinel/data/events.db"
+
+# --- Defaults (overridable via env file) ---
+NTFY_SERVER="${NTFY_SERVER:-https://10.0.0.150}"
+NTFY_TOPIC="${NTFY_TOPIC:-sentinel-health}"
+LAG_WARN="${LAG_WARN:-500}"
+LAG_CRIT="${LAG_CRIT:-5000}"
+MAX_RESTARTS="${MAX_RESTARTS:-3}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-5}"
+
+# Load env overrides if available
+if [ -f /opt/sentinel/config/health-monitor.env ]; then
+    # shellcheck source=/dev/null
+    source /opt/sentinel/config/health-monitor.env
+fi
+
+# --- Associative arrays for state tracking ---
+declare -A PREV_STATUS PREV_SINCE PREV_RESTARTS
+declare -A CURR_STATUS CURR_SINCE CURR_RESTARTS
+
+# --- Logging ---
+log_info()  { logger -t "$SCRIPT_NAME" "$*"; }
+log_error() { logger -t "$SCRIPT_NAME" -p user.err "$*"; }
+now_epoch() { date +%s; }
+
+# --- State File I/O ---
+
+load_state() {
+    if [ ! -f "$STATE_FILE" ]; then
+        return
+    fi
+    while IFS=: read -r name status since restarts; do
+        [ -z "$name" ] && continue
+        [[ "$name" == \#* ]] && continue
+        PREV_STATUS[$name]="$status"
+        PREV_SINCE[$name]="$since"
+        PREV_RESTARTS[$name]="$restarts"
+    done < "$STATE_FILE"
+}
+
+save_state() {
+    local now
+    now=$(now_epoch)
+    {
+        echo "# sentinel-health-monitor state — $(date -Iseconds)"
+        for name in "${!CURR_STATUS[@]}"; do
+            local status="${CURR_STATUS[$name]}"
+            local since="${CURR_SINCE[$name]:-$now}"
+            local restarts="${CURR_RESTARTS[$name]:-0}"
+            echo "$name:$status:$since:$restarts"
+        done
+    } > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
+
+# --- Alert Functions ---
+
+send_ntfy() {
+    local title="$1" message="$2" priority="${3:-3}" tags="${4:-warning}"
+    curl -sk \
+        -H "Title: $title" \
+        -H "Priority: $priority" \
+        -H "Tags: $tags" \
+        -d "$message" \
+        "$NTFY_SERVER/$NTFY_TOPIC" 2>/dev/null || true
+}
+
+alert_down() {
+    local name="$1" detail="$2" priority="$3"
+    send_ntfy \
+        "[SENTINEL] $name DOWN" \
+        "$detail. Auto-restart attempted." \
+        "$priority" \
+        "rotating_light,sentinel"
+    log_info "ALERT DOWN: $name — $detail"
+}
+
+alert_recovered() {
+    local name="$1" downtime_human="$2"
+    send_ntfy \
+        "[SENTINEL] $name RECOVERED" \
+        "Back online after $downtime_human downtime." \
+        "3" \
+        "white_check_mark,sentinel"
+    log_info "ALERT RECOVERED: $name after $downtime_human"
+}
+
+alert_lag() {
+    local lag="$1" severity="$2"
+    local priority=3
+    [ "$severity" = "critical" ] && priority=5
+    send_ntfy \
+        "[SENTINEL] Projection Lag ${severity^^}" \
+        "Lag: $lag events (warn: $LAG_WARN, crit: $LAG_CRIT)." \
+        "$priority" \
+        "snail,sentinel"
+    log_info "ALERT LAG $severity: $lag events"
+}
+
+human_duration() {
+    local secs="$1"
+    if [ "$secs" -lt 60 ]; then
+        echo "${secs}s"
+    elif [ "$secs" -lt 3600 ]; then
+        echo "$((secs / 60))m $((secs % 60))s"
+    elif [ "$secs" -lt 86400 ]; then
+        echo "$((secs / 3600))h $((secs % 3600 / 60))m"
+    else
+        echo "$((secs / 86400))d $((secs % 86400 / 3600))h"
+    fi
+}
+
+# --- Check Functions ---
+
+check_systemd_unit() {
+    local unit="$1"
+    systemctl is-active --quiet "$unit" 2>/dev/null
+}
+
+check_http_health() {
+    local port="$1" path="$2"
+    curl -sf --connect-timeout 3 --max-time "$CURL_TIMEOUT" \
+        "http://localhost:${port}${path}" >/dev/null 2>&1
+}
+
+check_nats_health() {
+    curl -sf --connect-timeout 3 --max-time "$CURL_TIMEOUT" \
+        "http://localhost:8222/healthz" >/dev/null 2>&1
+}
+
+check_projection_lag() {
+    if [ ! -f "$EVENT_STORE_DB" ]; then
+        echo "0"
+        return
+    fi
+    local max_id offset lag
+    max_id=$(sqlite3 "$EVENT_STORE_DB" \
+        "SELECT COALESCE(MAX(id), 0) FROM events" 2>/dev/null) || max_id=0
+    offset=$(sqlite3 "$EVENT_STORE_DB" \
+        "SELECT COALESCE(last_event_id, 0) FROM projection_offsets WHERE projection_name='sentinel-projection'" \
+        2>/dev/null) || offset=0
+    lag=$((max_id - offset))
+    [ "$lag" -lt 0 ] && lag=0
+    echo "$lag"
+}
+
+try_restart() {
+    local unit="$1" name="$2"
+    local count="${CURR_RESTARTS[$name]:-0}"
+
+    if [ "$count" -ge "$MAX_RESTARTS" ]; then
+        log_info "$name: restart limit ($MAX_RESTARTS) reached — manual intervention required"
+        return 1
+    fi
+
+    CURR_RESTARTS[$name]=$((count + 1))
+    log_info "$name: restarting (${CURR_RESTARTS[$name]}/$MAX_RESTARTS)"
+    systemctl restart "$unit" 2>/dev/null || true
+    sleep 3
+
+    if check_systemd_unit "$unit"; then
+        log_info "$name: restart successful"
+        return 0
+    else
+        log_info "$name: restart failed"
+        return 1
+    fi
+}
+
+# --- Service Check Logic ---
+
+check_service() {
+    local name="$1" unit="$2" check_type="$3" port="$4" path="$5" priority="$6"
+    local now
+    now=$(now_epoch)
+    local is_ok=false
+    local prev="${PREV_STATUS[$name]:-ok}"
+    local prev_since="${PREV_SINCE[$name]:-$now}"
+    local prev_restarts="${PREV_RESTARTS[$name]:-0}"
+
+    # Determine health
+    case "$check_type" in
+        systemd)
+            check_systemd_unit "$unit" && is_ok=true
+            ;;
+        http)
+            if check_systemd_unit "$unit"; then
+                check_http_health "$port" "$path" && is_ok=true
+            fi
+            ;;
+        nats)
+            if check_systemd_unit "$unit"; then
+                check_nats_health && is_ok=true
+            fi
+            ;;
+    esac
+
+    if $is_ok; then
+        CURR_STATUS[$name]="ok"
+        CURR_SINCE[$name]="$now"
+        CURR_RESTARTS[$name]=0
+
+        # Recovery detection
+        if [ "$prev" != "ok" ]; then
+            local downtime=$((now - prev_since))
+            alert_recovered "$name" "$(human_duration $downtime)"
+        fi
+    else
+        CURR_STATUS[$name]="failed"
+        CURR_RESTARTS[$name]="$prev_restarts"
+
+        if [ "$prev" = "ok" ]; then
+            # New failure — alert + restart
+            CURR_SINCE[$name]="$now"
+            alert_down "$name" "$unit is inactive/unhealthy" "$priority"
+            try_restart "$unit" "$name"
+        else
+            # Ongoing failure — keep since timestamp, try restart if under limit
+            CURR_SINCE[$name]="$prev_since"
+            try_restart "$unit" "$name" 2>/dev/null || true
+        fi
+    fi
+}
+
+# --- Main ---
+
+main() {
+    load_state
+    local now
+    now=$(now_epoch)
+
+    # Service definitions: name:unit:check_type:port:path:priority
+    local services=(
+        "daemon:sentinel-daemon.service:systemd:::5"
+        "projection:sentinel-projection.service:systemd:::5"
+        "nats:nats-server.service:nats:::5"
+        "cortex:sentinel-cortex.service:http:8080:/health:5"
+        "dashboard:sentinel-dashboard.service:http:8000:/api/health:3"
+        "judge:sentinel-judge.service:http:8082:/health:3"
+        "nats-bridge:sentinel-nats-bridge.service:http:8083:/health:3"
+    )
+
+    for entry in "${services[@]}"; do
+        IFS=: read -r name unit check_type port path priority <<< "$entry"
+        check_service "$name" "$unit" "$check_type" "$port" "$path" "$priority"
+    done
+
+    # --- Projection Lag Check (independent of service status) ---
+    local lag
+    lag=$(check_projection_lag)
+    local prev_lag_status="${PREV_STATUS[projection-lag]:-ok}"
+
+    if [ "$lag" -ge "$LAG_CRIT" ]; then
+        CURR_STATUS[projection-lag]="critical"
+        CURR_RESTARTS[projection-lag]="${PREV_RESTARTS[projection-lag]:-0}"
+        if [ "$prev_lag_status" != "critical" ]; then
+            CURR_SINCE[projection-lag]="$now"
+            alert_lag "$lag" "critical"
+            try_restart "sentinel-projection.service" "projection" 2>/dev/null || true
+        else
+            CURR_SINCE[projection-lag]="${PREV_SINCE[projection-lag]:-$now}"
+        fi
+    elif [ "$lag" -ge "$LAG_WARN" ]; then
+        CURR_STATUS[projection-lag]="warning"
+        CURR_RESTARTS[projection-lag]=0
+        if [ "$prev_lag_status" = "ok" ]; then
+            CURR_SINCE[projection-lag]="$now"
+            alert_lag "$lag" "warning"
+        else
+            CURR_SINCE[projection-lag]="${PREV_SINCE[projection-lag]:-$now}"
+        fi
+    else
+        CURR_STATUS[projection-lag]="ok"
+        CURR_SINCE[projection-lag]="$now"
+        CURR_RESTARTS[projection-lag]=0
+        if [ "$prev_lag_status" != "ok" ]; then
+            log_info "Projection lag recovered: $lag events"
+        fi
+    fi
+
+    save_state
+
+    # Summary log line
+    local summary=""
+    for k in $(echo "${!CURR_STATUS[@]}" | tr ' ' '\n' | sort); do
+        summary+="$k=${CURR_STATUS[$k]} "
+    done
+    log_info "Check complete: ${summary}lag=$lag"
+}
+
+main "$@"

--- a/deploy/systemd/nats-server.service
+++ b/deploy/systemd/nats-server.service
@@ -2,6 +2,8 @@
 Description=NATS JetStream Server — Go Message Bus
 Documentation=https://github.com/obtFusi/project-sentinel/issues/26
 Before=sentinel-nats-bridge.service sentinel-judge.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-cortex.service
+++ b/deploy/systemd/sentinel-cortex.service
@@ -3,6 +3,8 @@ Description=Sentinel Cortex Gateway — LLM Pipeline Proxy
 Documentation=https://github.com/obtFusi/project-sentinel/issues/28
 After=sentinel-daemon.service
 Requires=sentinel-daemon.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-daemon.service
+++ b/deploy/systemd/sentinel-daemon.service
@@ -3,6 +3,8 @@ Description=Sentinel Daemon — ECS Orchestrator
 Documentation=https://github.com/obtFusi/project-sentinel/issues/94
 After=network-online.target
 Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-dashboard.service
+++ b/deploy/systemd/sentinel-dashboard.service
@@ -2,6 +2,8 @@
 Description=Sentinel Dashboard — Web UI + WebSocket
 Documentation=https://github.com/obtFusi/project-sentinel/issues/28
 After=sentinel-cortex.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-health-monitor.service
+++ b/deploy/systemd/sentinel-health-monitor.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sentinel Health Monitor — Service Health Check
+Documentation=https://github.com/obtFusi/project-sentinel
+
+[Service]
+Type=oneshot
+ExecStart=/opt/sentinel/scripts/sentinel-health-monitor.sh
+TimeoutStartSec=30
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sentinel-health-monitor
+ReadWritePaths=/opt/sentinel/data

--- a/deploy/systemd/sentinel-health-monitor.timer
+++ b/deploy/systemd/sentinel-health-monitor.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sentinel Health Monitor Timer — Check every 60s
+Documentation=https://github.com/obtFusi/project-sentinel
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=60
+AccuracySec=5
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/sentinel-judge.service
+++ b/deploy/systemd/sentinel-judge.service
@@ -3,6 +3,8 @@ Description=Sentinel Judge — Quality Analysis Service (NATS + LLM)
 Documentation=https://github.com/obtFusi/project-sentinel/issues/26
 After=nats-server.service sentinel-nats-bridge.service sentinel-cortex.service
 Requires=nats-server.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-nats-bridge.service
+++ b/deploy/systemd/sentinel-nats-bridge.service
@@ -3,6 +3,8 @@ Description=Sentinel NATS Bridge — Limbo EventStore to NATS JetStream
 Documentation=https://github.com/obtFusi/project-sentinel/issues/26
 After=nats-server.service sentinel-daemon.service
 Requires=nats-server.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel-projection.service
+++ b/deploy/systemd/sentinel-projection.service
@@ -3,6 +3,8 @@ Description=Sentinel Projection Worker — CQRS Read-Model Service
 Documentation=https://github.com/obtFusi/project-sentinel/issues/53
 After=sentinel-daemon.service
 Requires=sentinel-daemon.service
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple

--- a/deploy/systemd/sentinel.target
+++ b/deploy/systemd/sentinel.target
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sentinel Simulation Stack
 Documentation=https://github.com/obtFusi/project-sentinel/issues/28
-Wants=sentinel-daemon.service sentinel-cortex.service sentinel-dashboard.service sentinel-projection.service sentinel-nightrun.timer nats-server.service sentinel-nats-bridge.service sentinel-judge.service
+Wants=sentinel-daemon.service sentinel-cortex.service sentinel-dashboard.service sentinel-projection.service sentinel-nightrun.timer nats-server.service sentinel-nats-bridge.service sentinel-judge.service sentinel-health-monitor.timer
 
 [Install]
 WantedBy=multi-user.target

--- a/typos.toml
+++ b/typos.toml
@@ -441,6 +441,18 @@ fertig = "fertig"
 schaue = "schaue"
 Satzlaenge = "Satzlaenge"
 
+# Bio-Engine dynamics words (Issue #148 - German in Rust doc comments)
+realistisch = "realistisch"
+realistische = "realistische"
+realistischen = "realistischen"
+realistischer = "realistischer"
+Muedigkeit = "Muedigkeit"
+Traegheit = "Traegheit"
+Erschoepft = "Erschoepft"
+Akkumuliert = "Akkumuliert"
+akkumuliert = "akkumuliert"
+Arbeitstages = "Arbeitstages"
+
 # Prompt Compiler words (Issue #58 - German personality traits in Go string literals)
 pragmatisch = "pragmatisch"
 flexibel = "flexibel"


### PR DESCRIPTION
## Summary
- Bio-Engine dynamics: stress inertia, auto-coffee at energy<70, autonomy return-to-work after P0 emergencies
- Active health monitoring: 60s timer checks all 7 services, ntfy alerts on state changes, auto-restart with max 3 attempts
- systemd unit hardening with StartLimitBurst across all services

## Changes
- `sentinel-bio`: Stress exponential smoothing (rise α=0.3, fall α=0.1), baseline work stress accumulating over day
- `sentinel-ecs/autonomy`: Return-to-work logic after P0 bio emergencies (toilet→office, kitchen→office)
- `sentinel-ecs/systems`: Auto-coffee in bio_system at energy<70, caffeine<10, sim_hour 8-16
- `sentinel-common/events`: valence/arousal fields in BioStateUpdated
- `sentinel-projection`: Handle new valence/arousal in agent_live_view handler
- `deploy/scripts/sentinel-health-monitor.sh`: Full health monitoring with ntfy integration
- `deploy/systemd/`: Timer, service unit, StartLimitBurst hardening on all 7 units

## Linked Issues
Closes #148

## Test Plan
- [x] `cargo remote -- test --workspace` — all tests pass
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — clean
- [x] Deploy to VM (10.0.0.240) and verify via API
- [x] Health monitor deployed, timer active, tested with simulated failure

## Benchmarks
N/A — no performance-critical changes, bio calculations are O(n) per agent per tick

## Evidence (AC Mapping)

| AC | Criterion | Evidence | Status |
|----|-----------|----------|--------|
| AC-1 | Stress != 0.0 | `curl api/agents` → stress 1.31-1.86 across 24 agents (previously constant 0.0) | PASS |
| AC-2 | Energy < 95 | `curl api/agents` → energy 15.5-43.75, all < 95 (previously constant 95.0) | PASS |
| AC-3 | Caffeine > 0 after coffee | Agent 19 (Tim Vogt): caffeine_mg=94.85 after auto-coffee trigger at tick 2034 | PASS |
| AC-N1 | No out-of-range values | 0 violations across all 24 agents (stress 0-100, energy 0-100) | PASS |

**Bonus: Health Monitor Verification**
- DOWN detection: cortex DOWN alert sent via ntfy (P5/urgent)
- Auto-restart: projection stopped → detected → restarted → confirmed running
- RECOVERY: projection RECOVERED alert sent with 16s downtime duration
- Timer active: `sentinel-health-monitor.timer` running every 60s on VM

## Checklist
- [x] Tests pass (`cargo remote -- test --workspace`)
- [x] Clippy clean (`cargo remote -- clippy ... -D warnings`)
- [x] CHANGELOG.md updated
- [x] Deployed and verified on VM (10.0.0.240)
- [x] No secrets committed
- [x] Conventional commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)