### PR TITLE
feat: add bolero + insta testing infrastructure (#223)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
       - name: Tests
         run: cargo test --workspace
 
+      - name: Snapshot tests
+        run: |
+          command -v cargo-insta >/dev/null 2>&1 || cargo install cargo-insta --locked
+          cargo insta test --workspace --review=false
+
       - name: Clippy (eBPF feature)
         run: cargo clippy -p sentinel-daemon -p sentinel-ebpf --features ebpf -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Snapshot tests
         run: |
           command -v cargo-insta >/dev/null 2>&1 || cargo install cargo-insta --locked
-          cargo insta test --workspace --review=false
+          cargo insta test --workspace --check
 
       - name: Clippy (eBPF feature)
         run: cargo clippy -p sentinel-daemon -p sentinel-ebpf --features ebpf -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Testing-Infrastruktur: bolero + insta** (#223)
+  - `bolero` v0.13 Property-Based Testing in sentinel-bio (3 Harnesses: hunger/energy/bladder bounds) und sentinel-physics (2 Harnesses: noise_db/co2_ppm lower bounds)
+  - `insta` v1.42 Snapshot Testing fuer Wahrnehmungs-Mappings (noise_to_text, co2_to_text) und Perception Injection Format ([SYSTEM_INJECTION] Block)
+  - Makefile Targets: `make fuzz`, `make verify`, `make snapshot-test`, `make snapshot-review`
+  - CI: Snapshot-Test Step in ci.yml rust Job
+
 - **sentinel-telemetry Criterion Benchmarks** (#34)
   - `crates/sentinel-telemetry/benches/telemetry_bench.rs`: 5 Benchmark-Gruppen (Counter, Histogram, Gauge, Registry Lookup, Snapshot) mit Criterion
   - Verifiziert Performance-Budget auf Deploy-VM: Counter ~6.5ns, Histogram ~21ns, Gauge ~5.5ns, Snapshot 36µs (< 100µs Budget)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -587,6 +587,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bolero"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff44d278fc0062c95327087ed96b3d256906d1d8f579e534a3de8d6b386913a"
+dependencies = [
+ "bolero-afl",
+ "bolero-engine",
+ "bolero-generator",
+ "bolero-honggfuzz",
+ "bolero-kani",
+ "bolero-libfuzzer",
+ "cfg-if",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "bolero-afl"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf4cbd0bacf9356d3c7e5d9d088480f2076ba3c595c15ee9a6a378cdd7b297"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
+name = "bolero-engine"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca199170a7c92c669c1019f9219a316b66bcdcfa4b36cac5a460a4c1a851aba"
+dependencies = [
+ "anyhow",
+ "bolero-generator",
+ "lazy_static",
+ "pretty-hex",
+ "rand 0.9.2",
+ "rand_xoshiro 0.7.0",
+]
+
+[[package]]
+name = "bolero-generator"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a5782f2650f80d533f58ec339c6dce4cc5428f9c2755894f98156f52af81f2"
+dependencies = [
+ "bolero-generator-derive",
+ "either",
+ "getrandom 0.3.4",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
+]
+
+[[package]]
+name = "bolero-generator-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a21a3b022507b9edd2050caf370d945e398c1a7c8455531220fa3968c45d29e"
+dependencies = [
+ "proc-macro-crate 2.0.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bolero-honggfuzz"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a118ef27295eddefadc6a99728ee698d1b18d2e80dc4777d21bee3385096ffd"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-kani"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852ea5784a9f3e68bfd302ca80b8b863bce140593eb5770fee6ab110899c28fc"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-libfuzzer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
+dependencies = [
+ "bolero-engine",
+ "cc",
 ]
 
 [[package]]
@@ -871,6 +964,18 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
  "portable-atomic",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1433,7 +1538,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1517,6 +1622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,7 +1680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2321,7 +2432,7 @@ checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
  "rand_core 0.6.4",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -2357,6 +2468,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2419,7 +2543,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2836,7 +2960,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2936,7 +3060,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3350,6 +3474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,11 +3491,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -3538,6 +3678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3839,7 +3988,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3929,7 +4078,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4095,6 +4244,7 @@ name = "sentinel-bio"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "bolero",
  "sentinel-common",
 ]
 
@@ -4171,6 +4321,7 @@ name = "sentinel-ecs"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs",
+ "insta",
  "sentinel-bio",
  "sentinel-common",
  "sentinel-limbo",
@@ -4279,6 +4430,8 @@ name = "sentinel-physics"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "bolero",
+ "insta",
  "sentinel-common",
 ]
 
@@ -4644,6 +4797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,7 +4939,7 @@ version = "72.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a768b1e51e4dbfa4fa52ae5c01241c0a41e2938fdffbb84add0c8238092f9091"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
@@ -4879,7 +5038,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5127,7 +5286,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5142,8 +5301,14 @@ dependencies = [
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_datetime"
@@ -5165,6 +5330,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
@@ -5172,7 +5348,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -5181,7 +5357,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6162,7 +6338,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6263,6 +6439,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6470,6 +6655,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ anyhow = "1"
 toml = "1.0"
 approx = "0.5"
 criterion = { version = "0.8", features = ["html_reports"] }
+bolero = "0.13"
+insta = { version = "1.42", features = ["yaml"] }
 sha2 = "0.10"
 blake3 = "1"
 rayon = "1"

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ verify: ## Formal verification via bolero kani engine (if available)
 
 snapshot-test: ## Run insta snapshot tests (CI mode, fails on mismatch)
 	@echo "=== Snapshot Tests ==="
-	cargo insta test --workspace --review=false
+	cargo insta test --workspace --check
 	@echo "Snapshot tests: OK"
 
 snapshot-review: ## Review pending insta snapshot changes

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help lint lint-all test build build-rust build-go build-dashboard \
        fmt check clean hooks ci deny coverage typos doc machete safe-merge \
-       manifest preflight smoke-test deploy
+       manifest preflight smoke-test deploy fuzz verify snapshot-test snapshot-review
 
 # Default target
 help: ## Show this help
@@ -123,6 +123,29 @@ machete: ## Find unused Rust dependencies
 bench: ## Run benchmarks
 	cargo bench --workspace
 	@echo "Benchmarks: DONE"
+
+# ──────────────────────────────────────────────
+# Property-Based / Snapshot Testing
+# ──────────────────────────────────────────────
+
+fuzz: ## Run bolero fuzzing (requires cargo-bolero)
+	@echo "=== Bolero Fuzzing (sentinel-bio) ==="
+	cargo bolero test -p sentinel-bio --all-targets --time 60
+	@echo "=== Bolero Fuzzing (sentinel-physics) ==="
+	cargo bolero test -p sentinel-physics --all-targets --time 60
+	@echo "Fuzzing: DONE (60s per crate)"
+
+verify: ## Formal verification via bolero kani engine (if available)
+	@command -v cargo-kani >/dev/null 2>&1 && cargo kani --workspace \
+		|| echo "WARN: cargo-kani not installed. Install with: cargo install --locked kani-verifier && cargo kani setup"
+
+snapshot-test: ## Run insta snapshot tests (CI mode, fails on mismatch)
+	@echo "=== Snapshot Tests ==="
+	cargo insta test --workspace --review=false
+	@echo "Snapshot tests: OK"
+
+snapshot-review: ## Review pending insta snapshot changes
+	cargo insta review
 
 # ──────────────────────────────────────────────
 # Setup

--- a/crates/sentinel-bio/Cargo.toml
+++ b/crates/sentinel-bio/Cargo.toml
@@ -10,3 +10,4 @@ sentinel-common = { path = "../sentinel-common" }
 
 [dev-dependencies]
 approx = { workspace = true }
+bolero = { workspace = true }

--- a/crates/sentinel-bio/tests/bolero_invariants.rs
+++ b/crates/sentinel-bio/tests/bolero_invariants.rs
@@ -1,0 +1,136 @@
+//! Property-Based Tests fuer Bio-Engine Invarianten (bolero).
+//!
+//! Verifiziert dass alle biologischen Zustaende nach `update_bio_state()`
+//! innerhalb ihrer definierten Grenzen bleiben, unabhaengig von den Eingaben.
+
+use bolero::check;
+use sentinel_bio::update_bio_state;
+use sentinel_common::components::{BioState, Personality, WorkContext};
+
+/// Sanitize f32: NaN/Inf → default_val, dann clamp.
+fn san(v: f32, min: f32, max: f32, default: f32) -> f32 {
+    if v.is_finite() {
+        v.clamp(min, max)
+    } else {
+        default
+    }
+}
+
+/// Erzeugt BioState aus beliebigen f32-Werten (NaN-safe, geclampt).
+fn make_bio(vals: &(f32, f32, f32, f32, f32, f32, f32)) -> BioState {
+    BioState {
+        hunger: san(vals.0, 0.0, 100.0, 50.0),
+        energy: san(vals.1, 0.0, 100.0, 50.0),
+        caffeine_mg: if vals.2.is_finite() {
+            vals.2.abs().min(500.0)
+        } else {
+            0.0
+        },
+        bladder: san(vals.3, 0.0, 100.0, 50.0),
+        stress: san(vals.4, 0.0, 100.0, 50.0),
+        social_need: san(vals.5, 0.0, 100.0, 50.0),
+        comfort: san(vals.6, 0.0, 100.0, 50.0),
+    }
+}
+
+/// Erzeugt Personality + WorkContext + Sim-Parameter aus beliebigen Werten.
+fn make_context(
+    vals: &(f32, f32, f32, f32, f32, bool, bool, bool, bool, f32, f32),
+) -> (Personality, WorkContext, f32, f32) {
+    let personality = Personality {
+        openness: 0.5,
+        conscientiousness: san(vals.0, 0.0, 1.0, 0.5),
+        extraversion: san(vals.1, 0.0, 1.0, 0.5),
+        agreeableness: 0.5,
+        neuroticism: san(vals.2, 0.0, 1.0, 0.5),
+        caffeine_tolerance: san(vals.3, 0.0, 1.0, 0.5),
+        is_morning_person: vals.5,
+    };
+    let work = WorkContext {
+        current_task: None,
+        in_meeting: vals.6,
+        has_deadline: vals.7,
+        has_conflict: vals.8,
+        conflict_cooldown: 0,
+    };
+    let dt_sec = if vals.9.is_finite() {
+        vals.9.abs().clamp(0.001, 3600.0)
+    } else {
+        1.0
+    };
+    let sim_hour = if vals.10.is_finite() {
+        vals.10.abs() % 24.0
+    } else {
+        12.0
+    };
+    (personality, work, dt_sec, sim_hour)
+}
+
+#[test]
+fn hunger_always_in_bounds() {
+    check!()
+        .with_type::<(
+            (f32, f32, f32, f32, f32, f32, f32),
+            (f32, f32, f32, f32, f32, bool, bool, bool, bool, f32, f32),
+        )>()
+        .for_each(|(bio_vals, ctx_vals)| {
+            let mut bio = make_bio(bio_vals);
+            let (personality, work, dt_sec, sim_hour) = make_context(ctx_vals);
+
+            update_bio_state(&mut bio, &personality, &work, dt_sec, sim_hour);
+
+            assert!(
+                bio.hunger >= 0.0 && bio.hunger <= 100.0,
+                "hunger out of bounds: {} (dt={}, sim_hour={})",
+                bio.hunger,
+                dt_sec,
+                sim_hour
+            );
+        });
+}
+
+#[test]
+fn energy_always_in_bounds() {
+    check!()
+        .with_type::<(
+            (f32, f32, f32, f32, f32, f32, f32),
+            (f32, f32, f32, f32, f32, bool, bool, bool, bool, f32, f32),
+        )>()
+        .for_each(|(bio_vals, ctx_vals)| {
+            let mut bio = make_bio(bio_vals);
+            let (personality, work, dt_sec, sim_hour) = make_context(ctx_vals);
+
+            update_bio_state(&mut bio, &personality, &work, dt_sec, sim_hour);
+
+            assert!(
+                bio.energy >= 0.0 && bio.energy <= 100.0,
+                "energy out of bounds: {} (dt={}, sim_hour={})",
+                bio.energy,
+                dt_sec,
+                sim_hour
+            );
+        });
+}
+
+#[test]
+fn bladder_always_in_bounds() {
+    check!()
+        .with_type::<(
+            (f32, f32, f32, f32, f32, f32, f32),
+            (f32, f32, f32, f32, f32, bool, bool, bool, bool, f32, f32),
+        )>()
+        .for_each(|(bio_vals, ctx_vals)| {
+            let mut bio = make_bio(bio_vals);
+            let (personality, work, dt_sec, sim_hour) = make_context(ctx_vals);
+
+            update_bio_state(&mut bio, &personality, &work, dt_sec, sim_hour);
+
+            assert!(
+                bio.bladder >= 0.0 && bio.bladder <= 100.0,
+                "bladder out of bounds: {} (dt={}, sim_hour={})",
+                bio.bladder,
+                dt_sec,
+                sim_hour
+            );
+        });
+}

--- a/crates/sentinel-ecs/Cargo.toml
+++ b/crates/sentinel-ecs/Cargo.toml
@@ -25,5 +25,6 @@ sentinel-wasm = { path = "../sentinel-wasm" }
 
 [dev-dependencies]
 sentinel-common = { path = "../sentinel-common" }
+insta = { workspace = true }
 tempfile = "3"
 toml = { workspace = true }

--- a/crates/sentinel-ecs/tests/snapshot_perception.rs
+++ b/crates/sentinel-ecs/tests/snapshot_perception.rs
@@ -1,0 +1,110 @@
+//! Snapshot-Test fuer Perception Injection Format (insta).
+//!
+//! Sichert das exakte `[SYSTEM_INJECTION]` Format ab, das in LLM-Prompts
+//! injiziert wird. Jede strukturelle Aenderung wird durch Snapshot-Diff sichtbar.
+
+use sentinel_common::components::{BioState, Personality, Position};
+use sentinel_ecs::perception::{format_injection, generate_perception, SmellEvent};
+
+fn test_bio() -> BioState {
+    BioState {
+        hunger: 75.0,
+        energy: 45.0,
+        caffeine_mg: 10.0,
+        bladder: 65.0,
+        stress: 55.0,
+        social_need: 70.0,
+        comfort: 60.0,
+    }
+}
+
+fn test_personality() -> Personality {
+    Personality {
+        openness: 0.7,
+        conscientiousness: 0.6,
+        extraversion: 0.8,
+        agreeableness: 0.5,
+        neuroticism: 0.4,
+        caffeine_tolerance: 0.5,
+        is_morning_person: true,
+    }
+}
+
+fn test_position() -> Position {
+    Position {
+        room_id: "buero-dev-1".to_string(),
+        in_transit: false,
+        transit_target: None,
+        transit_remaining_ms: 0,
+        transit_correlation_id: None,
+    }
+}
+
+#[test]
+fn snapshot_injection_stressed_hungry_agent() {
+    let smells = vec![SmellEvent {
+        source_room: "kueche".to_string(),
+        smell_type: "coffee".to_string(),
+        intensity: 0.8,
+        radius_rooms: 2,
+        decay_per_room: 0.3,
+        created_tick: 100,
+        duration_ticks: 500,
+    }];
+    let agents = vec![
+        ("Lisa".to_string(), "Design-Review".to_string()),
+        ("Andreas".to_string(), "Coding".to_string()),
+    ];
+
+    let perception = generate_perception(
+        &test_bio(),
+        &test_position(),
+        &test_personality(),
+        55.0,
+        23.5,
+        1100.0,
+        &smells,
+        &agents,
+        "14:30",
+        6.5,
+    );
+    let injection = format_injection(&perception);
+    insta::assert_snapshot!("injection_stressed_hungry", injection);
+}
+
+#[test]
+fn snapshot_injection_healthy_alone() {
+    let bio = BioState {
+        hunger: 20.0,
+        energy: 80.0,
+        caffeine_mg: 50.0,
+        bladder: 10.0,
+        stress: 15.0,
+        social_need: 50.0,
+        comfort: 70.0,
+    };
+    let personality = Personality {
+        openness: 0.5,
+        conscientiousness: 0.5,
+        extraversion: 0.3,
+        agreeableness: 0.5,
+        neuroticism: 0.3,
+        caffeine_tolerance: 0.2,
+        is_morning_person: true,
+    };
+
+    let perception = generate_perception(
+        &bio,
+        &test_position(),
+        &personality,
+        32.0,
+        21.5,
+        500.0,
+        &[],
+        &[],
+        "09:30",
+        1.5,
+    );
+    let injection = format_injection(&perception);
+    insta::assert_snapshot!("injection_healthy_alone", injection);
+}

--- a/crates/sentinel-ecs/tests/snapshots/snapshot_perception__injection_healthy_alone.snap
+++ b/crates/sentinel-ecs/tests/snapshots/snapshot_perception__injection_healthy_alone.snap
@@ -1,0 +1,11 @@
+---
+source: crates/sentinel-ecs/tests/snapshot_perception.rs
+expression: injection
+---
+[SYSTEM_INJECTION]
+CIRCADIAN: 09:30 (Du arbeitest seit 2h konzentriert)
+KOERPER: Du fuehlst dich gut.
+ENVIRONMENT: Die Temperatur ist angenehm.
+AKUSTIK: Stille.
+ANWESEND: Du bist allein.
+[/SYSTEM_INJECTION]

--- a/crates/sentinel-ecs/tests/snapshots/snapshot_perception__injection_stressed_hungry.snap
+++ b/crates/sentinel-ecs/tests/snapshots/snapshot_perception__injection_stressed_hungry.snap
@@ -1,0 +1,11 @@
+---
+source: crates/sentinel-ecs/tests/snapshot_perception.rs
+expression: injection
+---
+[SYSTEM_INJECTION]
+CIRCADIAN: 14:30 (Du arbeitest seit 6h konzentriert)
+KOERPER: Du koenntest etwas essen. Du solltest bald eine Pause einlegen. Leichte Kopfschmerzen - du brauchst Kaffee.
+ENVIRONMENT: Die Temperatur ist angenehm. Stickig. Kaffeeduft.
+AKUSTIK: Lebhafte Unterhaltungen.
+ANWESEND: Lisa (Design-Review), Andreas (Coding)
+[/SYSTEM_INJECTION]

--- a/crates/sentinel-physics/Cargo.toml
+++ b/crates/sentinel-physics/Cargo.toml
@@ -10,3 +10,5 @@ sentinel-common = { path = "../sentinel-common" }
 
 [dev-dependencies]
 approx = { workspace = true }
+bolero = { workspace = true }
+insta = { workspace = true }

--- a/crates/sentinel-physics/tests/bolero_invariants.rs
+++ b/crates/sentinel-physics/tests/bolero_invariants.rs
@@ -1,0 +1,65 @@
+//! Property-Based Tests fuer Physics-Engine Invarianten (bolero).
+//!
+//! Verifiziert dass Laermpegel und CO2-Konzentration nie unter ihre
+//! physikalischen Minima fallen, unabhaengig von den Eingaben.
+
+use bolero::check;
+use sentinel_physics::{calculate_co2, calculate_noise_level};
+
+/// Sanitize f32: NaN/Inf → default.
+fn san(v: f32, default: f32) -> f32 {
+    if v.is_finite() {
+        v
+    } else {
+        default
+    }
+}
+
+#[test]
+fn noise_db_never_below_base() {
+    check!()
+        .with_type::<(u8, bool, bool, f32, f32, f32, f32)>()
+        .for_each(|(agents, meeting, phone, adj1, adj2, adj3, adj4)| {
+            let agent_count = *agents as usize;
+            let adjacent: Vec<f32> = [*adj1, *adj2, *adj3, *adj4]
+                .iter()
+                .map(|n| san(*n, 30.0).abs().min(200.0))
+                .collect();
+
+            let noise = calculate_noise_level(agent_count, *meeting, *phone, &adjacent);
+
+            assert!(
+                noise >= 30.0,
+                "noise_db below BASE_NOISE_DB (30): {} (agents={}, meeting={}, phone={}, adj={:?})",
+                noise,
+                agent_count,
+                meeting,
+                phone,
+                adjacent
+            );
+        });
+}
+
+#[test]
+fn co2_ppm_never_below_atmospheric() {
+    check!().with_type::<(f32, u8, f32, f32)>().for_each(
+        |(base_ppm, agents, ventilation, hours)| {
+            let base = san(*base_ppm, 400.0).abs().clamp(400.0, 2000.0);
+            let agent_count = *agents as usize;
+            let vent = san(*ventilation, 0.5).clamp(0.0, 1.0);
+            let elapsed = san(*hours, 1.0).abs().min(24.0);
+
+            let co2 = calculate_co2(base, agent_count, vent, elapsed);
+
+            assert!(
+                co2 >= 400.0,
+                "co2_ppm below CO2_BASE_PPM (400): {} (base={}, agents={}, vent={}, hours={})",
+                co2,
+                base,
+                agent_count,
+                vent,
+                elapsed
+            );
+        },
+    );
+}

--- a/crates/sentinel-physics/tests/snapshot_perception.rs
+++ b/crates/sentinel-physics/tests/snapshot_perception.rs
@@ -1,0 +1,48 @@
+//! Snapshot-Tests fuer Physics Wahrnehmungs-Mappings (insta).
+//!
+//! Sichert die exakten deutschen Wahrnehmungstexte fuer Laerm und CO2 ab.
+//! Jede Aenderung an den Texten wird durch Snapshot-Diff sichtbar.
+
+use sentinel_physics::{co2_to_text, noise_to_text};
+
+#[test]
+fn snapshot_noise_perception_mapping() {
+    let mapping = [
+        (30.0, noise_to_text(30.0)),
+        (34.9, noise_to_text(34.9)),
+        (35.0, noise_to_text(35.0)),
+        (49.9, noise_to_text(49.9)),
+        (50.0, noise_to_text(50.0)),
+        (64.9, noise_to_text(64.9)),
+        (65.0, noise_to_text(65.0)),
+        (79.9, noise_to_text(79.9)),
+        (80.0, noise_to_text(80.0)),
+        (100.0, noise_to_text(100.0)),
+    ];
+    let output: String = mapping
+        .iter()
+        .map(|(db, text)| format!("{:>6.1} dB => {}", db, text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!("noise_perception_map", output);
+}
+
+#[test]
+fn snapshot_co2_perception_mapping() {
+    let mapping = [
+        (400.0, co2_to_text(400.0)),
+        (599.0, co2_to_text(599.0)),
+        (600.0, co2_to_text(600.0)),
+        (999.0, co2_to_text(999.0)),
+        (1000.0, co2_to_text(1000.0)),
+        (1499.0, co2_to_text(1499.0)),
+        (1500.0, co2_to_text(1500.0)),
+        (2000.0, co2_to_text(2000.0)),
+    ];
+    let output: String = mapping
+        .iter()
+        .map(|(ppm, text)| format!("{:>7.0} ppm => {}", ppm, text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    insta::assert_snapshot!("co2_perception_map", output);
+}

--- a/crates/sentinel-physics/tests/snapshots/snapshot_perception__co2_perception_map.snap
+++ b/crates/sentinel-physics/tests/snapshots/snapshot_perception__co2_perception_map.snap
@@ -1,0 +1,12 @@
+---
+source: crates/sentinel-physics/tests/snapshot_perception.rs
+expression: output
+---
+    400 ppm => Frische Luft
+    599 ppm => Frische Luft
+    600 ppm => Normale Raumluft
+    999 ppm => Normale Raumluft
+   1000 ppm => Es wird stickig
+   1499 ppm => Es wird stickig
+   1500 ppm => Kopfschmerzen und Schwindel
+   2000 ppm => Kopfschmerzen und Schwindel

--- a/crates/sentinel-physics/tests/snapshots/snapshot_perception__noise_perception_map.snap
+++ b/crates/sentinel-physics/tests/snapshots/snapshot_perception__noise_perception_map.snap
@@ -1,0 +1,14 @@
+---
+source: crates/sentinel-physics/tests/snapshot_perception.rs
+expression: output
+---
+  30.0 dB => Angenehme Stille
+  34.9 dB => Angenehme Stille
+  35.0 dB => Normales Buerogeraeusch
+  49.9 dB => Normales Buerogeraeusch
+  50.0 dB => Lebhafte Unterhaltungen
+  64.9 dB => Lebhafte Unterhaltungen
+  65.0 dB => Es ist laut
+  79.9 dB => Es ist laut
+  80.0 dB => Unertraeglicher Laerm
+ 100.0 dB => Unertraeglicher Laerm


### PR DESCRIPTION
## Summary
- Add property-based testing (bolero v0.13) and snapshot testing (insta v1.42) across the Rust workspace
- 5 bolero harnesses verify domain invariants (bio bounds, physics minimums)
- 4 insta snapshots lock down perception text mappings and SYSTEM_INJECTION format

## Changes
- `Cargo.toml`: bolero + insta as workspace dev-dependencies
- `sentinel-bio/tests/bolero_invariants.rs`: 3 harnesses (hunger, energy, bladder always in [0, 100])
- `sentinel-physics/tests/bolero_invariants.rs`: 2 harnesses (noise >= 30dB, CO2 >= 400ppm)
- `sentinel-physics/tests/snapshot_perception.rs`: noise_to_text + co2_to_text mapping snapshots
- `sentinel-ecs/tests/snapshot_perception.rs`: SYSTEM_INJECTION format snapshots (2 scenarios)
- `Makefile`: 4 new targets (fuzz, verify, snapshot-test, snapshot-review)
- `.github/workflows/ci.yml`: snapshot-test step in rust job
- `CHANGELOG.md`: documented changes

## Linked Issues
Closes #223

## Test Plan
- [x] `cargo remote -- test --workspace` — all 900+ tests pass (including 9 new)
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo remote -- deny check` — licenses ok (bolero + insta = Apache-2.0)
- [x] bolero harnesses run with default test engine (1000 random iterations each)
- [x] insta snapshots accepted and committed

## Benchmarks
N/A — testing infrastructure only, no performance-sensitive code paths.

## Evidence (AC Mapping)

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | bolero v0.13+ in sentinel-bio, sentinel-physics | PASS | `Cargo.toml:49` + crate Cargo.tomls |
| AC-2 | insta v1.x in relevanten Crates | PASS | sentinel-physics + sentinel-ecs Cargo.tomls |
| AC-3 | Makefile: fuzz, verify, snapshot-test, snapshot-review | PASS | `Makefile:130-150` |
| AC-4 | 3+ bolero harnesses Bio-Engine | PASS | `sentinel-bio/tests/bolero_invariants.rs` (hunger, energy, bladder) |
| AC-5 | 2+ bolero harnesses Physics | PASS | `sentinel-physics/tests/bolero_invariants.rs` (noise, co2) |
| AC-6 | 2+ insta snapshots | PASS | 4 snapshots: noise_map, co2_map, injection_stressed, injection_healthy |
| AC-7 | CI: snapshot-test step | PASS | `.github/workflows/ci.yml` snapshot tests step |
| AC-8 | deny.toml: no license conflicts | PASS | `cargo deny check` → `licenses ok` |
| AC-9 | cargo test --workspace green | PASS | All tests pass including 9 new |

## Checklist
- [x] Code compiles without warnings
- [x] All existing tests still pass
- [x] New tests added and passing
- [x] Clippy clean (`-D warnings`)
- [x] Formatted (`cargo fmt`)
- [x] CHANGELOG updated
- [x] Conventional commit message
- [x] No secrets committed