### PR TITLE
fix: move CARGO_TARGET_DIR to step context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,6 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     env:
       CARGO_BUILD_JOBS: "3"
-      # Persistent local cache on self-hosted runner - avoids GitHub API
-      # upload/download overhead (~1.3GB per run). Each runner instance
-      # gets its own target dir via RUNNER_NAME to prevent lock contention.
-      CARGO_TARGET_DIR: /opt/cargo-cache/${{ runner.name }}/target
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -95,8 +91,14 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Ensure local cache dir
-        run: mkdir -p "$CARGO_TARGET_DIR"
+      # Persistent local cache on self-hosted runner - avoids GitHub API
+      # upload/download overhead (~1.3GB per run). Each runner instance
+      # gets its own target dir via runner name to prevent lock contention.
+      - name: Configure local cache
+        run: |
+          export CARGO_TARGET_DIR="/opt/cargo-cache/${{ runner.name }}/target"
+          mkdir -p "$CARGO_TARGET_DIR"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
 
       - name: Format check
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
Fix CI workflow parse failure: `runner.name` is not available in job-level `env`, only in step-level context. Move `CARGO_TARGET_DIR` setup to a dedicated step that exports via `GITHUB_ENV`.

## Changes
- Move `CARGO_TARGET_DIR` from job `env` to a step using `GITHUB_ENV`
- `runner.name` is now correctly resolved at step execution time

## Linked Issues
Partially addresses #6

## Test Plan
- [ ] CI workflow triggers without "workflow file issue"
- [ ] Rust job uses persistent local cache

## Benchmarks
```
# Baseline (Swatinem/rust-cache):  ~17 min average
# Expected (local cache, warm):    ~5-8 min
```

## Evidence (AC Mapping)
| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PENDING | CI run timing after fix |

Previous runs failed with workflow file issue:
```shell
gh run view 22840963854
# X This run likely failed because of a workflow file issue.
gh run view 22841076989
# X This run likely failed because of a workflow file issue.
```

## Checklist
- [x] `runner.name` moved to step context
- [x] `GITHUB_ENV` propagates to subsequent steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)