### PR TITLE
fix: replace em-dash with ASCII in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     env:
       CARGO_BUILD_JOBS: "3"
-      # Persistent local cache on self-hosted runner — avoids GitHub API
+      # Persistent local cache on self-hosted runner - avoids GitHub API
       # upload/download overhead (~1.3GB per run). Each runner instance
       # gets its own target dir via RUNNER_NAME to prevent lock contention.
       CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target


### PR DESCRIPTION
## Summary
Fix potential GitHub Actions workflow parse failure by replacing em-dash with ASCII dash in ci.yml comment.

## Changes
- Line 87: `—` (U+2014) → `-` (U+002D) in comment

## Linked Issues
Partially addresses #6

## Test Plan
- [ ] CI workflow triggers and runs successfully

## Benchmarks
N/A - comment-only change

## Evidence (AC Mapping)
| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PENDING | CI run after merge |

Previous CI run failed with "workflow file issue":
```shell
gh run view 22840963854
# X This run likely failed because of a workflow file issue.
```

## Checklist
- [x] Single character change in comment
- [x] No functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)