### PR TITLE
feat: agent-runtime binary + Landlock detection fix (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **agent-runtime Binary** (#173)
+  - `services/agent-runtime/`: Leichtgewichtiger Sandbox-Prozess (Zero Dependencies, nur std)
+  - Stdin-Reader-Thread fuer zukuenftige Command-Dispatch, Heartbeat-Loop (30s) fuer VFS I/O
+  - Laeuft innerhalb bwrap-Namespace als `/usr/bin/agent-runtime`
+
+### Fixed
+
+- **Landlock Detection auf Kernel 6.11+** (#173)
+  - `crates/sentinel-sandbox/src/landlock.rs`: `detect_abi()` prueft nun auch `/sys/kernel/security/lsm` als Fallback
+  - Kernel 6.11+ entfernte `/sys/kernel/security/landlock/` securityfs-Directory
+  - Landlock war im Kernel aktiv aber wurde nicht erkannt — jetzt korrekt: "Landlock ABI v4 detected"
+
 - **WASM Component Model Runtime** (#19)
   - `crates/sentinel-wasm/wit/world.wit`: WIT Interface Definition (`sentinel:plugin@0.1.0`) mit Host-API (fs-read/write/list, get-agent-info, get-room-info, log, get-tick) und Plugin-Exports (execute, tool-name, tool-description)
   - `crates/sentinel-wasm/src/host.rs`: `bindgen!`-basierte Host-Implementation, `PluginState` mit WASI 0.2 Context, `AgentSnapshot`/`RoomSnapshot` ECS-Bridges, 7 Host-Function Traits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-runtime"
+version = "0.1.0"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "services/sentinel-nightrun",
     "services/sentinel-daemon",
     "services/sentinel-projection",
+    "services/agent-runtime",
 ]
 
 [workspace.dependencies]

--- a/cmd/cortex-gateway/go.mod
+++ b/cmd/cortex-gateway/go.mod
@@ -1,8 +1,8 @@
 module github.com/obtFusi/project-sentinel/cmd/cortex-gateway
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/cmd/cortex-gateway/go.mod
+++ b/cmd/cortex-gateway/go.mod
@@ -2,7 +2,7 @@ module github.com/obtFusi/project-sentinel/cmd/cortex-gateway
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/crates/sentinel-sandbox/src/landlock.rs
+++ b/crates/sentinel-sandbox/src/landlock.rs
@@ -114,13 +114,24 @@ impl LandlockRuleset {
 
 /// Detects whether Landlock is available on this kernel.
 /// Returns the ABI version (1-4) or None if not available.
+///
+/// Detection order:
+/// 1. `/sys/kernel/security/landlock` (securityfs, kernel < 6.11)
+/// 2. `/sys/kernel/security/lsm` contains "landlock" (kernel 6.11+ removed securityfs dir)
 pub fn detect_abi() -> Option<u8> {
-    if !std::path::Path::new("/sys/kernel/security/landlock").exists() {
-        return None;
+    // Kernel < 6.11: securityfs exposes landlock directory.
+    if std::path::Path::new("/sys/kernel/security/landlock").exists() {
+        return Some(4);
     }
-    // VM kernel 6.8 supports ABI v4.
-    // The landlock crate handles ABI negotiation via BestEffort compat level.
-    Some(4)
+
+    // Kernel 6.11+: securityfs directory removed, check LSM list instead.
+    if let Ok(lsm) = std::fs::read_to_string("/sys/kernel/security/lsm") {
+        if lsm.contains("landlock") {
+            return Some(4);
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 use (
 	./cmd/cortex-gateway

--- a/pkg/sentinel-go/go.mod
+++ b/pkg/sentinel-go/go.mod
@@ -1,8 +1,8 @@
 module github.com/obtFusi/project-sentinel/pkg/sentinel-go
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 require (
 	github.com/nats-io/nats.go v1.48.0

--- a/pkg/sentinel-go/go.mod
+++ b/pkg/sentinel-go/go.mod
@@ -2,7 +2,7 @@ module github.com/obtFusi/project-sentinel/pkg/sentinel-go
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/nats-io/nats.go v1.48.0

--- a/services/agent-runtime/Cargo.toml
+++ b/services/agent-runtime/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "agent-runtime"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+description = "Lightweight sandbox process for sentinel agents (runs inside bwrap)"
+
+# Intentionally zero external dependencies.
+# agent-runtime runs inside bwrap with minimal footprint.
+[dependencies]

--- a/services/agent-runtime/src/main.rs
+++ b/services/agent-runtime/src/main.rs
@@ -1,0 +1,76 @@
+//! agent-runtime: Lightweight sandbox process for sentinel agents.
+//!
+//! Runs inside bwrap namespace. Reads stdin (for future command dispatch),
+//! writes periodic heartbeats to generate VFS I/O (tracked by eBPF).
+//! Exits on EOF (stdin closed) or when `--die-with-parent` triggers.
+//!
+//! Zero external dependencies — only `std`.
+
+use std::io::{self, BufRead, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Heartbeat interval in seconds.
+const HEARTBEAT_INTERVAL_SECS: u64 = 30;
+
+/// Main loop sleep granularity in milliseconds.
+const SLEEP_MS: u64 = 500;
+
+fn main() {
+    eprintln!("agent-runtime: started (pid={})", std::process::id());
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    // Stdin reader thread — blocks on read, sets running=false on EOF.
+    let r = running.clone();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(cmd) if cmd.trim() == "shutdown" => {
+                    eprintln!("agent-runtime: shutdown command received");
+                    break;
+                }
+                Ok(_) => {}      // Consume silently (future: JSON command dispatch)
+                Err(_) => break, // EOF — daemon closed stdin
+            }
+        }
+        r.store(false, Ordering::Relaxed);
+    });
+
+    // Initial heartbeat (immediate I/O for eBPF tracking).
+    write_heartbeat();
+
+    let mut last_heartbeat = Instant::now();
+
+    while running.load(Ordering::Relaxed) {
+        if last_heartbeat.elapsed() >= Duration::from_secs(HEARTBEAT_INTERVAL_SECS) {
+            write_heartbeat();
+            last_heartbeat = Instant::now();
+        }
+        std::thread::sleep(Duration::from_millis(SLEEP_MS));
+    }
+
+    eprintln!("agent-runtime: shutting down");
+}
+
+/// Write a timestamp to `/tmp/heartbeat` — generates VFS I/O visible
+/// in `/proc/{pid}/io` (wchar), tracked by sentinel-ebpf collector.
+fn write_heartbeat() {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let result = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open("/tmp/heartbeat")
+        .and_then(|mut f| writeln!(f, "{ts}"));
+
+    if let Err(e) = result {
+        eprintln!("agent-runtime: heartbeat write failed: {e}");
+    }
+}

--- a/services/sentinel-judge/go.mod
+++ b/services/sentinel-judge/go.mod
@@ -2,7 +2,7 @@ module github.com/obtFusi/project-sentinel/services/sentinel-judge
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/services/sentinel-judge/go.mod
+++ b/services/sentinel-judge/go.mod
@@ -1,8 +1,8 @@
 module github.com/obtFusi/project-sentinel/services/sentinel-judge
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/services/sentinel-nats-bridge/go.mod
+++ b/services/sentinel-nats-bridge/go.mod
@@ -2,7 +2,7 @@ module github.com/obtFusi/project-sentinel/services/sentinel-nats-bridge
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/services/sentinel-nats-bridge/go.mod
+++ b/services/sentinel-nats-bridge/go.mod
@@ -1,8 +1,8 @@
 module github.com/obtFusi/project-sentinel/services/sentinel-nats-bridge
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.8
+toolchain go1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Add `agent-runtime` binary: lightweight sandbox process that runs inside bwrap namespace
- Fix Landlock ABI detection on kernel 6.11+ (securityfs directory removed)
- All 10 ACs verified live on VM (10.0.0.240)

## Changes
- **`services/agent-runtime/`**: New workspace member — zero-dependency Rust binary with stdin reader thread + 30s heartbeat loop (generates VFS I/O for eBPF tracking)
- **`crates/sentinel-sandbox/src/landlock.rs`**: `detect_abi()` now checks `/sys/kernel/security/lsm` as fallback when `/sys/kernel/security/landlock` directory is missing (kernel 6.11+ change)
- **`Cargo.toml`**: Added `services/agent-runtime` to workspace members
- **`CHANGELOG.md`**: Added entries for agent-runtime and Landlock fix

## Linked Issues
Closes #173

## Test Plan
- [x] `cargo clippy -p agent-runtime -- -D warnings` — clean
- [x] `cargo clippy -p sentinel-sandbox -- -D warnings` — clean
- [x] `cargo test -p sentinel-sandbox -p agent-runtime -p sentinel-daemon --lib` — 40 passed, 0 failed
- [x] `cargo fmt -- --check` — clean
- [x] Live verification on VM (10.0.0.240) — all 10 ACs PASS

## Benchmarks
No new benchmarks required — agent-runtime is a lightweight stdin-reading process. Spawn timing measured via daemon logs: 5 agents in 27ms (0.2-15ms each), well under AC-5 target of 100ms.

## Evidence (AC Mapping)

| AC | Kriterium | Status | Evidence |
|----|-----------|--------|----------|
| AC-1 | bwrap-Namespace | PASS | See below |
| AC-2 | cgroup v2 pro Agent | PASS | See below |
| AC-3 | cgroup Limits | PASS | See below |
| AC-4 | Landlock aktiv | PASS | See below |
| AC-5 | Spawn < 100ms | PASS | See below |
| AC-6 | eBPF vfs_write | PASS | See below |
| AC-7 | io_ops write > 0 | PASS | See below |
| AC-8 | PSI cpu.pressure | PASS | See below |
| AC-9 | Despawn Cleanup | PASS | See below |
| AC-10 | Graceful Degradation | PASS | See below |

### AC-1: Living bwrap processes (not defunct)
```bash
$ ssh ubuntu@10.0.0.240 "ps aux | grep bwrap | grep -v grep | grep -v defunct | head -5"
root 12847 0.0 0.0 3024 1408 ? Ss 16:40 0:00 bwrap --unshare-pid ...
root 12857 0.0 0.0 3024 1408 ? Ss 16:40 0:00 bwrap --unshare-pid ...
# 48 living bwrap processes (Status S), 24 agent-runtime (Status Sl)
```

### AC-2: cgroup v2 directories per agent
```bash
$ ssh ubuntu@10.0.0.240 "ls /sys/fs/cgroup/sentinel/ | head -5"
Andreas Weber
Carla Rossi
Dr. Anna Bergmann
Dr. Elena Fischer
# 77 agent directories total
```

### AC-3: cgroup limits enforced
```bash
$ ssh ubuntu@10.0.0.240 "cat '/sys/fs/cgroup/sentinel/Thomas Mueller/cpu.max'"
100000 100000
$ ssh ubuntu@10.0.0.240 "cat '/sys/fs/cgroup/sentinel/Thomas Mueller/memory.max'"
268435456
$ ssh ubuntu@10.0.0.240 "cat '/sys/fs/cgroup/sentinel/Thomas Mueller/io.max'"
259:0 riops=300 wiops=300
```

### AC-4: Landlock enforced
```bash
$ ssh ubuntu@10.0.0.240 "cat /sys/kernel/security/lsm"
landlock,lockdown,capability,yama,apparmor,bpf
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '10 min ago' | grep -i landlock | head -3"
Landlock ABI v4 detected
Landlock wrapper injected into bwrap config at /landlock-wrapper
Landlock enforced: fully
```

### AC-5: Spawn time < 100ms
```bash
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '10 min ago' | grep 'spawned.*bwrap' | head -3"
# 5 agents spawned in 27ms total (individual: 0.2ms - 15ms)
# Timestamps: 16:40:15.568 to 16:40:15.595
```

### AC-6 + AC-7: eBPF I/O metrics
```bash
$ ssh ubuntu@10.0.0.240 "curl -s localhost:9090/metrics | grep sentinel_io_ops | head -3"
sentinel_io_ops_total{cgroup_name="Michael Hartmann",direction="read"} 1
sentinel_io_ops_total{cgroup_name="Michael Hartmann",direction="write"} 1
sentinel_io_ops_total{cgroup_name="Carla Rossi",direction="write"} 1
```

### AC-8: PSI cpu.pressure
```bash
$ ssh ubuntu@10.0.0.240 "cat '/sys/fs/cgroup/sentinel/Thomas Mueller/cpu.pressure'"
some avg10=0.00 avg60=0.00 avg300=0.00 total=0
full avg10=0.00 avg60=0.00 avg300=0.00 total=0
```

### AC-9: Despawn cleanup
```bash
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon | grep 'Removed cgroup' | head -2"
Removed cgroup for Thomas Mueller
Removed cgroup for Lisa Schneider
```

### AC-10: Graceful degradation
```bash
$ ssh ubuntu@10.0.0.240 "systemctl is-active sentinel-daemon"
active
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '10 min ago' | grep -c PANIC"
0
```

## Checklist
- [x] Code compiles without warnings
- [x] All existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` applied
- [x] CHANGELOG.md updated
- [x] Conventional commit message
- [x] Live verification on deploy VM