### PR TITLE
refactor: prune in tick-loop — no separate thread, no lock conflict (#252)

### DIFF
--- a/crates/sentinel-limbo/src/event_store.rs
+++ b/crates/sentinel-limbo/src/event_store.rs
@@ -13,7 +13,6 @@ use sentinel_common::DomainEvent;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use tracing::{debug, info, instrument};
 
 /// Histogram-Buckets fuer EventStore Latenzen (Mikrosekunden).
@@ -641,17 +640,14 @@ impl EventStore {
         }
     }
 
-    /// Loescht alle Events mit id < cutoff_event_id.
-    ///
-    /// Safety: Prueft ob alle Projection-Offsets >= cutoff_event_id sind.
-    /// Nutzt eine separate Connection fuer Safety-Checks (read-only) und
-    /// batched DELETE (10.000 Rows pro Batch). Blockiert NICHT die shared Mutex.
-    pub fn prune_events_before(&self, cutoff_event_id: i64) -> anyhow::Result<u64> {
-        // Separate Connection — blockiert weder Tick-Loop noch API
-        let conn = Connection::open(&self.path)?;
-        conn.execute_batch("PRAGMA busy_timeout = 30000")?;
+    /// Prueft ob Pruning sicher ist (Projection-Offsets, Outbox-Backlog).
+    /// Gibt `Ok(true)` zurueck wenn Pruning erlaubt, `Ok(false)` bei Safety-Guard.
+    pub fn can_prune(&self, cutoff_event_id: i64) -> anyhow::Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
 
-        // Safety Guard: Pruefe ob alle Projections ueber dem Cutoff sind
         let min_offset: Option<i64> = conn
             .query_row(
                 "SELECT MIN(last_event_id) FROM projection_offsets",
@@ -661,13 +657,10 @@ impl EventStore {
             .ok();
         if let Some(min) = min_offset {
             if min < cutoff_event_id {
-                return Err(anyhow::anyhow!(
-                    "Prune blockiert: Projection-Offset ({min}) < Cutoff ({cutoff_event_id})"
-                ));
+                return Ok(false);
             }
         }
 
-        // Safety Guard: Pruefe Outbox-Backlog
         let pending_outbox: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM outbox WHERE status = 'pending'",
@@ -676,27 +669,27 @@ impl EventStore {
             )
             .unwrap_or(0);
         if pending_outbox > 0 {
-            return Err(anyhow::anyhow!(
-                "Prune blockiert: {pending_outbox} ausstehende Outbox-Eintraege"
-            ));
+            return Ok(false);
         }
 
-        // Batched DELETE: 10.000 Rows pro Batch, SQLite Writer-Lock nur pro Batch gehalten
-        const BATCH_SIZE: i64 = 10_000;
-        let mut total_deleted: u64 = 0;
-        loop {
-            let deleted = conn.execute(
-                "DELETE FROM events WHERE id IN (SELECT id FROM events WHERE id < ?1 LIMIT ?2)",
-                params![cutoff_event_id, BATCH_SIZE],
-            )? as u64;
-            total_deleted += deleted;
-            if deleted == 0 {
-                break;
-            }
-            // Tick-Loop atmen lassen — WAL Writer-Lock kurz freigeben
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        Ok(total_deleted)
+        Ok(true)
+    }
+
+    /// Loescht einen einzelnen Batch von Events mit id < cutoff_event_id.
+    ///
+    /// Designed fuer Aufruf aus dem Tick-Loop: 1 Batch (1000 Rows) pro Tick.
+    /// Nutzt die shared Connection — kein separater Thread, kein Lock-Konflikt.
+    /// Gibt die Anzahl geloeschter Rows zurueck (0 = fertig).
+    pub fn prune_batch(&self, cutoff_event_id: i64, batch_size: i64) -> anyhow::Result<u64> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let deleted = conn.execute(
+            "DELETE FROM events WHERE id IN (SELECT id FROM events WHERE id < ?1 LIMIT ?2)",
+            params![cutoff_event_id, batch_size],
+        )? as u64;
+        Ok(deleted)
     }
 
     /// Gibt den DB-Pfad zurueck (fuer Tests / Diagnostik).

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -95,6 +95,7 @@ struct AppState {
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
     event_store: Arc<sentinel_limbo::EventStore>,
+    prune_tx: mpsc::Sender<i64>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -162,6 +163,7 @@ pub async fn start_server(
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
     event_store: Arc<sentinel_limbo::EventStore>,
+    prune_tx: mpsc::Sender<i64>,
 ) -> AnyResult<tokio::task::JoinHandle<()>> {
     let listener = TcpListener::bind(&config.bind_addr)
         .await
@@ -175,6 +177,7 @@ pub async fn start_server(
         snapshot_tx,
         restore_tx,
         event_store,
+        prune_tx,
     };
 
     info!(
@@ -313,28 +316,29 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
         }
         OPERATOR_PRUNE_PATH => {
             info!("Manuelles Pruning via Operator-API angefordert");
-            let es = Arc::clone(&state.event_store);
-            std::thread::Builder::new()
-                .name("prune-worker".into())
-                .spawn(move || {
-                    let snapshots = es.list_world_snapshots().unwrap_or_default();
-                    if snapshots.len() < 2 {
-                        info!("Zu wenige Snapshots fuer Pruning");
-                        return;
-                    }
-                    let prune_point = snapshots[snapshots.len() - 2].last_event_id;
-                    match es.prune_events_before(prune_point) {
-                        Ok(deleted) => {
-                            info!(deleted, "Pruning abgeschlossen");
-                        }
-                        Err(e) => warn!(error = %e, "Pruning fehlgeschlagen"),
-                    }
-                })
-                .expect("prune-worker Thread starten");
-            json_response(
-                202,
-                serde_json::json!({"accepted": true, "message": "Pruning gestartet (asynchron)"}),
-            )
+            let snapshots = state.event_store.list_world_snapshots().unwrap_or_default();
+            if snapshots.len() < 2 {
+                return json_response(
+                    200,
+                    serde_json::json!({"accepted": false, "message": "Zu wenige Snapshots fuer Pruning"}),
+                );
+            }
+            let prune_point = snapshots[snapshots.len() - 2].last_event_id;
+            if !state.event_store.can_prune(prune_point).unwrap_or(false) {
+                return json_response(
+                    200,
+                    serde_json::json!({"accepted": false, "message": "Safety Guard: Projection-Offset oder Outbox blockiert Pruning"}),
+                );
+            }
+            match state.prune_tx.send(prune_point) {
+                Ok(()) => json_response(
+                    202,
+                    serde_json::json!({"accepted": true, "message": "Pruning gestartet (1000 Rows/Tick)"}),
+                ),
+                Err(_) => {
+                    ApiError::ServiceUnavailable("Prune-Channel nicht verfuegbar").to_response()
+                }
+            }
         }
         _ => ApiError::NotFound("Endpoint unbekannt").to_response(),
     }
@@ -628,6 +632,7 @@ mod tests {
                 sentinel_limbo::EventStore::open(":memory:")
                     .expect("in-memory EventStore fuer Tests"),
             ),
+            prune_tx: mpsc::channel().0,
         };
         (state, rx)
     }

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -369,6 +369,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let (nightrun_tx, nightrun_rx) = mpsc::channel::<sentinel_common::OperatorNightrunCommand>();
     let (snapshot_tx, snapshot_rx) = mpsc::channel::<sentinel_common::OperatorSnapshotCommand>();
     let (restore_tx, restore_rx) = mpsc::channel::<sentinel_common::OperatorRestoreCommand>();
+    let (prune_tx, prune_rx) = mpsc::channel::<i64>();
     let (perception_tx, perception_rx) = mpsc::sync_channel::<Perception>(64);
 
     // -- Zenoh SentinelBus (Core-Bus fuer Real-Time Event-Verteilung) --
@@ -443,6 +444,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 snapshot_tx.clone(),
                 restore_tx.clone(),
                 Arc::clone(&event_store),
+                prune_tx.clone(),
             )
             .await?,
         )
@@ -492,6 +494,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 nightrun_rx,
                 snapshot_rx,
                 restore_rx,
+                prune_rx,
                 config.retention.clone(),
                 evolution_db_path_clone,
                 agent_command_cfg,
@@ -759,6 +762,7 @@ fn ecs_tick_loop(
     nightrun_rx: mpsc::Receiver<sentinel_common::OperatorNightrunCommand>,
     snapshot_rx: mpsc::Receiver<sentinel_common::OperatorSnapshotCommand>,
     restore_rx: mpsc::Receiver<sentinel_common::OperatorRestoreCommand>,
+    prune_rx: mpsc::Receiver<i64>,
     retention_config: crate::config::RetentionConfig,
     evolution_db_path: String,
     agent_command_cfg: Vec<String>,
@@ -790,6 +794,7 @@ fn ecs_tick_loop(
         telemetry.enabled = true;
     }
     let event_store_for_episodes = Arc::clone(&event_store);
+    let event_store_for_prune = Arc::clone(&event_store);
     world.insert_resource(LimboEventStore(event_store));
     world.insert_resource(ActionReceiver(std::sync::Mutex::new(action_rx)));
     world.insert_resource(sentinel_ecs::OperatorCommandReceiver(
@@ -1158,6 +1163,12 @@ fn ecs_tick_loop(
 
         // ECS Schedule ausfuehren (alle 12 Systems in Reihenfolge)
         schedule.run(&mut world);
+
+        // Prune: Empfange Cutoff von Operator-API, arbeite 1 Batch/Tick ab
+        while let Ok(cutoff) = prune_rx.try_recv() {
+            snapshot_manager.start_prune(cutoff);
+        }
+        snapshot_manager.prune_tick(&event_store_for_prune, tick_count);
 
         // Controlplane-Zyklus (alle N Ticks) — SENTINEL_CONTROLPLANE_ENABLED gate (AC-6)
         if sentinel_common::feature_flags::RuntimeFlags::global().controlplane_enabled
@@ -2287,6 +2298,7 @@ mod tests {
             mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
             mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
             mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
+            mpsc::channel::<i64>().1,
             crate::config::RetentionConfig::default(),
             String::new(),
             vec!["true".to_string()],
@@ -2350,6 +2362,7 @@ mod tests {
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
+                mpsc::channel::<i64>().1,
                 crate::config::RetentionConfig::default(),
                 String::new(),
                 vec!["true".to_string()],
@@ -2430,6 +2443,7 @@ mod tests {
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
+                mpsc::channel::<i64>().1,
                 crate::config::RetentionConfig::default(),
                 String::new(),
                 vec!["true".to_string()],
@@ -2518,6 +2532,7 @@ mod tests {
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
+                mpsc::channel::<i64>().1,
                 crate::config::RetentionConfig::default(),
                 String::new(),
                 vec!["true".to_string()],

--- a/services/sentinel-daemon/src/snapshot.rs
+++ b/services/sentinel-daemon/src/snapshot.rs
@@ -44,10 +44,7 @@ impl SnapshotManager {
         }
         match event_store.prune_batch(self.prune_cutoff, 500) {
             Ok(0) => {
-                info!(
-                    total = self.prune_total,
-                    "Prune abgeschlossen"
-                );
+                info!(total = self.prune_total, "Prune abgeschlossen");
                 self.prune_cutoff = 0;
                 self.prune_total = 0;
             }

--- a/services/sentinel-daemon/src/snapshot.rs
+++ b/services/sentinel-daemon/src/snapshot.rs
@@ -39,7 +39,7 @@ impl SnapshotManager {
             return;
         }
         // Nur alle 10 Ticks einen Batch — gibt der API genug Fenster
-        if tick % 10 != 0 {
+        if !tick.is_multiple_of(10) {
             return;
         }
         match event_store.prune_batch(self.prune_cutoff, 500) {

--- a/services/sentinel-daemon/src/snapshot.rs
+++ b/services/sentinel-daemon/src/snapshot.rs
@@ -17,6 +17,9 @@ use crate::config::RetentionConfig;
 pub struct SnapshotManager {
     config: RetentionConfig,
     last_snapshot_tick: u64,
+    /// Aktiver Prune-Cutoff: wenn > 0, loescht prune_tick() 1 Batch pro Tick.
+    prune_cutoff: i64,
+    prune_total: u64,
 }
 
 impl SnapshotManager {
@@ -24,7 +27,53 @@ impl SnapshotManager {
         Self {
             config,
             last_snapshot_tick: 0,
+            prune_cutoff: 0,
+            prune_total: 0,
         }
+    }
+
+    /// Loescht einen kleinen Batch alle 10 Ticks. Aufgerufen aus dem Tick-Loop.
+    /// Nutzt die shared Connection — kein Lock-Konflikt, kein separater Thread.
+    pub fn prune_tick(&mut self, event_store: &EventStore, tick: u64) {
+        if self.prune_cutoff <= 0 {
+            return;
+        }
+        // Nur alle 10 Ticks einen Batch — gibt der API genug Fenster
+        if tick % 10 != 0 {
+            return;
+        }
+        match event_store.prune_batch(self.prune_cutoff, 500) {
+            Ok(0) => {
+                info!(
+                    total = self.prune_total,
+                    "Prune abgeschlossen"
+                );
+                self.prune_cutoff = 0;
+                self.prune_total = 0;
+            }
+            Ok(deleted) => {
+                self.prune_total += deleted;
+            }
+            Err(e) => {
+                debug!(error = %e, "Prune-Batch fehlgeschlagen");
+            }
+        }
+    }
+
+    /// Startet einen neuen Prune-Lauf (setzt Cutoff, prune_tick() arbeitet ab).
+    pub fn start_prune(&mut self, cutoff_event_id: i64) {
+        if self.prune_cutoff > 0 {
+            info!("Prune laeuft bereits — neuer Cutoff ignoriert");
+            return;
+        }
+        self.prune_cutoff = cutoff_event_id;
+        self.prune_total = 0;
+        info!(cutoff = cutoff_event_id, "Prune gestartet (1000 Rows/Tick)");
+    }
+
+    /// Gibt true zurueck wenn gerade ein Prune laeuft.
+    pub fn is_pruning(&self) -> bool {
+        self.prune_cutoff > 0
     }
 
     /// Prueft ob ein neuer Snapshot erstellt werden soll.
@@ -107,7 +156,7 @@ impl SnapshotManager {
     ///
     /// Promoted Snapshots durch die Tiers und loescht abgelaufene.
     /// Auto-Prune loescht Events vor dem zweitaeltesten Snapshot.
-    pub fn maintain(&self, event_store: &Arc<EventStore>) -> anyhow::Result<MaintenanceReport> {
+    pub fn maintain(&mut self, event_store: &Arc<EventStore>) -> anyhow::Result<MaintenanceReport> {
         let snapshots = event_store.list_world_snapshots()?;
         if snapshots.is_empty() {
             return Ok(MaintenanceReport::default());
@@ -185,19 +234,13 @@ impl SnapshotManager {
             info!(promoted, deleted, "Snapshot Maintenance abgeschlossen");
         }
 
-        // Auto-Prune: Events vor zweitaeltestem Snapshot loeschen
-        if self.config.auto_prune {
+        // Auto-Prune: Cutoff setzen, prune_tick() arbeitet 1 Batch/Tick ab
+        if self.config.auto_prune && !self.is_pruning() {
             let current_snapshots = event_store.list_world_snapshots().unwrap_or_default();
             if current_snapshots.len() >= 2 {
                 let prune_point = current_snapshots[current_snapshots.len() - 2].last_event_id;
-                match event_store.prune_events_before(prune_point) {
-                    Ok(pruned) if pruned > 0 => {
-                        info!(pruned, "Auto-Prune: Events geloescht");
-                    }
-                    Ok(_) => {} // Nichts zu prunen
-                    Err(e) => {
-                        debug!(error = %e, "Auto-Prune uebersprungen (Safety Guard)");
-                    }
+                if event_store.can_prune(prune_point).unwrap_or(false) {
+                    self.start_prune(prune_point);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Prune laeuft jetzt im Tick-Loop (500 Rows alle 10 Ticks) statt auf separatem Thread
- Keine separate Connection, kein Lock-Konflikt, API bleibt responsive

## Changes
- `sentinel-limbo`: `prune_events_before()` ersetzt durch `can_prune()` + `prune_batch()`
- `sentinel-daemon`: `SnapshotManager` hat `prune_tick()` + `start_prune()`, gesteuert per `prune_cutoff`
- `operator_api`: Prune-Handler sendet Cutoff per `mpsc::channel<i64>` an Tick-Loop
- Kein separater Thread, kein `std::thread::spawn`, kein Lock-Konflikt

## Linked Issues
Partially addresses #252

## Test Plan
```bash
cargo remote -- clippy --workspace --all-targets -- -D warnings
# 0 Warnings

# Live-Verifikation auf VM:
ssh ubuntu@10.0.0.240 "curl -m3 localhost:8084/operator/prune -X POST -d '{}'"
# {"accepted":true,"message":"Pruning gestartet (1000 Rows/Tick)"}

ssh ubuntu@10.0.0.240 "curl -m3 localhost:8084/operator/snapshots | head -c 80"
# JSON Response waehrend Prune — kein Timeout
```

## Benchmarks
N/A

## Evidence (AC Mapping)
| AC | Beschreibung | Status | Evidence |
|----|-------------|--------|---------|
| AC-1 | API responsive waehrend Prune | PASS | Snapshots-Endpoint antwortet waehrend laufendem Prune |
| AC-2 | Tick-Loop laeuft | PASS | Daemon schreibt Events, prune_tick() integriert |

```bash
ssh ubuntu@10.0.0.240 "curl -m3 -sw 'HTTP:%{http_code} TIME:%{time_total}s' localhost:8084/operator/snapshots"
# HTTP:200 TIME:0.001264s (waehrend Prune)

ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '20s ago' | grep prune"
# Prune gestartet (1000 Rows/Tick) cutoff=5555597
```

## Checklist
- [x] Code kompiliert
- [x] Clippy sauber
- [x] Live-Verifikation auf VM
- [x] Keine Secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)