### PR TITLE
fix: add claude-code capability profile to detection registry

### DIFF
--- a/cmd/cortex-gateway/internal/capability/detection.go
+++ b/cmd/cortex-gateway/internal/capability/detection.go
@@ -49,6 +49,17 @@ func New() *ProviderCapabilities {
 				CapPredictedOut: true,
 				CapKVRetention:  false,
 			},
+			"claude-code": {
+				CapStreaming:    true,
+				CapToolUse:      true,
+				CapVision:       true,
+				CapSystemPrompt: true,
+				CapJSONMode:     true,
+				CapFunctionCall: true,
+				CapCaching:      false,
+				CapPredictedOut: false,
+				CapKVRetention:  false,
+			},
 			"ollama": {
 				CapStreaming:    true,
 				CapToolUse:      false,

--- a/cmd/cortex-gateway/internal/capability/detection_test.go
+++ b/cmd/cortex-gateway/internal/capability/detection_test.go
@@ -224,6 +224,48 @@ func TestListCapabilities_OpenAI(t *testing.T) {
 	}
 }
 
+func TestHasCapability_ClaudeCode_AllCapabilities(t *testing.T) {
+	pc := New()
+
+	expected := map[Capability]bool{
+		CapStreaming:    true,
+		CapToolUse:      true,
+		CapVision:       true,
+		CapSystemPrompt: true,
+		CapJSONMode:     true,
+		CapFunctionCall: true,
+		CapCaching:      false,
+		CapPredictedOut: false,
+		CapKVRetention:  false,
+	}
+
+	for cap, want := range expected {
+		got := pc.HasCapability("claude-code", cap)
+		if got != want {
+			t.Errorf("claude-code %s = %v, want %v", cap, got, want)
+		}
+	}
+}
+
+func TestListCapabilities_ClaudeCode(t *testing.T) {
+	pc := New()
+	caps := pc.ListCapabilities("claude-code")
+	if caps == nil {
+		t.Fatal("expected non-nil capabilities for claude-code")
+	}
+	if len(caps) != 9 {
+		t.Errorf("expected 9 capabilities for claude-code, got %d", len(caps))
+	}
+}
+
+func TestGetFallback_ClaudeCode_NoCaching(t *testing.T) {
+	pc := New()
+	fb := pc.GetFallback("claude-code", CapCaching)
+	if fb == "" {
+		t.Error("expected non-empty fallback for claude-code missing caching")
+	}
+}
+
 func TestListCapabilities_IsCopy(t *testing.T) {
 	pc := New()
 	caps := pc.ListCapabilities("claude")

--- a/crates/sentinel-sandbox/benches/sandbox_bench.rs
+++ b/crates/sentinel-sandbox/benches/sandbox_bench.rs
@@ -235,6 +235,36 @@ fn bench_nftables_load(c: &mut Criterion) {
     });
 }
 
+// --- Tier 2: bwrap spawn latency (VM only) ---
+
+fn bench_bwrap_spawn_latency(c: &mut Criterion) {
+    if !BwrapConfig::test_userns() {
+        c.bench_function("bwrap_spawn_latency [no bwrap — config only]", |b| {
+            b.iter(|| {
+                std::hint::black_box(BwrapConfig::for_agent("bench-spawn").to_args());
+            });
+        });
+        return;
+    }
+
+    // Budget: < 10ms for bwrap spawn + "true" + exit
+    let config = BwrapConfig::for_agent("bench-spawn");
+    c.bench_function("bwrap_spawn_latency", |b| {
+        b.iter(|| {
+            let mut args = config.to_args();
+            args.push("true".to_string());
+            let child = std::process::Command::new("bwrap")
+                .args(&args)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("bwrap spawn failed");
+            let status = child.wait_with_output().expect("bwrap wait failed");
+            std::hint::black_box(status.status);
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_bwrap_config_to_args,
@@ -250,5 +280,7 @@ criterion_group!(
     bench_netns_setup_teardown,
     bench_veth_creation,
     bench_nftables_load,
+    // Tier 2 — bwrap spawn latency (VM only)
+    bench_bwrap_spawn_latency,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
Two fixes from verification findings:
1. **F18:** Adds the missing capability profile for `claude-code` provider (default provider had no entry)
2. **F12:** Adds bwrap spawn latency benchmark (was unmeasured)

## Changes
- `detection.go`: Add `claude-code` capability map (streaming, tool_use, vision, system_prompt, json_mode, function_calling = true; caching, predicted_output, kv_retention = false)
- `detection_test.go`: 3 new tests (AllCapabilities, ListCapabilities, GetFallback)
- `sandbox_bench.rs`: Add `bwrap_spawn_latency` benchmark (Tier 2, VM-only)

## Linked Issues
Fixes F18 and F12 from verification findings (direct hotfix, no dedicated issues)

## Test Plan
- [x] `go test ./cmd/cortex-gateway/internal/capability/ -v -count=1` — 22/22 PASS
- [x] `go vet ./cmd/cortex-gateway/...` — clean
- [x] `cargo remote -- bench -p sentinel-sandbox --no-run` — compiles

## Benchmarks

```
$ ssh ubuntu@10.0.0.240 "/tmp/sandbox_bench --bench bwrap_spawn_latency"
bwrap_spawn_latency     time:   [1.3796 ms 1.3874 ms 1.3965 ms]
```
Budget: < 10ms. Actual: **1.39ms** (86% under budget).

## Evidence (AC Mapping)

| AC | Beschreibung | Status | Evidence |
|----|-------------|--------|----------|
| F18 | claude-code Capability-Profil | PASS | See test output below |
| F12 | bwrap Spawn-Latenz | PASS | 1.39ms on VM (benchmark output above) |

```bash
$ GOTOOLCHAIN=auto go test ./cmd/cortex-gateway/internal/capability/ -v -count=1 2>&1 | grep -E "ClaudeCode|PASS|FAIL"
=== RUN   TestHasCapability_ClaudeCode_AllCapabilities
--- PASS: TestHasCapability_ClaudeCode_AllCapabilities (0.00s)
=== RUN   TestListCapabilities_ClaudeCode
--- PASS: TestListCapabilities_ClaudeCode (0.00s)
=== RUN   TestGetFallback_ClaudeCode_NoCaching
--- PASS: TestGetFallback_ClaudeCode_NoCaching (0.00s)
PASS
ok github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/capability 0.008s
```

## Checklist
- [x] `go vet` clean
- [x] All 22 capability tests pass (19 existing + 3 new)
- [x] Benchmark compiles and runs on VM
- [x] bwrap spawn time 1.39ms (under 10ms budget)