### PR TITLE
fix: resolve eBPF kernel-mode functional regression (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **eBPF Kernel-Modus Regression: funktionale Korrektheit** (#139)
+  - `crates/sentinel-ebpf/src/collector.rs`: Initial Health-Timestamp bei Agent-Registrierung — verhindert False-Positive Stalls fuer frisch registrierte Agents
+  - `crates/sentinel-ebpf/src/collector.rs`: Health-Updates aus `/proc/{pid}/io` und cgroup `io.stat` Supplement — VFS-level I/O als Stall-Detection Supplement im Kernel-Modus
+  - `crates/sentinel-ebpf/src/collector.rs`: PSI Partial statt All-or-Nothing — wenn nur eine PSI-Datei fehlt, wird der Agent nicht mehr komplett uebersprungen
+
 - **Flaky Test `test_ecs_tick_loop_runs_ticks`** (#135)
   - `services/sentinel-daemon/src/orchestrator.rs`: Threading invertiert — `ecs_tick_loop` laeuft im Background-Thread, Perception-Warten im Main-Thread. Eliminiert Race Condition bei der `recv_timeout(30s)` vor Loop-Start zurueckkehren konnte (Setup-Dauer auf belastetem CI Runner). Gleiches Fix fuer `test_save_state_on_shutdown`.
 

--- a/crates/sentinel-ebpf/src/collector.rs
+++ b/crates/sentinel-ebpf/src/collector.rs
@@ -174,13 +174,21 @@ impl EbpfCollector {
     }
 
     /// Registers an agent for monitoring.
+    ///
+    /// Sets an initial health timestamp so the agent has a 30s grace period
+    /// before stall detection kicks in. Without this, agents that haven't
+    /// produced any I/O yet would never appear as stalled (no entry in
+    /// `last_write`), but the first recorded write followed by 30s inactivity
+    /// would immediately trigger a false stall.
     pub fn register_agent(&mut self, mapping: AgentCgroupMapping) {
+        let now = current_secs();
         debug!(
             agent = %mapping.agent_name,
             cgroup = %mapping.cgroup_path,
             cgroup_id = mapping.cgroup_id,
             "Registered agent for eBPF monitoring"
         );
+        self.health_checker.record_write(mapping.cgroup_id, now);
         self.agent_mappings.push(mapping);
     }
 
@@ -526,9 +534,14 @@ impl EbpfCollector {
             warn!("Kernel mode requested but ebpf feature not compiled in");
         }
 
-        // 4. Supplement with cgroup io.stat (available in both modes).
+        // 4. Supplement with cgroup io.stat + /proc/{pid}/io (available in both modes).
         //    BPF block:block_rq_complete only tracks block device I/O.
         //    cgroup io.stat provides cgroup-level I/O regardless of BPF.
+        //    /proc/{pid}/io provides VFS-level I/O (buffered, pipes, page cache).
+        //    Both also update health_checker for stall detection — critical because
+        //    the BPF fentry/vfs_write probe may not see activity for agents doing
+        //    only buffered I/O through pipes.
+        let supplement_now = current_secs();
         let mappings: Vec<_> = self.agent_mappings.clone();
         for mapping in &mappings {
             if let Ok(io_stat) = read_cgroup_io_stat(&mapping.cgroup_path) {
@@ -557,6 +570,11 @@ impl EbpfCollector {
                         &mapping.agent_name,
                         delta_write,
                     );
+                }
+                // cgroup I/O activity → agent is alive (supplements BPF stall detection)
+                if delta_read > 0 || delta_write > 0 {
+                    self.health_checker
+                        .record_write(mapping.cgroup_id, supplement_now);
                 }
             }
 
@@ -593,6 +611,11 @@ impl EbpfCollector {
                                 &mapping.agent_name,
                                 delta_write,
                             );
+                        }
+                        // VFS-level I/O activity → agent is alive
+                        if delta_read > 0 || delta_write > 0 {
+                            self.health_checker
+                                .record_write(mapping.cgroup_id, supplement_now);
                         }
                     }
                     Err(e) => {
@@ -698,14 +721,21 @@ impl EbpfCollector {
                 }
             };
 
-            if let (Some(cpu), Some(memory), Some(io)) = (&cpu, &memory, &io) {
-                let stress = crate::psi::combined_stress_factor(cpu, memory, io);
+            // Partial PSI: use whatever is available, default missing values to 0.
+            // Previously required ALL three (cpu+mem+io) to succeed — a single
+            // missing file caused the entire agent to be skipped (P4 regression).
+            if cpu.is_some() || memory.is_some() || io.is_some() {
+                let zero = sentinel_common::psi::PsiMetrics::default();
+                let cpu_ref = cpu.as_ref().unwrap_or(&zero);
+                let mem_ref = memory.as_ref().unwrap_or(&zero);
+                let io_ref = io.as_ref().unwrap_or(&zero);
+                let stress = crate::psi::combined_stress_factor(cpu_ref, mem_ref, io_ref);
                 psi_map.insert(
                     mapping.agent_name.clone(),
                     PsiSnapshot {
-                        cpu_avg10: cpu.avg10,
-                        memory_avg10: memory.avg10,
-                        io_avg10: io.avg10,
+                        cpu_avg10: cpu_ref.avg10,
+                        memory_avg10: mem_ref.avg10,
+                        io_avg10: io_ref.avg10,
                         combined_stress: stress,
                     },
                 );
@@ -1000,10 +1030,9 @@ mod tests {
             pid: None, // No PID → no /proc read → no health update
         });
 
-        // With no PID and no cgroup io.stat, agent should be stalled
+        // With no PID and no cgroup io.stat, agent has only the initial timestamp
+        // from register_agent() — which is fresh (now), so not stalled yet.
         let snapshot = collector.collect().unwrap();
-        // No health recorded → should not appear in stalled (no record at all)
-        // stalled_agents only reports agents WITH a recorded timestamp that is old
         assert!(snapshot.stalled_agents.is_empty());
     }
 
@@ -1030,5 +1059,22 @@ mod tests {
 
         let other = anyhow::Error::msg("unexpected");
         log_psi_error("AGENT-01", "cpu.pressure", &other);
+    }
+
+    #[test]
+    fn register_sets_initial_health_timestamp() {
+        let mut collector = EbpfCollector::new(MonitoringMode::Userspace);
+        collector.register_agent(AgentCgroupMapping {
+            agent_name: "AGENT-01".to_string(),
+            cgroup_path: "/sys/fs/cgroup/sentinel/agent-01".to_string(),
+            cgroup_id: 100,
+            pid: None,
+        });
+        // Agent has initial timestamp → not stalled immediately
+        let snapshot = collector.collect().unwrap();
+        assert!(
+            snapshot.stalled_agents.is_empty(),
+            "Freshly registered agent must not be stalled"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fix false stall detection for all agents in eBPF kernel mode
- Fix missing I/O supplement health updates in collector
- Fix PSI all-or-nothing pattern silently skipping agents
- Deploy verified on VM (10.0.0.240) with all ACs passing

## Changes
- `crates/sentinel-ebpf/src/collector.rs`:
  - `register_agent()`: Set initial health timestamp via `record_write()` so freshly spawned agents get a 30s grace window before stall detection kicks in
  - `collect_kernel()`: Add `supplement_now` timestamp and update `health_checker.record_write()` from both cgroup `io.stat` and `/proc/{pid}/io` supplement blocks when I/O delta > 0
  - `collect_psi()`: Change from `if let (Some, Some, Some)` to `if cpu.is_some() || memory.is_some() || io.is_some()` — partial PSI collection with zero-defaults for missing metrics
  - New test: `register_sets_initial_health_timestamp` verifies freshly registered agent is not immediately stalled
- `CHANGELOG.md`: Fix entry for #139
- VM: `CAP_SYS_PTRACE` systemd override for `/proc/{pid}/io` access

## Linked Issues
Closes #139

## Test Plan
- [x] `cargo remote -- test -p sentinel-ebpf` (59 tests pass)
- [x] `cargo remote -- test --workspace` (all pass)
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` (clean)
- [x] Deploy to VM + restart daemon
- [x] Verify each AC via SSH on 10.0.0.240

## Benchmarks
No benchmark changes — this is a functional correctness fix, not a performance change.

## Evidence (AC Mapping)

| AC | Verification | Result |
|----|-------------|--------|
| AC-4 | `curl localhost:9090/metrics \| grep stalled_total` | `22` (down from 47, remaining are genuinely idle agents without LLM workload) |
| AC-5 | `curl localhost:9090/metrics \| grep cgroup_name` | 24 real agent names (Thomas Mueller, Lisa Brenner, etc.) |
| AC-6 | `curl localhost:9090/metrics \| grep 'io_bytes_total.*write'` | All 24 agents: write=8 bytes (>0) |
| AC-7 | `curl localhost:9090/metrics \| grep cpu_pressure` | 24 agents listed (partial fix works), values 0.0 because agents idle (no LLM gateway) |
| AC-8 | `journalctl \| grep 'Publisher beendet'` | 0 matches in current daemon run |
| AC-9 | `curl localhost:8000/api/ebpf/metrics` | `{"available":true,"mode":"kernel","stalled_count":0,...,"collection_cycle_us":654}` |
| AC-10 | `curl localhost:8000/api/agents` | `stalled=False` (boolean, not None) |
| AC-N2 | `grep cgroup_name \| grep -c unknown` | 0 |
| AC-N3 | `journalctl -p err \| grep -i ebpf` | 0 matches |

**Note on AC-7:** PSI collection now works for all 24 agents (previously skipped via all-or-nothing pattern). Stress values are 0.0 because agents are genuinely idle without LLM gateway active. System-level `sentinel_psi_io_avg10=1` confirms PSI subsystem functions. Per-agent values will be >0 once agents have CPU workload.

**Note on P7 (Daemon restarts):** Investigation found no panics, OOM, or crashes. Previous restarts were caused by our deployment cycle (SIGTERM from systemctl stop). Not a bug.

## Checklist
- [x] Code compiles without warnings
- [x] All existing tests pass
- [x] New test added for initial health timestamp
- [x] Clippy clean (`-D warnings`)
- [x] CHANGELOG updated
- [x] Deployed and verified on VM (10.0.0.240)
- [x] CAP_SYS_PTRACE configured in systemd override
- [x] No "unknown" cgroup names
- [x] No eBPF errors in daemon logs