### PR TITLE
feat: Judge-NATS integration cleanup (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,17 +163,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Functional Audit Judge:** `docs/functional-audit-judge.md` (B-5, M-17-M-20)
   - **Zenoh Wiring Status:** `docs/zenoh-wiring-status.md` cataloging all 22 topics
 
-### Fixed
+### Removed
 
-- **EBPF_STATUS Double-Publish Bug** (#140)
-  - PSI metrics were published on `EBPF_STATUS` topic (overwriting mode status);
-    now correctly published on dedicated `EBPF_PSI` topic
-  - New `EBPF_PSI` Zenoh topic constant added to sentinel-zenoh
-
-### Deprecated
-
-- `JUDGE_ALERT` Zenoh topic (ADR-001: alerts flow via NATS)
-- `MODEL_SWAP` Zenoh topic (ADR-001: swap via NATS alert + HTTP)
+- `JUDGE_ALERT` Zenoh constant (ADR-001: alerts flow via NATS, was deprecated)
+- `MODEL_SWAP` Zenoh constant (ADR-001: swap via NATS alert + HTTP, was deprecated)
+- `cortex_inject()` topic function (no active subscribers)
+- Claude API provider registration block from Cortex Gateway — Claude Code
+  (subscription-based subprocess) is the default, no API key needed
 
 ### Fixed
 

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -51,23 +51,17 @@ func main() {
 	// 3. Provider registry
 	registry := proxy.NewRegistry()
 
-	claudeAPIKey := os.Getenv("ANTHROPIC_API_KEY")
-	if claudeAPIKey != "" {
-		claudeProvider := proxy.NewClaudeProvider(proxy.ProviderConfig{
-			Name:      "claude",
-			Type:      "claude",
-			BaseURL:   envOrDefault("CLAUDE_BASE_URL", "https://api.anthropic.com"),
-			APIKey:    claudeAPIKey,
-			Model:     envOrDefault("CLAUDE_MODEL", "claude-sonnet-4-5-20250929"),
-			MaxTokens: 4096,
-			Priority:  1,
-		})
-		registry.Register("claude", claudeProvider)
-		logger.Info("registered provider", "name", "claude")
-	} else {
-		logger.Warn("ANTHROPIC_API_KEY not set, claude provider not registered")
-	}
+	// Default provider: Claude Code (subprocess, uses existing subscription)
+	claudeCodeProvider := proxy.NewClaudeCodeProvider(proxy.ProviderConfig{
+		Name:    "claude-code",
+		Type:    "claude-code",
+		BaseURL: envOrDefault("CLAUDE_CODE_BINARY", "claude"), // binary path
+		Model:   envOrDefault("CLAUDE_CODE_MODEL", "claude-opus-4-6"),
+	}, logger)
+	registry.Register("claude-code", claudeCodeProvider)
+	logger.Info("registered provider", "name", "claude-code", "model", envOrDefault("CLAUDE_CODE_MODEL", "claude-opus-4-6"))
 
+	// Optional provider: Ollama (local models)
 	ollamaURL := envOrDefault("OLLAMA_BASE_URL", "http://localhost:11434")
 	ollamaProvider := proxy.NewOllamaProvider(proxy.ProviderConfig{
 		Name:      "ollama",
@@ -80,24 +74,8 @@ func main() {
 	registry.Register("ollama", ollamaProvider)
 	logger.Info("registered provider", "name", "ollama")
 
-	// 3b. Claude Code provider (subprocess, no API key required)
-	if os.Getenv("CLAUDE_CODE_ENABLED") == "1" {
-		claudeCodeProvider := proxy.NewClaudeCodeProvider(proxy.ProviderConfig{
-			Name:    "claude-code",
-			Type:    "claude-code",
-			BaseURL: envOrDefault("CLAUDE_CODE_BINARY", "claude"), // binary path
-			Model:   envOrDefault("CLAUDE_CODE_MODEL", "claude-opus-4-6"),
-		}, logger)
-		registry.Register("claude-code", claudeCodeProvider)
-		logger.Info("registered provider", "name", "claude-code", "model", envOrDefault("CLAUDE_CODE_MODEL", "claude-opus-4-6"))
-	}
-
 	// 4. Control config (shared between pipeline + control plane)
-	defaultProvider := "claude"
-	if os.Getenv("CLAUDE_CODE_ENABLED") == "1" {
-		defaultProvider = "claude-code"
-	}
-	controlConfig := control.NewConfig(defaultProvider)
+	controlConfig := control.NewConfig("claude-code")
 
 	// 4b. Event Store (optional, enabled via SENTINEL_CORTEX_EVENT_STORE_PATH)
 	var evStore *eventstore.Store

--- a/config/cortex-gateway.toml
+++ b/config/cortex-gateway.toml
@@ -7,13 +7,11 @@ control_port = 8081
 read_timeout_seconds = 30
 write_timeout_seconds = 60
 
-[providers.claude]
-type = "claude"
-base_url = "https://api.anthropic.com"
-model = "claude-sonnet-4-5-20250929"
-max_tokens = 4096
+[providers.claude-code]
+type = "claude-code"
+binary = "claude"
+model = "claude-opus-4-6"
 priority = 1
-# api_key: Set via ANTHROPIC_API_KEY env var
 
 [providers.ollama]
 type = "ollama"

--- a/crates/sentinel-zenoh/src/topics.rs
+++ b/crates/sentinel-zenoh/src/topics.rs
@@ -44,29 +44,10 @@ pub fn physics_tick(tick_number: u64) -> String {
 /// Topic for chaos monkey events
 pub const CHAOS_EVENT: &str = "sentinel/chaos/event";
 
-/// Topic for sentinel judge alerts.
-///
-/// ADR-001: Judge publishes alerts via NATS (`sentinel.judge.alert.*`), not Zenoh.
-/// This constant is retained for type-signature compatibility; no active subscribers.
-#[deprecated(note = "ADR-001: Judge alerts flow via NATS, not Zenoh")]
-pub const JUDGE_ALERT: &str = "sentinel/judge/alert";
-
 /// Build topic for agent PSI (Pressure Stall Information) metrics
 pub fn agent_psi(name: &str) -> String {
     format!("{PREFIX}/agent/{name}/psi")
 }
-
-/// Build topic for cortex gateway injection per agent
-pub fn cortex_inject(name: &str) -> String {
-    format!("{PREFIX}/cortex/inject/{name}")
-}
-
-/// Topic for model swap requests (invisible to agents).
-///
-/// ADR-001: Model-swap flows via NATS alert (type: "swap") + Daemon HTTP to Gateway.
-/// This constant is retained for type-signature compatibility; no active subscribers.
-#[deprecated(note = "ADR-001: Model-swap flows via NATS + HTTP, not Zenoh")]
-pub const MODEL_SWAP: &str = "sentinel/meta/model-swap";
 
 /// Topic for eBPF agent health metrics.
 pub const EBPF_AGENT_HEALTH: &str = "sentinel/ebpf/agent-health";
@@ -139,16 +120,8 @@ mod tests {
     }
 
     #[test]
-    fn test_cortex_inject() {
-        assert_eq!(cortex_inject("thomas"), "sentinel/cortex/inject/thomas");
-    }
-
-    #[test]
-    #[allow(deprecated)]
     fn test_constants() {
         assert_eq!(CHAOS_EVENT, "sentinel/chaos/event");
-        assert_eq!(JUDGE_ALERT, "sentinel/judge/alert");
-        assert_eq!(MODEL_SWAP, "sentinel/meta/model-swap");
         assert_eq!(QUERY_REQUEST_GLOBAL, "sentinel/query/global/request");
         assert_eq!(PREFIX, "sentinel");
     }

--- a/crates/sentinel-zenoh/tests/acceptance.rs
+++ b/crates/sentinel-zenoh/tests/acceptance.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 
 /// AC 6.2: Topic string format is correct for all TopicType variants
 #[test]
-#[allow(deprecated)]
 fn ac_06_02_topic_generation() {
     // Agent topics
     assert_eq!(
@@ -37,16 +36,8 @@ fn ac_06_02_topic_generation() {
     assert_eq!(topics::physics_tick(0), "sentinel/physics/tick/0");
     assert_eq!(topics::physics_tick(42), "sentinel/physics/tick/42");
 
-    // Cortex inject
-    assert_eq!(
-        topics::cortex_inject("thomas"),
-        "sentinel/cortex/inject/thomas"
-    );
-
     // Constants
     assert_eq!(topics::CHAOS_EVENT, "sentinel/chaos/event");
-    assert_eq!(topics::JUDGE_ALERT, "sentinel/judge/alert");
-    assert_eq!(topics::MODEL_SWAP, "sentinel/meta/model-swap");
     assert_eq!(topics::PREFIX, "sentinel");
 
     // Query topics (neu)


### PR DESCRIPTION
## Summary

- Remove dead ANTHROPIC_API_KEY provider from Cortex Gateway (Claude Code is the default)
- Remove deprecated Zenoh constants (JUDGE_ALERT, MODEL_SWAP, cortex_inject) per ADR-001
- All VM services verified running and functional

## Changes

- **cmd/cortex-gateway/main.go**: Removed Claude API provider block; Claude Code is always-registered default
- **config/cortex-gateway.toml**: Replaced `[providers.claude]` with `[providers.claude-code]`
- **crates/sentinel-zenoh/src/topics.rs**: Removed `JUDGE_ALERT`, `MODEL_SWAP`, `cortex_inject()`
- **crates/sentinel-zenoh/tests/acceptance.rs**: Updated to match removed symbols
- **CHANGELOG.md**: Corrected Double-Publish entry (bug never existed), Deprecated→Removed

## Linked Issues

Partially addresses #140

## Test Plan

- [x] `cargo remote -- test -p sentinel-zenoh` — 30 tests pass (22 unit + 8 acceptance)
- [x] `cargo remote -- clippy -p sentinel-zenoh --all-targets -- -D warnings` — clean
- [x] `go vet ./cmd/cortex-gateway/...` — clean
- [x] Gateway binary deployed to VM, no ANTHROPIC_API_KEY warnings
- [x] Judge binary deployed to VM with eBPF consumer active
- [x] E2E Model-Swap flow tested (NATS pub → Daemon → Gateway HTTP → 200 OK)

## Benchmarks

No performance-critical changes. Dead code removal only.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `docs/adr/ADR-001-judge-nats-communication.md` exists |
| AC-2 | PASS | `docs/togaf-deviations.md` exists with 3 deviations |
| AC-3 | PASS | `journalctl -u sentinel-judge: "ebpf consumer started" stream=SENTINEL_EBPF` |
| AC-4 | PASS | `journalctl -u sentinel-daemon: "Model-Swap an Gateway gesendet status=200 OK"` |
| AC-5 | PASS | `curl POST /control/agent-provider → 200 {"agent_id":"AGENT-01","provider":"ollama"}` |
| AC-6 | PASS | `curl DELETE /control/agent-provider → 200 {"agent_id":"AGENT-01","provider":null}` |
| AC-7 | PASS | `nats stream ls` shows 3 streams (EVENTS 857k, JUDGE 78k, EBPF 665) |
| AC-8 | PASS | `grep JUDGE_ALERT\|MODEL_SWAP\|cortex_inject crates/sentinel-zenoh/src/ → 0 matches` |
| AC-9 | PASS | ADR-001 contains sunset plan (15 matches for sunset/migration/bridge) |
| AC-10 | PASS | `nats sub sentinel.ebpf.> --count 3` received agent-health, io-profile, network |
| AC-11 | N/A | Bug never existed — PSI on EBPF_PSI, status on EBPF_STATUS (separate topics) |
| AC-12 | PASS | `docs/functional-audit-judge.md` exists with B-5, M-17-M-20 |
| AC-13 | PASS | `systemctl status nats-server → active (running) 23min` |
| AC-14 | PASS | `curl localhost:8080/health → {"status":"ok","version":"0.1.0"}` |
| AC-15 | PASS | AGENT-05 swap alert → Daemon received → Gateway 200 OK (full E2E) |
| AC-16 | PASS | `curl localhost:8082/health → {"status":"ok"}` |

## Checklist

- [x] Tests pass (`cargo remote -- test -p sentinel-zenoh`)
- [x] Clippy clean (`-D warnings`)
- [x] Go vet clean
- [x] CHANGELOG.md updated
- [x] All services running on VM (nats, cortex, judge, bridge, daemon)
- [x] E2E model-swap verified
- [x] eBPF consumer active on Judge
- [x] No ANTHROPIC_API_KEY references remaining