### PR TITLE
fix: resolve RoomId type mismatch breaking transit variance (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Transit-Varianz: RoomId-Typ-Mismatch** (#194)
+  - `crates/sentinel-common/src/types.rs`: `AgentAction.target_room` von `Option<RoomId>` auf `Option<String>` geaendert
+  - `crates/sentinel-ecs/src/systems.rs`: `input_system()` nutzt jetzt echte Raumnamen statt `format!("ROOM-{}")` — Distance-Lookup funktioniert endlich
+  - `services/sentinel-daemon/src/llm_bridge.rs`: Echter Raumname statt Dummy `RoomId(1)`
+  - Vorher: Alle Transits hatten identische Dauer (3100ms), Room-IDs waren nach erstem Transit kaputt
+  - 5 neue Integration-Tests: Distance-Varianz, Bounds-Check, Room-ID nach Transit, Encounter-Events, RoomDistanceMap-Lookup
+
 - **Landlock Detection auf Kernel 6.11+** (#173)
   - `crates/sentinel-sandbox/src/landlock.rs`: `detect_abi()` prueft nun auch `/sys/kernel/security/lsm` als Fallback
   - Kernel 6.11+ entfernte `/sys/kernel/security/landlock/` securityfs-Directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,6 +4112,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 1.0.3+spec-1.1.0",
  "tracing",
  "uuid",
 ]

--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -267,7 +267,7 @@ mod tests {
         let action = AgentAction {
             agent_id: AgentId(1),
             action_type: ActionType::Chat,
-            target_room: Some(RoomId(3)),
+            target_room: Some("konferenz-1".to_string()),
             target_agent: Some(AgentId(5)),
             content: Some("Guten Morgen!".to_string()),
             timestamp: Timestamp(1000),
@@ -277,7 +277,7 @@ mod tests {
         let deserialized: AgentAction = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.agent_id, AgentId(1));
         assert_eq!(deserialized.action_type, ActionType::Chat);
-        assert_eq!(deserialized.target_room, Some(RoomId(3)));
+        assert_eq!(deserialized.target_room, Some("konferenz-1".to_string()));
     }
 
     #[test]

--- a/crates/sentinel-common/src/types.rs
+++ b/crates/sentinel-common/src/types.rs
@@ -135,7 +135,7 @@ pub enum EventType {
 pub struct AgentAction {
     pub agent_id: AgentId,
     pub action_type: ActionType,
-    pub target_room: Option<RoomId>,
+    pub target_room: Option<String>,
     pub target_agent: Option<AgentId>,
     pub content: Option<String>,
     pub timestamp: Timestamp,

--- a/crates/sentinel-common/tests/acceptance.rs
+++ b/crates/sentinel-common/tests/acceptance.rs
@@ -44,7 +44,7 @@ fn ac_05_04_serde_roundtrip_all_types() {
     let action = AgentAction {
         agent_id: AgentId(1),
         action_type: ActionType::Chat,
-        target_room: Some(RoomId(3)),
+        target_room: Some("konferenz-1".to_string()),
         target_agent: Some(AgentId(5)),
         content: Some("Hallo Welt".to_string()),
         timestamp: Timestamp(1000),

--- a/crates/sentinel-ecs/Cargo.toml
+++ b/crates/sentinel-ecs/Cargo.toml
@@ -26,3 +26,4 @@ sentinel-wasm = { path = "../sentinel-wasm" }
 [dev-dependencies]
 sentinel-common = { path = "../sentinel-common" }
 tempfile = "3"
+toml = { workspace = true }

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -743,8 +743,7 @@ mod tests {
             .collect();
         assert_eq!(transit_events.len(), 1);
 
-        let payload1: serde_json::Value =
-            serde_json::from_str(&transit_events[0].payload).unwrap();
+        let payload1: serde_json::Value = serde_json::from_str(&transit_events[0].payload).unwrap();
         let duration_near = payload1["duration_ms"].as_u64().unwrap();
         assert_eq!(duration_near, 2300, "1-hop transit should be 2300ms");
 
@@ -790,8 +789,7 @@ mod tests {
             .collect();
         assert_eq!(transit_events.len(), 2);
 
-        let payload2: serde_json::Value =
-            serde_json::from_str(&transit_events[1].payload).unwrap();
+        let payload2: serde_json::Value = serde_json::from_str(&transit_events[1].payload).unwrap();
         let duration_far = payload2["duration_ms"].as_u64().unwrap();
         assert_eq!(duration_far, 4700, "4-hop transit should be 4700ms");
 
@@ -873,8 +871,7 @@ mod tests {
         assert_eq!(transit_events.len(), targets.len());
 
         for event in &transit_events {
-            let payload: serde_json::Value =
-                serde_json::from_str(&event.payload).unwrap();
+            let payload: serde_json::Value = serde_json::from_str(&event.payload).unwrap();
             let duration = payload["duration_ms"].as_u64().unwrap();
             assert!(
                 (2000..=5000).contains(&duration),
@@ -1033,8 +1030,7 @@ mod tests {
             .collect();
         assert_eq!(transit_events.len(), 1);
 
-        let payload: serde_json::Value =
-            serde_json::from_str(&transit_events[0].payload).unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&transit_events[0].payload).unwrap();
         assert_eq!(
             payload["duration_ms"].as_u64().unwrap(),
             3100,

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -695,6 +695,355 @@ mod tests {
         assert_eq!(tool_events[0].aggregate_id, "AGENT-05");
     }
 
+    /// Transit-Dauer variiert mit Raum-Distanz (nicht hardcoded!)
+    #[test]
+    fn test_transit_duration_varies_with_distance() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_db_path = dir.path().join("transit-distance.db");
+        let event_store = Arc::new(EventStore::open(event_db_path.to_str().unwrap()).unwrap());
+
+        let (mut world, mut schedule) = create_simulation_world();
+        world.insert_resource(LimboEventStore(event_store.clone()));
+
+        let rooms_toml = include_str!("../../../config/rooms.toml");
+        let building_config: sentinel_common::room::BuildingConfig =
+            toml::from_str(rooms_toml).expect("rooms.toml parse error");
+        world.insert_resource(RoomDistanceMap::from_building_config(&building_config));
+
+        spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        world.insert_resource(ActionReceiver(std::sync::Mutex::new(rx)));
+
+        // Move zu nahem Raum: empfang → flur-eg (1 hop → 2300ms)
+        tx.send(AgentAction {
+            agent_id: AgentId(1),
+            action_type: ActionType::Move,
+            target_room: Some("flur-eg".to_string()),
+            target_agent: None,
+            content: None,
+            timestamp: Timestamp(1000),
+            tick: Tick(1),
+        })
+        .unwrap();
+
+        {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(1);
+            time.tick_count = 1;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+        }
+        schedule.run(&mut world);
+
+        let events = event_store.get_events_since(0, 100).unwrap();
+        let transit_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == "transit_started")
+            .collect();
+        assert_eq!(transit_events.len(), 1);
+
+        let payload1: serde_json::Value =
+            serde_json::from_str(&transit_events[0].payload).unwrap();
+        let duration_near = payload1["duration_ms"].as_u64().unwrap();
+        assert_eq!(duration_near, 2300, "1-hop transit should be 2300ms");
+
+        // Transit abschliessen (manuell Position resetten)
+        {
+            let entity_id = world
+                .query_filtered::<bevy_ecs::prelude::Entity, bevy_ecs::prelude::With<AgentIdentity>>()
+                .iter(&world)
+                .next()
+                .unwrap();
+            let mut pos = world.get_mut::<Position>(entity_id).unwrap();
+            pos.in_transit = false;
+            pos.transit_target = None;
+            pos.transit_remaining_ms = 0;
+            pos.room_id = "empfang".to_string();
+        }
+
+        // Move zu fernem Raum: empfang → buero-ceo (4 hops → 4700ms)
+        tx.send(AgentAction {
+            agent_id: AgentId(1),
+            action_type: ActionType::Move,
+            target_room: Some("buero-ceo".to_string()),
+            target_agent: None,
+            content: None,
+            timestamp: Timestamp(2000),
+            tick: Tick(2),
+        })
+        .unwrap();
+
+        {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(2);
+            time.tick_count = 2;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+        }
+        schedule.run(&mut world);
+
+        let events = event_store.get_events_since(0, 100).unwrap();
+        let transit_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == "transit_started")
+            .collect();
+        assert_eq!(transit_events.len(), 2);
+
+        let payload2: serde_json::Value =
+            serde_json::from_str(&transit_events[1].payload).unwrap();
+        let duration_far = payload2["duration_ms"].as_u64().unwrap();
+        assert_eq!(duration_far, 4700, "4-hop transit should be 4700ms");
+
+        assert!(
+            duration_far > duration_near,
+            "Far room ({duration_far}ms) must take longer than near room ({duration_near}ms)"
+        );
+    }
+
+    /// Transit-Dauer bleibt immer in [2000, 5000]ms Bounds
+    #[test]
+    fn test_transit_duration_within_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_db_path = dir.path().join("transit-bounds.db");
+        let event_store = Arc::new(EventStore::open(event_db_path.to_str().unwrap()).unwrap());
+
+        let (mut world, mut schedule) = create_simulation_world();
+        world.insert_resource(LimboEventStore(event_store.clone()));
+
+        let rooms_toml = include_str!("../../../config/rooms.toml");
+        let building_config: sentinel_common::room::BuildingConfig =
+            toml::from_str(rooms_toml).expect("rooms.toml parse error");
+        world.insert_resource(RoomDistanceMap::from_building_config(&building_config));
+
+        spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        world.insert_resource(ActionReceiver(std::sync::Mutex::new(rx)));
+
+        let targets = [
+            "flur-eg",        // 1 hop
+            "kueche",         // 2 hops
+            "treppenhaus",    // 2 hops
+            "buero-ceo",      // 4 hops
+            "buero-design-1", // 4 hops
+        ];
+
+        for (i, target) in targets.iter().enumerate() {
+            {
+                let entity = world
+                    .query_filtered::<bevy_ecs::prelude::Entity, bevy_ecs::prelude::With<AgentIdentity>>()
+                    .iter(&world)
+                    .next()
+                    .unwrap();
+                let mut pos = world.get_mut::<Position>(entity).unwrap();
+                pos.in_transit = false;
+                pos.transit_target = None;
+                pos.transit_remaining_ms = 0;
+                pos.room_id = "empfang".to_string();
+            }
+
+            tx.send(AgentAction {
+                agent_id: AgentId(1),
+                action_type: ActionType::Move,
+                target_room: Some(target.to_string()),
+                target_agent: None,
+                content: None,
+                timestamp: Timestamp(i as u64 * 1000),
+                tick: Tick(i as u64 + 10),
+            })
+            .unwrap();
+
+            {
+                let mut time = world.resource_mut::<SimulationTime>();
+                time.tick = Tick(i as u64 + 10);
+                time.tick_count = i as u64 + 10;
+                time.delta_seconds = 1.0;
+                time.sim_hour = 8.0;
+            }
+            schedule.run(&mut world);
+        }
+
+        let events = event_store.get_events_since(0, 200).unwrap();
+        let transit_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == "transit_started")
+            .collect();
+
+        assert_eq!(transit_events.len(), targets.len());
+
+        for event in &transit_events {
+            let payload: serde_json::Value =
+                serde_json::from_str(&event.payload).unwrap();
+            let duration = payload["duration_ms"].as_u64().unwrap();
+            assert!(
+                (2000..=5000).contains(&duration),
+                "Duration {duration}ms outside bounds [2000, 5000]"
+            );
+        }
+    }
+
+    /// Room-ID nach Transit ist der echte Raumname (nicht "ROOM-1")
+    #[test]
+    fn test_room_id_correct_after_transit() {
+        let (mut world, mut schedule) = create_simulation_world();
+        let entity = spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1);
+
+        // Agent manuell in Transit nach "kueche" setzen
+        {
+            let mut pos = world.get_mut::<Position>(entity).unwrap();
+            pos.in_transit = true;
+            pos.transit_target = Some("kueche".to_string());
+            pos.transit_remaining_ms = 1000;
+        }
+
+        // 2 Ticks a 1s (1000ms Transit → abgeschlossen)
+        for tick in 0..2u64 {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(tick);
+            time.delta_seconds = 1.0;
+            time.sim_hour = 10.0;
+            schedule.run(&mut world);
+        }
+
+        let pos = world.get::<Position>(entity).unwrap();
+        assert!(!pos.in_transit);
+        assert_eq!(
+            pos.room_id, "kueche",
+            "Room ID must be real room name, not ROOM-X format"
+        );
+        assert!(
+            !pos.room_id.starts_with("ROOM-"),
+            "Room ID must not use ROOM-X format"
+        );
+    }
+
+    /// Encounter-System erzeugt HallwayEncounterDetected Events
+    #[test]
+    fn test_encounter_system_generates_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_db_path = dir.path().join("encounter.db");
+        let event_store = Arc::new(EventStore::open(event_db_path.to_str().unwrap()).unwrap());
+
+        let (mut world, mut schedule) = create_simulation_world();
+        world.insert_resource(LimboEventStore(event_store.clone()));
+
+        // 3 Agents spawnen, alle manuell in Transit setzen
+        for i in 1..=3 {
+            let entity = spawn_agent(
+                &mut world,
+                AgentId(i),
+                &format!("Agent-{i:02}"),
+                "Tester",
+                1,
+            );
+            let mut pos = world.get_mut::<Position>(entity).unwrap();
+            pos.in_transit = true;
+            pos.transit_target = Some("kueche".to_string());
+            pos.transit_remaining_ms = 600_000; // 10min — lang genug damit Transit nicht endet
+        }
+
+        // Mehrere Ticks laufen (encounter_system laeuft alle 3 Ticks)
+        // Bei 30% Wahrscheinlichkeit und 3 Paaren pro Check: ~0.9 Events pro Check
+        // 30 Ticks = 10 Checks → statistisch ~9 Events
+        for tick in 1..=30u64 {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(tick);
+            time.tick_count = tick;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+            schedule.run(&mut world);
+        }
+
+        let events = event_store.get_events_since(0, 500).unwrap();
+        let encounter_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == "hallway_encounter_detected")
+            .collect();
+
+        assert!(
+            !encounter_events.is_empty(),
+            "Encounter system must generate HallwayEncounterDetected events \
+             when multiple agents are in transit (got 0 events after 30 ticks \
+             with 3 agents in transit)"
+        );
+    }
+
+    /// Move-Action mit echtem Raumnamen → korrekte Transit-Duration via RoomDistanceMap
+    #[test]
+    fn test_move_action_uses_room_distance_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let event_db_path = dir.path().join("move-rdm.db");
+        let event_store = Arc::new(EventStore::open(event_db_path.to_str().unwrap()).unwrap());
+
+        let (mut world, mut schedule) = create_simulation_world();
+        world.insert_resource(LimboEventStore(event_store.clone()));
+
+        let rooms_toml = include_str!("../../../config/rooms.toml");
+        let building_config: sentinel_common::room::BuildingConfig =
+            toml::from_str(rooms_toml).expect("rooms.toml parse error");
+        let rdm = RoomDistanceMap::from_building_config(&building_config);
+
+        // Verifiziere: Distanzen sind nicht alle gleich
+        let d1 = rdm.distance("empfang", "flur-eg"); // 1 hop
+        let d2 = rdm.distance("empfang", "kueche"); // 2 hops
+        let d3 = rdm.distance("empfang", "buero-ceo"); // 4 hops
+        assert_eq!(d1, 1);
+        assert_eq!(d2, 2);
+        assert_eq!(d3, 4);
+
+        world.insert_resource(rdm);
+
+        let entity = spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        world.insert_resource(ActionReceiver(std::sync::Mutex::new(rx)));
+
+        // Move nach kueche (2 hops → 3100ms)
+        tx.send(AgentAction {
+            agent_id: AgentId(1),
+            action_type: ActionType::Move,
+            target_room: Some("kueche".to_string()),
+            target_agent: None,
+            content: None,
+            timestamp: Timestamp(1000),
+            tick: Tick(1),
+        })
+        .unwrap();
+
+        {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(1);
+            time.tick_count = 1;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+        }
+        schedule.run(&mut world);
+
+        // Position muss in Transit sein
+        let pos = world.get::<Position>(entity).unwrap();
+        assert!(pos.in_transit, "Agent should be in transit");
+        assert_eq!(pos.transit_target, Some("kueche".to_string()));
+
+        // TransitStarted Event muss korrekte Duration haben
+        let events = event_store.get_events_since(0, 100).unwrap();
+        let transit_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.event_type == "transit_started")
+            .collect();
+        assert_eq!(transit_events.len(), 1);
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&transit_events[0].payload).unwrap();
+        assert_eq!(
+            payload["duration_ms"].as_u64().unwrap(),
+            3100,
+            "empfang→kueche = 2 hops → 1500+1600=3100ms"
+        );
+        assert_eq!(payload["to_room"].as_str().unwrap(), "kueche");
+        assert_eq!(payload["from_room"].as_str().unwrap(), "empfang");
+    }
+
     /// ToolUse ohne ToolRuntime: Fallback auf WorkContext
     #[test]
     fn test_tool_dispatch_fallback_without_runtime() {

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -83,7 +83,7 @@ pub fn input_system(
                 ActionType::Move => {
                     if let Some(target_room) = &action.target_room {
                         let from_room = position.room_id.clone();
-                        let to_room = format!("ROOM-{}", target_room.0);
+                        let to_room = target_room.clone();
                         // Distance-basierte Transit-Dauer: 1500ms Basis + 800ms pro Hop
                         // Clamp auf 2000-5000ms (TRANSIT_MIN/MAX aus sentinel-physics)
                         let hops = room_distances
@@ -212,7 +212,7 @@ pub fn input_system(
         let payload = DomainEventPayload::AgentActionReceived {
             agent_id: action.agent_id,
             action_type: format!("{:?}", action.action_type),
-            target_room: action.target_room.map(|r| format!("ROOM-{}", r.0)),
+            target_room: action.target_room.clone(),
             content: action.content.clone(),
         };
         let action_event = DomainEvent::new(

--- a/crates/sentinel-ecs/tests/integration_event_path.rs
+++ b/crates/sentinel-ecs/tests/integration_event_path.rs
@@ -6,7 +6,7 @@
 //! AC3: Event+Outbox atomar (via append_with_outbox, hier indirekt geprueft)
 //! AC4: E2E: Action rein → Event in Limbo → State veraendert
 
-use sentinel_common::{ActionType, AgentAction, AgentId, RoomId, Tick, Timestamp};
+use sentinel_common::{ActionType, AgentAction, AgentId, Tick, Timestamp};
 use sentinel_ecs::{
     attach_redb_store, create_simulation_world, spawn_agent, ActionReceiver, BioState, EventBuffer,
     LimboEventStore, SimulationTime,
@@ -244,7 +244,7 @@ fn test_e2e_move_action_transit_with_correlation() {
     tx.send(AgentAction {
         agent_id: AgentId(1),
         action_type: ActionType::Move,
-        target_room: Some(RoomId(5)),
+        target_room: Some("buero-dev-1".to_string()),
         target_agent: None,
         content: None,
         timestamp: Timestamp(1000),
@@ -303,7 +303,7 @@ fn test_all_action_types_generate_events() {
     // 5 verschiedene ActionTypes senden
     let actions = vec![
         (ActionType::Chat, None, Some("Hallo".to_string())),
-        (ActionType::Move, Some(RoomId(3)), None),
+        (ActionType::Move, Some("kueche".to_string()), None),
         (ActionType::ToolUse, None, Some("drink_coffee".to_string())),
         (ActionType::Emote, None, Some("lacht".to_string())),
         (

--- a/services/sentinel-daemon/src/llm_bridge.rs
+++ b/services/sentinel-daemon/src/llm_bridge.rs
@@ -22,7 +22,7 @@ pub mod bridge {
     use tokio::sync::Semaphore;
     use tracing::{debug, error, info, instrument, warn};
 
-    use sentinel_common::{ActionType, AgentAction, AgentId, Perception, RoomId, Tick, Timestamp};
+    use sentinel_common::{ActionType, AgentAction, AgentId, Perception, Tick, Timestamp};
     use sentinel_redb::StateStore;
 
     /// LLM Bridge Konfiguration.
@@ -461,11 +461,8 @@ pub mod bridge {
             }
         };
 
-        // Target Room: Versuche aus dem target-Feld eine RoomId zu parsen
         let target_room = if !extracted.target.is_empty() {
-            // Gateway liefert Room-Name (z.B. "kueche"), RoomId braucht u16
-            // Fuer jetzt: Dummy-RoomId 1 — rooms.toml Mapping kommt spaeter
-            Some(RoomId(1))
+            Some(extracted.target.clone())
         } else {
             None
         };

--- a/typos.toml
+++ b/typos.toml
@@ -441,6 +441,9 @@ fertig = "fertig"
 schaue = "schaue"
 Satzlaenge = "Satzlaenge"
 
+# Transit-Varianz words (Issue #194 - German in Rust test comments)
+statistisch = "statistisch"
+
 # Bio-Engine dynamics words (Issue #148 - German in Rust doc comments)
 realistisch = "realistisch"
 realistische = "realistische"


### PR DESCRIPTION
## Summary

- Fix critical bug where `AgentAction.target_room` was `Option<RoomId>` (numeric) but `RoomDistanceMap` uses string room names — all transits always had identical 3100ms duration
- Change `target_room` to `Option<String>`, pass real room names from LLM bridge through distance lookup
- Add 5 integration tests proving transit-varianz and encounter functionality actually works

## Changes

| File | Change |
|------|--------|
| `crates/sentinel-common/src/types.rs:138` | `AgentAction.target_room`: `Option<RoomId>` → `Option<String>` |
| `crates/sentinel-ecs/src/systems.rs:84-86` | `input_system`: use string room name directly instead of `format!("ROOM-{}", target_room.0)` |
| `crates/sentinel-ecs/src/systems.rs:215` | `AgentActionReceived` event: `.clone()` instead of `.map(\|r\| format!("ROOM-{}", r.0))` |
| `services/sentinel-daemon/src/llm_bridge.rs:464-468` | Pass `extracted.target.clone()` instead of dummy `RoomId(1)` |
| `services/sentinel-daemon/src/llm_bridge.rs:25` | Remove unused `RoomId` import |
| `crates/sentinel-ecs/src/lib.rs` | +5 new integration tests (349 lines) |
| `crates/sentinel-common/src/lib.rs` | Fix test to use `String` instead of `RoomId` |
| `crates/sentinel-common/tests/acceptance.rs` | Fix test to use `String` instead of `RoomId` |
| `crates/sentinel-ecs/tests/integration_event_path.rs` | Fix tests to use `String` instead of `RoomId` |
| `crates/sentinel-ecs/Cargo.toml` | Add `toml` dev-dependency for rooms.toml parsing in tests |
| `CHANGELOG.md` | Bug-fix entry |

## Linked Issues

Closes #194

## Test Plan

| Ebene | Command | Ergebnis |
|-------|---------|----------|
| Static | `cargo remote -- clippy --workspace --all-targets -- -D warnings` | 0 warnings |
| Unit + Integration | `cargo remote -- test --workspace` | All pass (300+ tests) |
| System | Deploy on VM, verify ACs via SQLite queries | Pending post-merge |

**5 new integration tests:**
1. `test_transit_duration_varies_with_distance` — near room (1 hop=2300ms) vs far room (4 hops=4700ms)
2. `test_transit_duration_within_bounds` — 5 rooms, all durations in [2000, 5000]ms
3. `test_room_id_correct_after_transit` — room_id is "kueche" not "ROOM-1" after transit
4. `test_encounter_system_generates_events` — 3 agents in transit, HallwayEncounterDetected events appear
5. `test_move_action_uses_room_distance_map` — RoomDistanceMap distances (1,2,4 hops) produce correct duration

## Benchmarks

No benchmarks affected — this is a bug fix in type handling, not a performance change.
Transit duration formula `(1500 + hops * 800).clamp(2000, 5000)` is unchanged.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `cargo remote -- test -p sentinel-ecs test_move_action_uses_room_distance_map` — verifies BFS distances (empfang→flur-eg=1, empfang→kueche=2, empfang→buero-ceo=4) produce correct durations |
| AC-2 | PASS (unit) / PENDING (VM) | `test_transit_duration_varies_with_distance`: near=2300ms, far=4700ms — two different values confirmed. VM verification pending post-deploy |
| AC-3 | PASS (unit) / PENDING (VM) | Same test: 1-hop (2300ms) < 4-hop (4700ms) confirmed. VM verification pending |
| AC-4 | PASS (unit) / PENDING (VM) | `test_encounter_system_generates_events`: 3 agents in transit, HallwayEncounterDetected events found in Limbo after 30 ticks |
| AC-N1 | PASS (unit) / PENDING (VM) | `test_transit_duration_within_bounds`: 5 rooms tested, all durations in [2000, 5000]ms |

```bash
# Clippy (0 warnings)
$ cargo remote -- clippy --workspace --all-targets -- -D warnings
Finished `dev` profile target(s) in 0.70s

# Tests (all pass)
$ cargo remote -- test -p sentinel-common -p sentinel-ecs --lib
test result: ok. 21 passed; 0 failed (sentinel-common)
test result: ok. 52 passed; 0 failed (sentinel-ecs, incl. 5 new transit tests)

# Full workspace tests
$ cargo remote -- test --workspace
All test suites pass, 0 failures
```

**VM verification commands (post-deploy):**
```bash
# AC-2: Transit duration varies
ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \
  \"SELECT json_extract(payload,'$.duration_ms') as d FROM events \
   WHERE event_type='TransitStarted' ORDER BY id DESC LIMIT 20\""

# AC-3: Near < Far
ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \
  \"SELECT json_extract(payload,'$.from_room'), json_extract(payload,'$.to_room'), \
   json_extract(payload,'$.duration_ms') FROM events \
   WHERE event_type='TransitStarted' ORDER BY id DESC LIMIT 30\""

# AC-4: Encounter events exist
ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \
  \"SELECT count(*) FROM events WHERE event_type='HallwayEncounterDetected'\""

# AC-N1: No out-of-bounds durations
ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \
  \"SELECT count(*) FROM events WHERE event_type='TransitStarted' \
   AND (json_extract(payload,'$.duration_ms') < 2000 OR json_extract(payload,'$.duration_ms') > 5000)\""
```

## Checklist

- [x] Code follows project conventions
- [x] Tests added for new functionality (5 integration tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CHANGELOG.md updated
- [x] No secrets or PII committed
- [x] Conventional commit message used

🤖 Generated with [Claude Code](https://claude.com/claude-code)