### PR TITLE
fix: smell decay, bio_system SmellEvent, perception logging (#195)

### DIFF
--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -357,13 +357,7 @@ pub fn bio_system(
                     tick,
                 );
                 event_buffer.events.push(smell_event);
-                active_smells.add(
-                    &position.room_id,
-                    "coffee".to_string(),
-                    0.8,
-                    tick,
-                    120,
-                );
+                active_smells.add(&position.room_id, "coffee".to_string(), 0.8, tick, 120);
             }
         }
 

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -24,7 +24,7 @@ use sentinel_common::{
     ActionType, DomainEvent, DomainEventPayload, Emotion, Perception, Timestamp,
 };
 use std::time::Instant;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// Ausfuehrungsreihenfolge der Simulation-Systems
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
@@ -299,6 +299,7 @@ pub fn bio_system(
     time: Res<SimulationTime>,
     psi: Option<Res<PsiMetrics>>,
     mut event_buffer: ResMut<EventBuffer>,
+    mut active_smells: ResMut<super::world::ActiveSmells>,
 ) {
     let tick = time.tick.0;
 
@@ -326,6 +327,7 @@ pub fn bio_system(
             && tick.is_multiple_of(180)
         {
             sentinel_bio::drink_coffee(&mut bio);
+            let correlation_id = uuid::Uuid::new_v4().to_string();
             let bio_payload = DomainEventPayload::BioActionPerformed {
                 agent_id: identity.agent_id,
                 action: "drink_coffee".to_string(),
@@ -334,10 +336,35 @@ pub fn bio_system(
                 bio_payload.event_type_str(),
                 &identity.agent_id.to_string(),
                 &bio_payload.to_json(),
-                &uuid::Uuid::new_v4().to_string(),
+                &correlation_id,
                 tick,
             );
             event_buffer.events.push(bio_event);
+
+            // SmellEvent bei Auto-Coffee (nur wenn Agent nicht in Transit)
+            if !position.in_transit {
+                let smell_payload = DomainEventPayload::SmellEventTriggered {
+                    room_id: position.room_id.clone(),
+                    smell_type: "coffee".to_string(),
+                    intensity: 0.8,
+                    duration_ticks: 120,
+                };
+                let smell_event = DomainEvent::new(
+                    smell_payload.event_type_str(),
+                    &position.room_id,
+                    &smell_payload.to_json(),
+                    &correlation_id,
+                    tick,
+                );
+                event_buffer.events.push(smell_event);
+                active_smells.add(
+                    &position.room_id,
+                    "coffee".to_string(),
+                    0.8,
+                    tick,
+                    120,
+                );
+            }
         }
 
         // Periodischer Bio-State Snapshot alle 20 Ticks (~20 Sekunden bei 1Hz)
@@ -796,6 +823,12 @@ pub fn perception_system(
                         _ => "",
                     };
                     if !text.is_empty() {
+                        debug!(
+                            room = %position.room_id,
+                            smell_type = %smell.smell_type,
+                            intensity = smell.intensity,
+                            "Smell injected into perception"
+                        );
                         perception.environment_text.push_str(text);
                     }
                 }

--- a/crates/sentinel-projection/src/store.rs
+++ b/crates/sentinel-projection/src/store.rs
@@ -153,6 +153,51 @@ impl ReadModelStore {
         Ok(())
     }
 
+    /// Entfernt abgelaufene Smells aus room_live_view.
+    ///
+    /// Prueft alle Rooms mit active_smells und setzt auf NULL wenn
+    /// `current_tick > smell.tick + smell.duration_ticks`.
+    pub fn cleanup_expired_smells(&self, current_tick: u64) -> anyhow::Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+
+        let mut stmt = conn.prepare(
+            "SELECT room_id, active_smells FROM room_live_view WHERE active_smells IS NOT NULL",
+        )?;
+        let expired: Vec<String> = stmt
+            .query_map([], |row| {
+                let room_id: String = row.get(0)?;
+                let json: String = row.get(1)?;
+                Ok((room_id, json))
+            })?
+            .filter_map(|r| r.ok())
+            .filter(|(_, json)| {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(json) {
+                    let tick = v["tick"].as_u64().unwrap_or(0);
+                    let duration = v["duration_ticks"].as_u64().unwrap_or(0);
+                    current_tick > tick + duration
+                } else {
+                    true // Malformed JSON → cleanup
+                }
+            })
+            .map(|(room_id, _)| room_id)
+            .collect();
+
+        if !expired.is_empty() {
+            let mut update = conn.prepare(
+                "UPDATE room_live_view SET active_smells = NULL WHERE room_id = ?1",
+            )?;
+            for room_id in &expired {
+                update.execute(params![room_id])?;
+            }
+            tracing::debug!(count = expired.len(), "Expired smells cleaned up");
+        }
+
+        Ok(())
+    }
+
     /// Loescht alle Daten aus allen drei View-Tabellen (fuer Rebuild).
     pub fn clear_all(&self) -> anyhow::Result<()> {
         let conn = self

--- a/crates/sentinel-projection/src/store.rs
+++ b/crates/sentinel-projection/src/store.rs
@@ -186,9 +186,8 @@ impl ReadModelStore {
             .collect();
 
         if !expired.is_empty() {
-            let mut update = conn.prepare(
-                "UPDATE room_live_view SET active_smells = NULL WHERE room_id = ?1",
-            )?;
+            let mut update =
+                conn.prepare("UPDATE room_live_view SET active_smells = NULL WHERE room_id = ?1")?;
             for room_id in &expired {
                 update.execute(params![room_id])?;
             }

--- a/crates/sentinel-projection/src/worker.rs
+++ b/crates/sentinel-projection/src/worker.rs
@@ -105,6 +105,11 @@ impl ProjectionWorker {
             let count = self.process_batch(&batch)?;
             let last_row_id = batch.last().unwrap().0;
 
+            // Abgelaufene Smells bereinigen (basierend auf dem hoechsten Tick im Batch)
+            if let Some(max_tick) = batch.iter().map(|(_, e)| e.tick).max() {
+                self.read_store.cleanup_expired_smells(max_tick)?;
+            }
+
             // Guard: nur updaten wenn tatsaechlich Fortschritt (schuetzt vor
             // Race Conditions bei Auto-Restart und idempotenten Batches)
             if last_row_id > offset {


### PR DESCRIPTION
## Summary
- Fixes three gaps in SmellEvents E2E pipeline discovered during live verification of #195
- Smell decay in projection, missing SmellEvent emission in bio_system, debug logging for perception injection

## Changes
- `store.rs`: Added `cleanup_expired_smells()` method to ReadModelStore — NULLs expired smells based on `current_tick > tick + duration_ticks`
- `worker.rs`: Calls `cleanup_expired_smells()` in batch loop using max tick from batch
- `systems.rs`: bio_system Auto-Coffee now emits `SmellEventTriggered` + updates `ActiveSmells` resource (was missing, only input_system and autonomy_system did this)
- `systems.rs`: Added `debug!()` log in perception_system when smell text is injected, added `debug` to tracing imports

## Linked Issues
Closes #195

## Test Plan
- [x] `cargo clippy -p sentinel-ecs -p sentinel-projection -p sentinel-projection-service -p sentinel-daemon --all-targets -- -D warnings` — clean
- [x] `cargo test -p sentinel-ecs -p sentinel-projection` — 9/9 passed (4 unit + 5 acceptance)
- [x] Live deploy to VM 10.0.0.240 + AC verification (see Evidence below)

## Benchmarks
No benchmark changes — this is a fix for existing functionality.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `sqlite3 events.db "SELECT count(*) FROM events WHERE event_type='smell_event_triggered' AND rowid > 3882000"` → **48** new SmellEvents (24 coffee from bio_system Auto-Coffee + 24 from smell_system) |
| AC-2 | PASS | `curl -s http://localhost:8000/api/rooms` → **6 rooms with active_smells** (before decay), **0** after decay |
| AC-3 | PASS | At tick 242: 3 rooms with smells (created at tick 180, duration 120). At tick 320: **0 rooms with smells** — `cleanup_expired_smells()` correctly NULLed expired entries |
| AC-4 | PASS | `journalctl -u sentinel-daemon | grep 'Smell injected'` → `DEBUG sentinel_ecs::systems: Smell injected into perception room=toilette-eg-herren smell_type=coffee intensity=0.8` |
| AC-N1 | PASS | `journalctl -u sentinel-daemon | grep -c 'ERROR\|PANIC'` → **0**; `journalctl -u sentinel-projection | grep -c 'ERROR\|PANIC'` → **0** |

```
$ ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \
  \"SELECT count(*) FROM events WHERE event_type='smell_event_triggered' AND rowid > 3882000\""
48

$ ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/projection.db \
  \"SELECT room_id, active_smells FROM room_live_view WHERE active_smells IS NOT NULL\""
kueche|{"duration_ticks":120,"intensity":0.800000011920929,"smell_type":"coffee","tick":180}
toilette-eg-damen|{"duration_ticks":120,"intensity":0.800000011920929,"smell_type":"coffee","tick":180}
toilette-eg-herren|{"duration_ticks":120,"intensity":0.800000011920929,"smell_type":"coffee","tick":180}

# After tick 300 (decay):
$ ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/projection.db \
  \"SELECT room_id, active_smells FROM room_live_view WHERE active_smells IS NOT NULL\""
(empty - all expired)

$ ssh ubuntu@10.0.0.240 "sudo journalctl -u sentinel-daemon --since '5 min ago' | \
  grep 'Smell injected' | head -3"
DEBUG sentinel_ecs::systems: Smell injected into perception room=toilette-eg-herren smell_type=coffee intensity=0.800000011920929
DEBUG sentinel_ecs::systems: Smell injected into perception room=toilette-eg-herren smell_type=coffee intensity=0.800000011920929
DEBUG sentinel_ecs::systems: Smell injected into perception room=toilette-eg-herren smell_type=coffee intensity=0.800000011920929
```

## Checklist
- [x] Code compiles without warnings
- [x] Clippy passes with `-D warnings`
- [x] All existing tests pass
- [x] CHANGELOG.md updated (in PR #209)
- [x] Deployed and verified on VM 10.0.0.240
- [x] Production config restored (time_scale=1.0, no debug RUST_LOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)