### PR TITLE
ci: replace rust-cache with persistent local target dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     env:
       CARGO_BUILD_JOBS: "3"
+      # Persistent local cache on self-hosted runner — avoids GitHub API
+      # upload/download overhead (~1.3GB per run). Each runner instance
+      # gets its own target dir via RUNNER_NAME to prevent lock contention.
+      CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -91,9 +95,8 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
+      - name: Ensure local cache dir
+        run: mkdir -p "$CARGO_TARGET_DIR"
 
       - name: Format check
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
Replace `Swatinem/rust-cache` (GitHub API upload/download of ~1.3GB per run) with a persistent `CARGO_TARGET_DIR` on the self-hosted runner.

## Changes
- Remove `Swatinem/rust-cache@v2.8.2` step from `rust` job
- Add `CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target` env var
- Add `mkdir -p` step to ensure cache dir exists

## Linked Issues
Partially addresses #6

## Test Plan
- [ ] CI runs with new cache config
- [ ] All existing checks still pass

## Benchmarks
**Baseline (with `Swatinem/rust-cache`):**
```
Run                  Duration
zenoh-core-bus       18.5 min
smell-decay fix      15.0 min
smell-events         15.7 min
transit-varianz      19.0 min
Average              ~17 min
```

## Evidence (AC Mapping)
| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PENDING | Timing after merge |

```shell
# Baseline timing collected:
gh run view 22831575540 --json jobs --jq '.jobs[] | select(.name == "rust") | {started: .startedAt, completed: .completedAt}'
# {"completed":"2026-03-08T23:01:28Z","started":"2026-03-08T22:42:58Z"}  # 18.5 min

# Runner directory prepared:
ssh root@10.0.0.127 "mkdir -p /opt/cargo-cache && chmod 777 /opt/cargo-cache"
```

## Checklist
- [x] YAML syntax valid
- [x] Runner directory created
- [x] No GitHub API dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)