### PR TITLE
revert: remove unnecessary retry from llm_evolution_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `services/sentinel-daemon/src/orchestrator.rs`: `extract_swap_provider()` setzte Fallback auf "claude" (API) statt "claude-code" (Subscription) — alle Agent-Overrides zeigten auf nicht-registrierten Provider → 502
   - Match-Reihenfolge korrigiert: "claude-code" vor "claude" (laengster Match zuerst)
 
-- **Evolution LLM-Calls schlagen bei Schichtwechsel-Last fehl** (#138)
-  - `services/sentinel-daemon/src/orchestrator.rs`: `llm_evolution_call()` Retry-Logik mit Exponential Backoff (2s, 4s, 8s) bei 5xx/429 — Schichtwechsel mit 15 Agents erzeugt Gateway-Lastspitzen die ohne Retry zu voice_style=false fuehren
-
 - **Bio-Engine Dynamics flach** (#148)
   - `sentinel-bio/src/lib.rs`: Stress-Berechnung mit Traegheit (Exponential Smoothing: Anstieg alpha=0.3, Abfall alpha=0.1) + Baseline-Arbeitsstress der ueber den Tag akkumuliert (max 25)
   - `sentinel-ecs/src/systems.rs`: Auto-Coffee Threshold von energy<50 auf energy<70 gesenkt, Frequenz von 300 auf 180 Ticks erhoehen — Agents trinken nun realistisch Kaffee am Vormittag

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1352,9 +1352,6 @@ fn generate_evolution_fields(
 }
 
 /// Einzelner LLM-Call fuer Evolution-Feld-Generierung.
-///
-/// Retry bei 5xx/429 mit Exponential Backoff (2s, 4s, 8s), max 3 Versuche.
-/// Schichtwechsel erzeugt Lastspitzen am Gateway — ohne Retry schlagen Voice/Notes fehl.
 #[cfg(feature = "llm")]
 fn llm_evolution_call(
     client: &reqwest::blocking::Client,
@@ -1363,9 +1360,6 @@ fn llm_evolution_call(
     system_prompt: &str,
     user_prompt: &str,
 ) -> Option<Vec<u8>> {
-    const MAX_RETRIES: u32 = 3;
-    const BASE_DELAY_SECS: u64 = 2;
-
     let body = serde_json::json!({
         "messages": [
             {"role": "system", "content": system_prompt},
@@ -1380,70 +1374,39 @@ fn llm_evolution_call(
         }
     });
 
-    for attempt in 0..=MAX_RETRIES {
-        match client.post(url).json(&body).send() {
-            Ok(resp) => {
-                let status = resp.status();
-                if status.is_success() {
-                    return match resp.json::<serde_json::Value>() {
-                        Ok(json) => {
-                            let content = json
-                                .get("content")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default();
-                            if content.is_empty() {
-                                warn!(agent = agent_name, "Evolution LLM Response leer");
-                                None
-                            } else {
-                                Some(content.as_bytes().to_vec())
-                            }
-                        }
-                        Err(e) => {
-                            warn!(agent = agent_name, error = %e, "Evolution LLM Response parse fehlgeschlagen");
-                            None
-                        }
-                    };
-                }
-                // Retryable: 5xx (Server-Error) oder 429 (Rate-Limit)
-                let retryable = status.is_server_error() || status.as_u16() == 429;
-                if retryable && attempt < MAX_RETRIES {
-                    let delay = Duration::from_secs(BASE_DELAY_SECS * 2u64.pow(attempt));
-                    warn!(
-                        agent = agent_name,
-                        status = %status,
-                        attempt = attempt + 1,
-                        retry_in_secs = delay.as_secs(),
-                        "Evolution LLM Call fehlgeschlagen (HTTP), Retry"
-                    );
-                    std::thread::sleep(delay);
-                    continue;
-                }
+    match client.post(url).json(&body).send() {
+        Ok(resp) => {
+            if !resp.status().is_success() {
                 warn!(
                     agent = agent_name,
-                    status = %status,
-                    "Evolution LLM Call fehlgeschlagen (HTTP), kein Retry"
+                    status = %resp.status(),
+                    "Evolution LLM Call fehlgeschlagen (HTTP)"
                 );
                 return None;
             }
-            Err(e) => {
-                if attempt < MAX_RETRIES {
-                    let delay = Duration::from_secs(BASE_DELAY_SECS * 2u64.pow(attempt));
-                    warn!(
-                        agent = agent_name,
-                        error = %e,
-                        attempt = attempt + 1,
-                        retry_in_secs = delay.as_secs(),
-                        "Evolution LLM Call fehlgeschlagen, Retry"
-                    );
-                    std::thread::sleep(delay);
-                    continue;
+            match resp.json::<serde_json::Value>() {
+                Ok(json) => {
+                    let content = json
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    if content.is_empty() {
+                        warn!(agent = agent_name, "Evolution LLM Response leer");
+                        return None;
+                    }
+                    Some(content.as_bytes().to_vec())
                 }
-                warn!(agent = agent_name, error = %e, "Evolution LLM Call fehlgeschlagen, kein Retry");
-                return None;
+                Err(e) => {
+                    warn!(agent = agent_name, error = %e, "Evolution LLM Response parse fehlgeschlagen");
+                    None
+                }
             }
         }
+        Err(e) => {
+            warn!(agent = agent_name, error = %e, "Evolution LLM Call fehlgeschlagen");
+            None
+        }
     }
-    None
 }
 
 /// Fallback wenn LLM-Feature deaktiviert ist.


### PR DESCRIPTION
## Summary
Reverts the retry logic added in PR #199. The 503 errors were caused by the provider routing bug (PR #198), not Gateway load spikes. With correct routing, no retries needed.

## Changes
- Revert `llm_evolution_call()` to original single-attempt implementation
- Remove CHANGELOG entry for unnecessary fix

## Linked Issues
Partially addresses #138

## Test Plan
- [x] `cargo remote -- clippy -p sentinel-daemon --all-targets -- -D warnings` — clean
- [x] Release binary deployed to VM, no 503 errors

## Benchmarks
N/A — removing unnecessary code

## Evidence (AC Mapping)
| AC-5 | PASS | No 503 errors after provider routing fix. Retry was unnecessary. |

```bash
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '20 min ago' | grep -c 503"
0
```

## Checklist
- [x] Clippy clean
- [x] CHANGELOG.md updated
- [x] Deployed and verified on VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)