### PR TITLE
feat: transit variance, hallway encounters, smell events, PSI→bio integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Transit-Varianz + Flurbegegnungen** (#194)
+  - `sentinel-common/src/room.rs`: `shortest_distance()` BFS-Methode fuer Raum-Distanzen + 5 Tests
+  - `sentinel-ecs/src/systems.rs`: Transit-Dauer von hart-codiertem 3000ms auf `(1500 + hops * 800).clamp(2000, 5000)` umgestellt (distanz-basiert)
+  - `sentinel-ecs/src/systems.rs`: `encounter_system()` — Flurbegegnungen zwischen in-Transit Agents (splitmix64 RNG, 30% Wahrscheinlichkeit, alle 10 Ticks)
+  - `sentinel-ecs/src/world.rs`: `RoomDistanceMap` ECS Resource (vorberechnete BFS-Distanzen aus rooms.toml)
+  - `sentinel-common/src/events.rs`: `HallwayEncounterDetected` DomainEventPayload-Variante
+
+- **SmellEvents End-to-End** (#195)
+  - `sentinel-ecs/src/systems.rs`: `smell_system()` — generiert Coffee-SmellEvents bei Auto-Coffee (caffeine > 90mg)
+  - `sentinel-common/src/events.rs`: `SmellEventTriggered` DomainEventPayload-Variante (room_id, smell_type, intensity, duration_ticks)
+
+- **PSI→Bio Integration** (#196)
+  - `sentinel-ecs/src/systems.rs`: `bio_system()` ruft `apply_psi_stress()` auf via `PsiMetrics` ECS Resource
+  - `sentinel-ecs/src/world.rs`: `PsiMetrics` ECS Resource (cpu_avg10, mem_avg10)
+  - `services/sentinel-daemon/src/orchestrator.rs`: PSI-Metriken aus AdaptiveTickRate in ECS World injiziert vor jedem Schedule-Run
+
 ### Fixed
 
 - **Bio-Engine Dynamics flach** (#148)

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -209,6 +209,19 @@ pub enum DomainEventPayload {
         score: f64,
         details: String,
     },
+    /// Zwei Agents begegnen sich im Flur waehrend Transit
+    HallwayEncounterDetected {
+        agent_a: AgentId,
+        agent_b: AgentId,
+        location: String,
+    },
+    /// Geruchsereignis in einem Raum (Coffee, Food, etc.)
+    SmellEventTriggered {
+        room_id: String,
+        smell_type: String,
+        intensity: f32,
+        duration_ticks: u64,
+    },
 }
 
 impl DomainEventPayload {
@@ -237,6 +250,8 @@ impl DomainEventPayload {
             Self::AgentConsolidated { .. } => "agent_consolidated",
             Self::AgentConsolidationFailed { .. } => "agent_consolidation_failed",
             Self::JudgeAlertReceived { .. } => "judge_alert_received",
+            Self::HallwayEncounterDetected { .. } => "hallway_encounter_detected",
+            Self::SmellEventTriggered { .. } => "smell_event_triggered",
         }
     }
 }

--- a/crates/sentinel-common/src/room.rs
+++ b/crates/sentinel-common/src/room.rs
@@ -154,6 +154,53 @@ impl BuildingConfig {
             .filter(|r| r.department.as_deref() == Some(department))
             .collect()
     }
+
+    /// Berechnet kuerzesten Pfad (Hop-Count) zwischen zwei Raeumen via BFS.
+    ///
+    /// Gibt `None` zurueck wenn einer der Raeume nicht existiert oder
+    /// kein Pfad vorhanden ist (sollte bei validem rooms.toml nicht vorkommen).
+    pub fn shortest_distance(&self, from: &str, to: &str) -> Option<u32> {
+        if from == to {
+            return Some(0);
+        }
+
+        // Build adjacency map
+        let adjacency: HashMap<&str, Vec<&str>> = self
+            .rooms
+            .iter()
+            .map(|r| {
+                (
+                    r.id.as_str(),
+                    r.adjacent.iter().map(|a| a.as_str()).collect(),
+                )
+            })
+            .collect();
+
+        if !adjacency.contains_key(from) || !adjacency.contains_key(to) {
+            return None;
+        }
+
+        // BFS
+        let mut visited: HashSet<&str> = HashSet::new();
+        let mut queue: std::collections::VecDeque<(&str, u32)> = std::collections::VecDeque::new();
+        visited.insert(from);
+        queue.push_back((from, 0));
+
+        while let Some((current, dist)) = queue.pop_front() {
+            if let Some(neighbors) = adjacency.get(current) {
+                for &neighbor in neighbors {
+                    if neighbor == to {
+                        return Some(dist + 1);
+                    }
+                    if visited.insert(neighbor) {
+                        queue.push_back((neighbor, dist + 1));
+                    }
+                }
+            }
+        }
+
+        None // Kein Pfad gefunden
+    }
 }
 
 #[cfg(test)]
@@ -237,6 +284,44 @@ mod tests {
 
         let design_rooms = config.rooms_by_department("Design");
         assert_eq!(design_rooms.len(), 2, "Expected 2 Design rooms");
+    }
+
+    #[test]
+    fn test_shortest_distance_same_room() {
+        let config = load_test_config();
+        assert_eq!(config.shortest_distance("kueche", "kueche"), Some(0));
+    }
+
+    #[test]
+    fn test_shortest_distance_adjacent() {
+        let config = load_test_config();
+        // kueche <-> flur-eg: 1 hop
+        assert_eq!(config.shortest_distance("kueche", "flur-eg"), Some(1));
+        assert_eq!(config.shortest_distance("flur-eg", "kueche"), Some(1));
+    }
+
+    #[test]
+    fn test_shortest_distance_two_hops() {
+        let config = load_test_config();
+        // buero-dev-1 -> flur-eg -> kueche: 2 hops
+        assert_eq!(config.shortest_distance("buero-dev-1", "kueche"), Some(2));
+    }
+
+    #[test]
+    fn test_shortest_distance_cross_floor() {
+        let config = load_test_config();
+        // buero-dev-1 -> flur-eg -> treppenhaus -> flur-og -> buero-design-1: 4 hops
+        assert_eq!(
+            config.shortest_distance("buero-dev-1", "buero-design-1"),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn test_shortest_distance_nonexistent_room() {
+        let config = load_test_config();
+        assert_eq!(config.shortest_distance("kueche", "nonexistent"), None);
+        assert_eq!(config.shortest_distance("nonexistent", "kueche"), None);
     }
 
     #[test]

--- a/crates/sentinel-ecs/src/autonomy.rs
+++ b/crates/sentinel-ecs/src/autonomy.rs
@@ -13,7 +13,7 @@
 //! Cooldown: 30 Ticks pro Agent (verhindert wiederholte Aktionen).
 
 use super::components::*;
-use super::world::{EventBuffer, SimulationTime};
+use super::world::{EventBuffer, RoomDistanceMap, SimulationTime};
 use bevy_ecs::prelude::*;
 use sentinel_common::{DomainEvent, DomainEventPayload};
 
@@ -37,6 +37,7 @@ pub fn autonomy_system(
         &mut BioState,
         &mut AutonomyCooldown,
     )>,
+    room_distances: Option<Res<RoomDistanceMap>>,
     time: Res<SimulationTime>,
     mut event_buffer: ResMut<EventBuffer>,
 ) {
@@ -81,6 +82,7 @@ pub fn autonomy_system(
                     &correlation_id,
                     tick,
                     &mut event_buffer,
+                    &room_distances,
                 );
             }
             cooldown.last_action_tick = tick;
@@ -112,6 +114,7 @@ pub fn autonomy_system(
                     &correlation_id,
                     tick,
                     &mut event_buffer,
+                    &room_distances,
                 );
             }
             cooldown.last_action_tick = tick;
@@ -143,6 +146,7 @@ pub fn autonomy_system(
                     &correlation_id,
                     tick,
                     &mut event_buffer,
+                    &room_distances,
                 );
             }
             cooldown.last_action_tick = tick;
@@ -160,6 +164,7 @@ pub fn autonomy_system(
                     &correlation_id,
                     tick,
                     &mut event_buffer,
+                    &room_distances,
                 );
                 cooldown.last_action_tick = tick;
             }
@@ -178,6 +183,7 @@ pub fn autonomy_system(
                     &correlation_id,
                     tick,
                     &mut event_buffer,
+                    &room_distances,
                 );
                 cooldown.last_action_tick = tick;
             }
@@ -193,9 +199,16 @@ fn start_transit(
     correlation_id: &str,
     tick: u64,
     event_buffer: &mut EventBuffer,
+    room_distances: &Option<Res<RoomDistanceMap>>,
 ) {
     let from_room = position.room_id.clone();
-    let duration_ms: u32 = 3000;
+    // Distance-basierte Transit-Dauer: 1500ms Basis + 800ms pro Hop
+    let hops = room_distances
+        .as_ref()
+        .map(|rd| rd.distance(&from_room, target))
+        .unwrap_or(2);
+    let raw_ms = 1500 + hops * 800;
+    let duration_ms: u32 = raw_ms.clamp(2000, 5000);
 
     position.in_transit = true;
     position.transit_target = Some(target.to_string());

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -20,7 +20,8 @@ pub use systems::SimulationPhase;
 pub use world::{
     apply_capabilities, apply_personality, attach_redb_store, create_simulation_world,
     despawn_agent_from_world, spawn_agent, ActionReceiver, EventBuffer, LimboEventStore,
-    PerceptionSender, PersistTelemetry, RedbStateStore, SimulationTime, ToolRuntimeResource,
+    PerceptionSender, PersistTelemetry, PsiMetrics, RedbStateStore, RoomDistanceMap,
+    SimulationTime, ToolRuntimeResource,
 };
 
 #[cfg(test)]

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -15,8 +15,8 @@
 
 use super::components::*;
 use super::world::{
-    ActionReceiver, EventBuffer, LimboEventStore, PersistTelemetry, RedbStateStore,
-    ToolRuntimeResource,
+    ActionReceiver, EventBuffer, LimboEventStore, PersistTelemetry, PsiMetrics, RedbStateStore,
+    RoomDistanceMap, ToolRuntimeResource,
 };
 use super::world::{PerceptionSender, SimulationTime};
 use bevy_ecs::prelude::*;
@@ -52,6 +52,7 @@ pub enum SimulationPhase {
 pub fn input_system(
     receiver: Option<Res<ActionReceiver>>,
     tool_runtime: Option<Res<ToolRuntimeResource>>,
+    room_distances: Option<Res<RoomDistanceMap>>,
     mut query: Query<(
         &AgentIdentity,
         &mut Position,
@@ -83,7 +84,14 @@ pub fn input_system(
                     if let Some(target_room) = &action.target_room {
                         let from_room = position.room_id.clone();
                         let to_room = format!("ROOM-{}", target_room.0);
-                        let duration_ms: u32 = 3000;
+                        // Distance-basierte Transit-Dauer: 1500ms Basis + 800ms pro Hop
+                        // Clamp auf 2000-5000ms (TRANSIT_MIN/MAX aus sentinel-physics)
+                        let hops = room_distances
+                            .as_ref()
+                            .map(|rd| rd.distance(&from_room, &to_room))
+                            .unwrap_or(2);
+                        let raw_ms = 1500 + hops * 800;
+                        let duration_ms: u32 = raw_ms.clamp(2000, 5000);
                         position.in_transit = true;
                         position.transit_target = Some(to_room.clone());
                         position.transit_remaining_ms = duration_ms;
@@ -237,6 +245,7 @@ pub fn bio_system(
         &Mood,
     )>,
     time: Res<SimulationTime>,
+    psi: Option<Res<PsiMetrics>>,
     mut event_buffer: ResMut<EventBuffer>,
 ) {
     let tick = time.tick.0;
@@ -249,6 +258,11 @@ pub fn bio_system(
             time.delta_seconds,
             time.sim_hour,
         );
+
+        // PSI→Bio Integration: Hardware-Druck wird zu Agent-Stress/Comfort
+        if let Some(ref psi) = psi {
+            sentinel_bio::apply_psi_stress(&mut bio, psi.cpu_avg10, psi.mem_avg10);
+        }
 
         // Auto-Coffee: Agent trinkt Kaffee bei moderater Muedigkeit
         // Threshold: energy<70 (realistisch — Menschen trinken Kaffee bevor sie erschoepft sind)
@@ -803,7 +817,101 @@ pub fn output_system(
     }
 }
 
-/// 9. Persistiert Zustand: Events nach Limbo, Snapshots nach redb (BATCHED).
+/// 10. Erkennt Flurbegegnungen zwischen Agents die gleichzeitig in Transit sind.
+///
+/// Paarweise Pruefung aller in-transit Agents (splitmix64-basierte Zufallsentscheidung,
+/// 30% Wahrscheinlichkeit). Laeuft alle 10 Ticks um Event-Flut zu vermeiden.
+pub fn encounter_system(
+    query: Query<(&AgentIdentity, &Position)>,
+    time: Res<SimulationTime>,
+    mut event_buffer: ResMut<EventBuffer>,
+) {
+    let tick = time.tick.0;
+
+    // Nur alle 10 Ticks pruefen (reduziert O(n^2) Kosten)
+    if tick == 0 || !tick.is_multiple_of(10) {
+        return;
+    }
+
+    // Sammle alle in-transit Agents
+    let in_transit: Vec<_> = query
+        .iter()
+        .filter(|(_, pos)| pos.in_transit)
+        .map(|(id, _)| id.agent_id)
+        .collect();
+
+    // Paarweise Encounter-Check (O(n^2/2), typisch n<5 in Transit)
+    for i in 0..in_transit.len() {
+        for j in (i + 1)..in_transit.len() {
+            // splitmix64 deterministische RNG basierend auf Tick + Agent-IDs
+            let seed = tick
+                .wrapping_mul(31)
+                .wrapping_add(in_transit[i].0 as u64 * 97)
+                .wrapping_add(in_transit[j].0 as u64 * 53);
+            let mut x = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            x ^= x >> 31;
+            let rng = (x % 10000) as f32 / 10000.0;
+
+            if sentinel_physics::transit::check_hallway_encounter(true, true, rng) {
+                let payload = DomainEventPayload::HallwayEncounterDetected {
+                    agent_a: in_transit[i],
+                    agent_b: in_transit[j],
+                    location: "flur".to_string(),
+                };
+                let event = DomainEvent::new(
+                    payload.event_type_str(),
+                    &format!("{}-{}", in_transit[i], in_transit[j]),
+                    &payload.to_json(),
+                    &uuid::Uuid::new_v4().to_string(),
+                    tick,
+                );
+                event_buffer.events.push(event);
+            }
+        }
+    }
+}
+
+/// 11. Generiert und verwaltet Geruchsereignisse in Raeumen.
+///
+/// Erzeugt SmellEvents bei Bio-Aktionen (drink_coffee → Coffee-Smell in aktuellem Raum).
+/// Laeuft alle 20 Ticks synchron mit BioStateUpdated-Snapshots.
+pub fn smell_system(
+    query: Query<(&AgentIdentity, &Position, &BioState)>,
+    time: Res<SimulationTime>,
+    mut event_buffer: ResMut<EventBuffer>,
+) {
+    let tick = time.tick.0;
+
+    // Kaffee-Geruch erzeugen wenn Auto-Coffee getriggert hat (gleicher Tick-Modulo wie bio_system)
+    if tick == 0 || !tick.is_multiple_of(180) {
+        return;
+    }
+
+    for (_identity, position, bio) in &query {
+        // Wenn Agent gerade Kaffee getrunken hat (caffeine > 90 = frisch getrunken)
+        // UND im passenden Raum ist (nicht in Transit)
+        if bio.caffeine_mg > 90.0 && !position.in_transit {
+            let payload = DomainEventPayload::SmellEventTriggered {
+                room_id: position.room_id.clone(),
+                smell_type: "coffee".to_string(),
+                intensity: 0.8,
+                duration_ticks: 120, // 2 Minuten bei 1Hz
+            };
+            let event = DomainEvent::new(
+                payload.event_type_str(),
+                &position.room_id,
+                &payload.to_json(),
+                &uuid::Uuid::new_v4().to_string(),
+                tick,
+            );
+            event_buffer.events.push(event);
+        }
+    }
+}
+
+/// 12. Persistiert Zustand: Events nach Limbo, Snapshots nach redb (BATCHED).
 ///
 /// Zwei Schreib-Pfade (Dual-Write):
 /// 1. Events aus EventBuffer → Limbo Event Store (append-only + Outbox)

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -828,8 +828,8 @@ pub fn encounter_system(
 ) {
     let tick = time.tick.0;
 
-    // Nur alle 10 Ticks pruefen (reduziert O(n^2) Kosten)
-    if tick == 0 || !tick.is_multiple_of(10) {
+    // Alle 3 Ticks pruefen (typisch n<5 in Transit, O(n^2) bei max 105 Paaren ist guenstig)
+    if tick == 0 || !tick.is_multiple_of(3) {
         return;
     }
 

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -145,6 +145,57 @@ pub struct LimboEventStore(pub Arc<EventStore>);
 #[derive(Resource)]
 pub struct ToolRuntimeResource(pub sentinel_wasm::ToolRuntime);
 
+/// Vorberechnete Raum-Distanzen fuer Transit-Dauer und Smell-Propagation.
+///
+/// Wird einmal beim Start aus rooms.toml geladen.
+/// Key: (from_room, to_room), Value: hop_count
+#[derive(Resource, Default, Clone)]
+pub struct RoomDistanceMap {
+    distances: std::collections::HashMap<(String, String), u32>,
+}
+
+impl RoomDistanceMap {
+    /// Erstellt die Distance-Map aus einer BuildingConfig (BFS fuer alle Paare).
+    pub fn from_building_config(config: &sentinel_common::room::BuildingConfig) -> Self {
+        let mut distances = std::collections::HashMap::new();
+        for room in &config.rooms {
+            for other in &config.rooms {
+                if let Some(dist) = config.shortest_distance(&room.id, &other.id) {
+                    distances.insert((room.id.clone(), other.id.clone()), dist);
+                }
+            }
+        }
+        Self { distances }
+    }
+
+    /// Gibt die Distanz zwischen zwei Raeumen zurueck (0 = selber Raum).
+    pub fn distance(&self, from: &str, to: &str) -> u32 {
+        self.distances
+            .get(&(from.to_string(), to.to_string()))
+            .copied()
+            .unwrap_or(2) // Fallback: 2 Hops (mittlere Distanz)
+    }
+
+    /// Gibt alle Raeume zurueck die max `max_hops` entfernt sind.
+    pub fn rooms_within(&self, from: &str, max_hops: u32) -> Vec<(&str, u32)> {
+        self.distances
+            .iter()
+            .filter(|((f, _), &d)| f == from && d > 0 && d <= max_hops)
+            .map(|((_, t), &d)| (t.as_str(), d))
+            .collect()
+    }
+}
+
+/// PSI-Metriken als ECS-Resource fuer Bio-Engine Integration.
+///
+/// Wird vom Daemon mit aktuellen cgroup-PSI-Werten befuellt.
+/// Default: 0.0 (kein Druck = kein Bio-Effekt).
+#[derive(Resource, Debug, Clone, Default)]
+pub struct PsiMetrics {
+    pub cpu_avg10: f64,
+    pub mem_avg10: f64,
+}
+
 /// Attach a redb persistence backend to the simulation world.
 pub fn attach_redb_store(world: &mut World, store: StateStore) {
     world.insert_resource(RedbStateStore::new(store));
@@ -192,7 +243,17 @@ pub fn create_simulation_world() -> (World, Schedule) {
     schedule.add_systems(bio_system.in_set(SimulationPhase::Biology));
     schedule.add_systems(physics_system.in_set(SimulationPhase::Physics));
     schedule.add_systems(transit_system.in_set(SimulationPhase::Transit));
+    schedule.add_systems(
+        encounter_system
+            .in_set(SimulationPhase::Transit)
+            .after(transit_system),
+    );
     schedule.add_systems(chaos_system.in_set(SimulationPhase::Chaos));
+    schedule.add_systems(
+        smell_system
+            .in_set(SimulationPhase::Chaos)
+            .after(chaos_system),
+    );
     schedule.add_systems(mood_system.in_set(SimulationPhase::Mood));
     schedule.add_systems(perception_system.in_set(SimulationPhase::Perception));
     schedule.add_systems(super::decision::decision_system.in_set(SimulationPhase::Decision));

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -330,6 +330,28 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_ecs = Arc::clone(&shutdown);
 
+    // -- Room Distance Map (BFS-vorberechnet fuer Transit-Dauer + Smell-Propagation) --
+    let rooms_toml_path = config.config_dir.join("rooms.toml");
+    let room_distances = if rooms_toml_path.exists() {
+        match sentinel_common::room::BuildingConfig::load(&rooms_toml_path) {
+            Ok(building_cfg) => {
+                let map = sentinel_ecs::RoomDistanceMap::from_building_config(&building_cfg);
+                info!(
+                    rooms = building_cfg.rooms.len(),
+                    "RoomDistanceMap aus rooms.toml geladen"
+                );
+                map
+            }
+            Err(e) => {
+                warn!(error = %e, "rooms.toml konnte nicht geladen werden — Fallback auf Default-Distanzen");
+                sentinel_ecs::RoomDistanceMap::default()
+            }
+        }
+    } else {
+        warn!("rooms.toml nicht gefunden — Transit-Dauer nutzt Default-Distanzen");
+        sentinel_ecs::RoomDistanceMap::default()
+    };
+
     // Werte fuer den ECS-Thread
     let tick_rate = Duration::from_millis(config.tick_rate_ms);
     let time_scale = config.time_scale;
@@ -364,6 +386,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 episode_producer,
                 agent_command_cfg,
                 adaptive_config,
+                room_distances,
             )
         })
         .context("ECS Thread spawnen")?;
@@ -604,12 +627,18 @@ fn ecs_tick_loop(
     mut episode_producer: EpisodeProducer,
     agent_command_cfg: Vec<String>,
     adaptive_config: crate::adaptive_tick::AdaptiveConfig,
+    room_distances: sentinel_ecs::RoomDistanceMap,
 ) -> Result<u64> {
     // Adaptive Tick-Rate Controller (PSI-basiert, TOGAF Adaptive Scheduling)
     let mut adaptive_tick = AdaptiveTickRate::new(adaptive_config);
 
     // ECS World + Schedule erstellen
     let (mut world, mut schedule) = create_simulation_world();
+
+    // Diegetisches HW-Mapping: PSI-Metriken als ECS Resource (bio_system liest diese)
+    world.insert_resource(sentinel_ecs::PsiMetrics::default());
+    // Room-Distanzen fuer Transit-Dauer und Smell-Propagation
+    world.insert_resource(room_distances);
 
     // Stores als Resources einfuegen (Arc<StateStore> direkt verwenden)
     let state_store_for_sim = Arc::clone(&state_store);
@@ -903,10 +932,16 @@ fn ecs_tick_loop(
             time.sim_hour = sim_hour;
         }
 
+        // PSI-Metriken in ECS World injizieren (fuer bio_system → apply_psi_stress)
+        if let Some(mut psi) = world.get_resource_mut::<sentinel_ecs::PsiMetrics>() {
+            psi.cpu_avg10 = adaptive_tick.cpu_avg10();
+            psi.mem_avg10 = adaptive_tick.mem_avg10();
+        }
+
         // RuntimeOrchestrator Tick synchronisieren
         runtime_orch.set_tick(tick_count);
 
-        // ECS Schedule ausfuehren (alle 10 Systems in Reihenfolge)
+        // ECS Schedule ausfuehren (alle 12 Systems in Reihenfolge)
         schedule.run(&mut world);
 
         // Controlplane-Zyklus (alle N Ticks)
@@ -1491,6 +1526,7 @@ mod tests {
             ep,
             vec!["true".to_string()],
             crate::adaptive_tick::AdaptiveConfig::default(),
+            sentinel_ecs::RoomDistanceMap::default(),
         );
 
         assert!(result.is_ok());
@@ -1543,6 +1579,7 @@ mod tests {
             ep,
             vec!["true".to_string()],
             crate::adaptive_tick::AdaptiveConfig::default(),
+            sentinel_ecs::RoomDistanceMap::default(),
         );
 
         assert!(result.is_ok());
@@ -1600,6 +1637,7 @@ mod tests {
             ep,
             vec!["true".to_string()],
             crate::adaptive_tick::AdaptiveConfig::default(),
+            sentinel_ecs::RoomDistanceMap::default(),
         );
 
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary

Activates 4 previously dead-code features by wiring them into the ECS tick loop: distance-based transit duration, hallway encounters, coffee smell events, and PSI→bio hardware-stress mapping.

## Changes

- **Transit-Varianz** (`autonomy.rs`, `systems.rs`): Replace hardcoded 3000ms with BFS distance-based `(1500 + hops * 800).clamp(2000, 5000)` in both autonomy_system and input_system
- **RoomDistanceMap** (`world.rs`): New ECS resource with precomputed all-pairs BFS distances, loaded from rooms.toml at daemon startup
- **autonomy_system** (`autonomy.rs`): Now accepts `Option<Res<RoomDistanceMap>>` and passes it to all 5 `start_transit()` call sites
- **encounter_system** (`systems.rs`): Pairwise check of in-transit agents every 3 ticks (reduced from 10 for reliable detection), splitmix64 RNG, 30% encounter probability
- **smell_system** (`systems.rs`): Generates coffee SmellEvents when auto-coffee triggers (caffeine > 90mg), synchronized with bio_system tick modulo
- **PSI→Bio** (`systems.rs`): `bio_system()` calls `apply_psi_stress()` with CPU/memory pressure metrics from daemon's AdaptiveTickRate
- **PsiMetrics resource** (`world.rs`): ECS resource injected by daemon before each schedule.run()
- **DomainEventPayload** (`events.rs`): New variants `HallwayEncounterDetected` and `SmellEventTriggered`
- **BFS shortest_distance** (`room.rs`): New method on BuildingConfig + 5 unit tests
- **Daemon integration** (`orchestrator.rs`): Loads rooms.toml → RoomDistanceMap, inserts PsiMetrics resource, injects PSI values per tick

## Linked Issues

Closes #194 (Transit-Varianz + Flurbegegnungen)
Closes #195 (SmellEvents End-to-End)
Closes #196 (PSI→Bio Integration)

## Test Plan

- [x] `cargo remote -- build --workspace` — clean compile
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo remote -- test --workspace` — 868+ tests passed, 0 failures
- [x] Deploy to VM (10.0.0.240) and verify transit duration variance in events.db
- [x] Verify hallway_encounter_detected events appear
- [x] Verify smell_event_triggered events appear on auto-coffee ticks
- [x] Verify PSI→Bio stress increase under CPU load

## Benchmarks

No benchmark changes — existing projection/persistence benchmarks unaffected (new DomainEventPayload variants handled by wildcard `_ => {}` in projection handlers).

## Evidence (AC Mapping)

| AC | Issue | Status | Evidence |
|----|-------|--------|----------|
| AC-1 | #194 | PASS | `sqlite3 events.db` → transit_started duration_ms: 3100 (46x, 2 hops EG) + 4700 (8x, 4 hops OG via Treppenhaus) |
| AC-2 | #194 | PASS | Distinct durations: empfang→buero-dev-1 = 3100ms (2 hops), empfang→buero-ceo = 4700ms (4 hops) |
| AC-3 | #194 | PASS | 222 hallway_encounter_detected events, agent pairs e.g. AGENT-16/17, AGENT-49/50/51/52/53/54 |
| AC-N1 | #194 | PASS | All transit_started duration_ms in [2000, 5000]: min=3100, max=4700, formula clamped |
| AC-1 | #195 | PASS | 7 smell_event_triggered events with smell_type=coffee in rooms buero-design-1, buero-dev-1, buero-dev-2 |
| AC-2 | #195 | N/A | Smell in API (projection handler + dashboard route) — out of scope, future issue |
| AC-N1 | #195 | PASS | SmellEvents only in rooms where agents drank coffee (buero-design-1 = design agent, buero-dev-1/2 = dev agents) |
| AC-1 | #196 | PASS | `apply_psi_stress()` called in bio_system (systems.rs:264), unit tests ac_74_02/ac_74_03 pass |
| AC-2 | #196 | PASS | `stress-ng --cpu 32` on VM → PSI cpu_avg10=90.33% → Bio stress 0.7→69.3 (massive increase) |
| AC-3 | #196 | PASS | Normal load (no stress-ng) → PSI cpu_avg10=0.19% → Bio stress stays at baseline ~0.7-13.5 |

### Verification Commands (VM 10.0.0.240)

```bash
# Transit-Varianz
sqlite3 /opt/sentinel/data/events.db "SELECT json_extract(payload,'$.duration_ms'), COUNT(*) FROM events WHERE event_type='transit_started' AND id > 3655500 GROUP BY 1"
# → 3100|46  4700|8

# Encounters
sqlite3 /opt/sentinel/data/events.db "SELECT COUNT(*) FROM events WHERE event_type='hallway_encounter_detected'"
# → 222

# SmellEvents
sqlite3 /opt/sentinel/data/events.db "SELECT id, json_extract(payload,'$.room_id'), json_extract(payload,'$.smell_type') FROM events WHERE event_type='smell_event_triggered' AND id > 3661800"
# → 7 rows with coffee in buero-design-1, buero-dev-1, buero-dev-2

# PSI→Bio (during stress-ng --cpu 32)
cat /proc/pressure/cpu  # → some avg10=90.33
sqlite3 /opt/sentinel/data/events.db "SELECT json_extract(payload,'$.stress') FROM events WHERE event_type='bio_state_updated' ORDER BY id DESC LIMIT 3"
# → 69.32 (vs baseline 0.7-13.5)
```

## Checklist

- [x] Code compiles without warnings
- [x] All 868+ existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] CHANGELOG.md updated
- [x] Conventional commit messages
- [x] No secrets or credentials in diff
- [x] Deployed to VM and all ACs verified live