### PR TITLE
ci: replace rust-cache with persistent local target dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     env:
       CARGO_BUILD_JOBS: "3"
+      # Persistent local cache on self-hosted runner — avoids GitHub API
+      # upload/download overhead (~1.3GB per run). Each runner instance
+      # gets its own target dir via RUNNER_NAME to prevent lock contention.
+      CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -91,9 +95,8 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
+      - name: Ensure local cache dir
+        run: mkdir -p "$CARGO_TARGET_DIR"
 
       - name: Format check
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ sha2 = "0.10"
 blake3 = "1"
 rayon = "1"
 async-nats = "0.38"
+# workspace dependencies above — keep sorted alphabetically when adding new entries


### PR DESCRIPTION
## Summary
Replace `Swatinem/rust-cache` (GitHub API upload/download of ~1.3GB per run) with a persistent `CARGO_TARGET_DIR` on the self-hosted runner. Each runner instance gets its own target dir via `RUNNER_NAME` to prevent lock contention.

## Changes
- Remove `Swatinem/rust-cache@v2.8.2` step from `rust` job
- Add `CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target` env var
- Add `mkdir -p` step to ensure cache dir exists

## Linked Issues
Partially addresses #6 (CI performance concern raised during review)

## Test Plan
- [ ] First run: cold cache, expect normal or slightly longer build
- [ ] Second run: warm cache, expect significant speedup (incremental compilation)
- [ ] Verify all CI checks still pass

## Benchmarks
**Baseline (with `Swatinem/rust-cache`):**

```
Run                  Duration
zenoh-core-bus       18.5 min
smell-decay fix      15.0 min
smell-events         15.7 min
transit-varianz      19.0 min
Average              ~17 min
```

**Expected (persistent local cache):**
- Cold: ~17 min (same as baseline, no cache to download)
- Warm: ~5-8 min (incremental compilation, no upload/download overhead)

Results will be updated after merge.

## Evidence (AC Mapping)
| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PENDING | Timing measurement after merge |

Baseline timing collected via:
```shell
gh run view <ID> --json jobs --jq '[.jobs[] | select(.name == "rust") | {started: .startedAt, completed: .completedAt}]'
```

Runner directory prepared:
```shell
ssh root@10.0.0.127 "mkdir -p /opt/cargo-cache && chmod 777 /opt/cargo-cache"
# Directory ready
```

## Checklist
- [x] CI workflow syntax valid
- [x] Runner has write access to `/opt/cargo-cache/`
- [x] Each runner instance uses unique dir via `${{ runner.name }}`
- [x] No GitHub API cache dependency (works offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)