### PR TITLE
feat: Cortex pipeline hardening config persistence (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sentinel-ecs/src/world.rs`: `PsiMetrics` ECS Resource (cpu_avg10, mem_avg10)
   - `services/sentinel-daemon/src/orchestrator.rs`: PSI-Metriken aus AdaptiveTickRate in ECS World injiziert vor jedem Schedule-Run
 
+- **Cortex Pipeline Hardening: Config Persistence** (#144)
+  - `cmd/cortex-gateway/main.go`: `applyHardeningDefaults()` laedt Personality Guard, Quality Gate und Narrative Nudge Defaults aus Environment-Variablen beim Start
+  - `config/cortex-gateway.toml`: Hardening-Dokumentation mit Env-Var-Referenzen
+  - systemd Drop-in (`hardening.conf`): Guards sind im Production-Betrieb by-default aktiviert
+  - systemd Drop-in (`user.conf`): Gateway laeuft als `ubuntu` User (Claude CLI Auth)
+
 ### Security
 
 - **Go Toolchain Update** go1.25.7 → go1.25.8 (GO-2026-4600, GO-2026-4601, GO-2026-4602)

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -76,6 +77,7 @@ func main() {
 
 	// 4. Control config (shared between pipeline + control plane)
 	controlConfig := control.NewConfig("claude-code")
+	applyHardeningDefaults(controlConfig, logger)
 
 	// 4b. Event Store (optional, enabled via SENTINEL_CORTEX_EVENT_STORE_PATH)
 	var evStore *eventstore.Store
@@ -276,6 +278,45 @@ func envOrDefault(key, defaultVal string) string {
 		return val
 	}
 	return defaultVal
+}
+
+// applyHardeningDefaults reads pipeline hardening settings from environment
+// variables and applies them to the control config so they survive restarts.
+func applyHardeningDefaults(cfg *control.Config, logger *slog.Logger) {
+	updates := make(map[string]interface{})
+
+	if v := os.Getenv("SENTINEL_PERSONALITY_GUARD_ENABLED"); v == "true" || v == "1" {
+		updates["personality_guard_enabled"] = true
+	}
+	if v := os.Getenv("SENTINEL_DRIFT_THRESHOLD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			updates["drift_threshold"] = f
+		}
+	}
+	if v := os.Getenv("SENTINEL_QUALITY_GATE_ENABLED"); v == "true" || v == "1" {
+		updates["quality_gate_enabled"] = true
+	}
+	if v := os.Getenv("SENTINEL_QUALITY_THRESHOLD"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			updates["quality_threshold"] = float64(i)
+		}
+	}
+	if v := os.Getenv("SENTINEL_QUALITY_MAX_REGEN"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			updates["quality_max_regen"] = float64(i)
+		}
+	}
+	if v := os.Getenv("SENTINEL_NARRATIVE_NUDGE"); v != "" {
+		updates["narrative_nudge"] = v
+	}
+
+	if len(updates) > 0 {
+		if err := cfg.Update(updates); err != nil {
+			logger.Error("failed to apply hardening defaults", "error", err)
+		} else {
+			logger.Info("pipeline hardening defaults applied", "updates", updates)
+		}
+	}
 }
 
 // loadAgentProfiles reads all agent TOMLs and registers their Big Five profiles

--- a/config/cortex-gateway.toml
+++ b/config/cortex-gateway.toml
@@ -50,6 +50,17 @@ output_price_per_m_token = 15.0  # USD per 1M output tokens
 input_price_per_m_token = 0.0
 output_price_per_m_token = 0.0
 
+[hardening]
+# Pipeline Hardening (#144): Personality Guard, Quality Gate, Narrative Nudge
+# These are loaded via environment variables (see systemd unit):
+#   SENTINEL_PERSONALITY_GUARD_ENABLED=true
+#   SENTINEL_DRIFT_THRESHOLD=0.7
+#   SENTINEL_QUALITY_GATE_ENABLED=true
+#   SENTINEL_QUALITY_THRESHOLD=2
+#   SENTINEL_QUALITY_MAX_REGEN=1
+#   SENTINEL_NARRATIVE_NUDGE=""
+# All settings are also changeable at runtime via PATCH /control/config
+
 [metrics]
 enabled = true
 path = "/metrics"

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1230,8 +1230,7 @@ fn ecs_tick_loop(
                             .hippocampus()
                             .get_goals(name)
                             .unwrap_or_default();
-                        let active_goals: Vec<_> =
-                            goals.iter().filter(|g| g.is_active()).collect();
+                        let active_goals: Vec<_> = goals.iter().filter(|g| g.is_active()).collect();
                         for goal in &active_goals {
                             let new_progress = (goal.progress + 0.05).min(1.0);
                             match episode_producer.hippocampus().update_goal_progress(


### PR DESCRIPTION
## Summary

- Adds environment-variable-based config persistence for Pipeline Hardening features (Personality Guard, Quality Gate, Narrative Nudge)
- Guards are now persistently enabled via systemd drop-in, surviving gateway restarts
- Gateway runs as `ubuntu` user for Claude CLI authentication compatibility

## Changes

- `cmd/cortex-gateway/main.go`: New `applyHardeningDefaults()` function reads `SENTINEL_PERSONALITY_GUARD_ENABLED`, `SENTINEL_DRIFT_THRESHOLD`, `SENTINEL_QUALITY_GATE_ENABLED`, `SENTINEL_QUALITY_THRESHOLD`, `SENTINEL_QUALITY_MAX_REGEN`, `SENTINEL_NARRATIVE_NUDGE` from environment and applies to control config at startup.
- `config/cortex-gateway.toml`: Added `[hardening]` documentation section with env var reference.
- `CHANGELOG.md`: Added config persistence entry under #144.

## Linked Issues

Closes #144

## Test Plan

- [x] `go vet ./cmd/cortex-gateway/...` — clean
- [x] `go test ./cmd/cortex-gateway/...` — all pass (14 packages)
- [x] Deploy on VM (10.0.0.240) with systemd drop-in
- [x] Verify guards loaded at startup: `journalctl | grep "hardening defaults applied"`
- [x] Verify personality guard triggers: `journalctl | grep "personality drift detected"`
- [x] Verify quality gate triggers: `journalctl | grep "low quality response detected"`

## Benchmarks

No performance-critical path affected. `applyHardeningDefaults()` runs once at startup (O(6) env lookups). No benchmark needed.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | Narrative nudge set via `PATCH /control/config`, pipeline requests processed with nudge active. Nudge injection code at pipeline.go:468-472 appends `[NARRATIVE_NUDGE]` block to system prompt |
| AC-2 | PASS | `journalctl`: `"personality drift detected" agent="AGENT-51" drift_score=1 severity="critical"` followed by `"personality guard re-generated response" agent="AGENT-51"` — Guard detected drift AND re-generated |
| AC-3 | PASS | `journalctl`: `"low quality response detected" agent="AGENT-48" score=3 factors="len=4 spec=5 cons=1"` followed by `"quality gate re-generation failed" attempt=1` — Quality Gate triggered re-generation |
| AC-N1 | PASS | Re-gen attempt=1 with max_regen=1 (max 2 provider calls). Unit test `TestQualityGateMaxRegen` confirms loop bound. No infinite loop possible |

## Checklist

- [x] Code compiles without warnings
- [x] All existing tests pass
- [x] go vet clean
- [x] CHANGELOG.md updated
- [x] Deployed and verified on VM (10.0.0.240)
- [x] Guards persist across gateway restart (env-var based)
- [x] All 4 ACs verified with live evidence