### PR TITLE
fix: gc terminal actions from controlplane action log (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Controlplane-Zyklus Latenz: 872ms → <50ms** (#227)
-  - Root Cause: 4 separate redb Write-Transaktionen pro Zyklus (je ~150ms fsync)
+- **Controlplane-Zyklus Latenz: 872ms → <200ms** (#227)
+  - Root Cause 1: 4 separate redb Write-Transaktionen pro Zyklus (je ~150ms fsync)
+  - Root Cause 2: 750k+ Terminal-State Actions in ACTION_LOG Tabelle (full table scan bei jedem Zyklus)
   - Fix: Single-Transaction via `write_cycle_batch()` — alle Incidents, Actions, State in einem Commit
+  - Fix: Garbage Collection — Terminal Actions (Verified/Expired/RolledBack) werden geloescht statt behalten
+  - Startup-GC bereinigt historische Altlasten, per-Cycle-GC haelt Tabelle kompakt
+  - `ActionStatus::is_terminal()` Methode fuer GC-Entscheidung
   - `execute_actions_no_store()` fuer in-memory Action-Execution ohne I/O
   - `verify_actions_from_cache()` fuer Store-unabhaengige Verification
   - Per-Phase Timing in debug-Log: observe_ms, decide_ms, act_ms, verify_ms, store_ms

--- a/services/sentinel-daemon/src/controlplane/mod.rs
+++ b/services/sentinel-daemon/src/controlplane/mod.rs
@@ -58,6 +58,12 @@ impl ControlplaneKernel {
         let config_json = serde_json::to_vec(&config)?;
         store.set_config("active_config", &config_json)?;
 
+        // GC: Historische Terminal-Actions entfernen (Altlast-Bereinigung)
+        let gc_count = store.gc_terminal_actions()?;
+        if gc_count > 0 {
+            info!(removed = gc_count, "Startup GC: Terminal Actions bereinigt");
+        }
+
         info!(
             cycle_interval = config.cycle_interval_ticks,
             guarded_mode = config.guarded_mode,

--- a/services/sentinel-daemon/src/controlplane/store.rs
+++ b/services/sentinel-daemon/src/controlplane/store.rs
@@ -191,6 +191,47 @@ impl ControlplaneStore {
         Ok(actions)
     }
 
+    // -- Garbage Collection --
+
+    /// Entfernt alle Actions in Terminal-States aus der Tabelle.
+    ///
+    /// Wird einmalig beim Kernel-Start aufgerufen um historische
+    /// Altlasten zu bereinigen. Danach haelt write_cycle_batch()
+    /// die Tabelle inkrementell sauber.
+    pub fn gc_terminal_actions(&self) -> Result<usize> {
+        // Erst lesen, dann loeschen (redb erlaubt kein Mutieren waehrend Iteration)
+        let ids_to_remove: Vec<String> = {
+            let read_txn = self.db.begin_read()?;
+            let table = read_txn.open_table(CONTROL_ACTION_LOG)?;
+            let mut ids = Vec::new();
+            for entry in table.iter()? {
+                let (key, value) = entry?;
+                let action: ControlAction = serde_json::from_slice(value.value())?;
+                if action.status.is_terminal() {
+                    ids.push(key.value().to_string());
+                }
+            }
+            ids
+        };
+
+        if ids_to_remove.is_empty() {
+            return Ok(0);
+        }
+
+        let count = ids_to_remove.len();
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(CONTROL_ACTION_LOG)?;
+            for id in &ids_to_remove {
+                table.remove(id.as_str())?;
+            }
+        }
+        write_txn.commit()?;
+
+        debug!(removed = count, "Terminal Actions bereinigt (GC)");
+        Ok(count)
+    }
+
     // -- Batch Cycle Write (Single Transaction) --
 
     /// Schreibt alle Daten eines Controlplane-Zyklus in EINER Transaktion.
@@ -225,13 +266,18 @@ impl ControlplaneStore {
                 }
             }
 
-            // Updated Actions (aus Verify-Phase)
+            // Updated Actions (aus Verify-Phase): Terminal-State Actions loeschen,
+            // nicht-terminale updaten. Haelt die Tabelle klein fuer schnelles Scannen.
             if !updated_actions.is_empty() {
                 let mut table = write_txn.open_table(CONTROL_ACTION_LOG)?;
                 for action in updated_actions {
-                    let bytes = serde_json::to_vec(action)
-                        .context("ControlAction update serialisieren")?;
-                    table.insert(action.id.as_str(), bytes.as_slice())?;
+                    if action.status.is_terminal() {
+                        table.remove(action.id.as_str())?;
+                    } else {
+                        let bytes = serde_json::to_vec(action)
+                            .context("ControlAction update serialisieren")?;
+                        table.insert(action.id.as_str(), bytes.as_slice())?;
+                    }
                 }
             }
 

--- a/services/sentinel-daemon/src/controlplane/types.rs
+++ b/services/sentinel-daemon/src/controlplane/types.rs
@@ -91,6 +91,13 @@ pub enum ActionStatus {
     Expired,
 }
 
+impl ActionStatus {
+    /// Terminal States werden aus der Action-Tabelle entfernt (GC).
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Verified | Self::RolledBack | Self::Expired)
+    }
+}
+
 /// Ergebnis der Verify-Phase.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerifyOutcome {


### PR DESCRIPTION
## Summary
- Garbage Collection fuer Terminal-State Actions in der Controlplane ACTION_LOG Tabelle
- Behebt den zweiten Root Cause von #227: `get_pending_actions()` scannte 750k+ abgeschlossene Actions bei jedem Zyklus

## Changes
- `ActionStatus::is_terminal()` — identifiziert Verified/Expired/RolledBack als löschbar
- `write_cycle_batch()` — löscht terminal Actions statt sie zurückzuschreiben (inkrementelles GC)
- `gc_terminal_actions()` — Startup-Cleanup für historische Altlasten
- Kernel::new() ruft GC beim Start auf
- CHANGELOG aktualisiert mit vollständiger Root-Cause-Analyse

## Linked Issues
Closes #227

## Test Plan
- 36/36 Controlplane-Tests grün (`cargo remote -- test -p sentinel-daemon --lib controlplane`)
- Clippy clean (`cargo remote -- clippy -p sentinel-daemon --all-targets -- -D warnings`)
- Live-Verifikation auf Deploy-VM (10.0.0.240)

## Benchmarks
Vorher (verify_ms dominiert):
```
elapsed_ms=872  verify_ms=~800  store_ms=~150  (vor PR #228)
elapsed_ms=856  verify_ms=843   store_ms=12    (nach PR #228, vor GC)
```
Nachher (nach GC — 750.275 Actions bereinigt):
```
0 Budget-Warnungen über 2+ Minuten Laufzeit (alle Zyklen < 200ms)
Startup GC: removed=750275 Terminal Actions
```

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|---------|
| AC-1 | PASS | `journalctl -u sentinel-daemon \| grep '200ms Budget'` → 0 Warnungen vom neuen Daemon (PID 1264284). Alle Zyklen unter 200ms Budget. |

```
# Startup GC Log:
Mar 13 20:05:44 sentinel-daemon[1264284]: Startup GC: Terminal Actions bereinigt removed=750275

# Keine 200ms-Warnungen vom neuen Daemon:
$ journalctl -u sentinel-daemon | grep -c 'sentinel-daemon\[1264284\].*200ms Budget'
0
```

## Checklist
- [x] Tests grün (36/36 controlplane)
- [x] Clippy clean
- [x] CHANGELOG aktualisiert
- [x] Live-verifiziert auf Deploy-VM
- [x] Conventional Commit Format