### PR TITLE
feat: GOLF goal-progress updates at shift consolidation (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `service.rs`: Goal-CRUD facade on HippocampusService (create, append, update_progress, get, get_active, list)
   - `orchestrator.rs`: Default-Goals created at agent spawn based on role (CEO→Career+Project, Dev→Project+Skill, HR→Social+Career, Designer→Skill+Project)
   - `default_goals_for_role()`: Role-based goal initialization (initial + shift-change spawn)
+  - `orchestrator.rs`: Goal-Progress Updates bei Schichtwechsel-Konsolidierung (+0.05 pro ueberlebte Schicht, auto-Completed bei >= 1.0)
   - 29 new unit tests (13 golf, 9 store, 7 service)
   - Issue #141 ACs corrected: redb instead of SQLite, log/test-based verification
 

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1217,6 +1217,52 @@ fn ecs_tick_loop(
                     }
                 }
 
+                // GOLF: Goal-Progress fuer konsolidierte Agents aktualisieren
+                // Pro ueberlebte Schicht erhoehen wir den Progress aktiver Goals
+                // um einen kleinen Betrag (0.05 = ~20 Schichten bis Completion).
+                for agent_id in &removed {
+                    let agent_name = all_agents
+                        .iter()
+                        .find(|a| AgentId(a.identity.id) == *agent_id)
+                        .map(|a| a.identity.name.as_str());
+                    if let Some(name) = agent_name {
+                        let goals = episode_producer
+                            .hippocampus()
+                            .get_goals(name)
+                            .unwrap_or_default();
+                        let active_goals: Vec<_> =
+                            goals.iter().filter(|g| g.is_active()).collect();
+                        for goal in &active_goals {
+                            let new_progress = (goal.progress + 0.05).min(1.0);
+                            match episode_producer.hippocampus().update_goal_progress(
+                                name,
+                                goal.id,
+                                new_progress,
+                                tick_count,
+                            ) {
+                                Ok(true) => {
+                                    info!(
+                                        agent = name,
+                                        goal_id = goal.id,
+                                        goal_type = %goal.goal_type,
+                                        progress = format!("{:.2}", new_progress),
+                                        "GOLF: Goal-Progress aktualisiert"
+                                    );
+                                }
+                                Ok(false) => {} // Goal not found (unlikely)
+                                Err(e) => {
+                                    warn!(
+                                        agent = name,
+                                        goal_id = goal.id,
+                                        error = %e,
+                                        "GOLF: Goal-Progress Update fehlgeschlagen"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // Memory-Pressure Check: Agent-Spawn blockieren wenn Mem PSI > Threshold
                 if adaptive_tick.should_block_spawn() {
                     warn!(


### PR DESCRIPTION
## Summary

- Implements the missing Goal-Progress update logic (AC-3) for the GOLF Framework
- Active goals are incremented by +0.05 per survived shift during consolidation
- Goals auto-complete at >= 1.0 progress via existing `update_progress()` logic

## Changes

- `services/sentinel-daemon/src/orchestrator.rs`: Added goal-progress update loop in shift-change consolidation block. For each removed (consolidated) agent, all active goals get +0.05 progress via `HippocampusService::update_goal_progress()`.
- `CHANGELOG.md`: Added goal-progress update entry under GOLF Framework section.

## Linked Issues

Closes #141

## Test Plan

- [x] `cargo remote -- test -p sentinel-hippocampus -- golf` — 22 tests pass (golf, store, service)
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] Deploy on VM (10.0.0.240), set `time_scale=600.0`, verify shift change triggers goal-progress logs
- [x] Reset `time_scale=1.0` after verification

## Benchmarks

No performance-critical path affected. Goal-Progress update is O(agents * goals) per shift change (~15 agents * ~2 goals = ~30 redb writes every 8h). No benchmark needed.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `cargo remote -- test -p sentinel-hippocampus -- golf` → 22 passed, GOALS table roundtrip works |
| AC-2 | PASS | `journalctl -u sentinel-daemon \| grep 'GOLF: Default-Goals erstellt'` → "agent=Michael Hartmann goal_count=2" (and 9+ more agents) |
| AC-3 | PASS | `journalctl -u sentinel-daemon \| grep 'GOLF: Goal-Progress aktualisiert'` → 52 entries: "agent=Selina Hoffmann goal_id=1 goal_type=project progress=0.05" etc. |
| AC-5 | PASS | `Goal` struct (golf.rs:65-83) has all required fields: agent_name, goal_type, description, progress, status, created_tick |
| AC-6 | PASS | 22 golf tests pass — CRUD methods (create, update_progress, get_goals, store/load roundtrip) |
| AC-7 | PASS | `GOALS` dedicated redb table (store.rs:17), tests prove isolation from other tables |
| AC-N1 | PASS | `agent_name: String` is non-optional — compile-time guarantee, no goals without agent |

## Checklist

- [x] Code compiles without warnings
- [x] All existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] CHANGELOG.md updated
- [x] Deployed and verified on VM (10.0.0.240)
- [x] time_scale reset to 1.0 after verification
- [x] No panics/errors in daemon logs after deploy