### PR TITLE
fix: operation_id restart uniqueness fuer AgentSpawned Events (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AgentSpawned Events fehlen nach Daemon-Restart** (#267)
+  - Root Cause: `operation_id` in `RuntimeOrchestrator.emit_event()` war deterministisch (`runtime-spawn-{id}-{tick}-{seq}`) und identisch ueber Restarts hinweg
+  - `INSERT OR IGNORE` mit UNIQUE INDEX auf `operation_id` dropped Events still
+  - Fix: Millisekunden-Timestamp in die operation_id eingebaut fuer Restart-Uniqueness
+  - Behebt auch #269 (Dashboard zeigte historische Agents weil Projection keine aktiven hatte)
+
 ### Added
 
 - **Vollbetriebs-Vorbereitung: 9 Raeume, 6 Agents, Workflow-Infrastruktur** (#260)

--- a/crates/sentinel-runtime/src/lib.rs
+++ b/crates/sentinel-runtime/src/lib.rs
@@ -506,9 +506,13 @@ impl RuntimeOrchestrator {
         };
 
         self.event_seq += 1;
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
         let op_id = format!(
-            "runtime-{}-{}-{}",
-            op_suffix, self.current_tick, self.event_seq
+            "runtime-{}-{}-{}-{}",
+            op_suffix, self.current_tick, self.event_seq, ts
         );
         let event = DomainEvent::new(event_type, aggregate_id, payload, &op_id, self.current_tick)
             .with_operation_id(&op_id);


### PR DESCRIPTION
## Summary

- operation_id in RuntimeOrchestrator.emit_event() war deterministisch und identisch ueber Restarts
- INSERT OR IGNORE dropped AgentSpawned Events still wegen UNIQUE constraint
- Fix: Millisekunden-Timestamp in operation_id eingebaut

## Changes

**crates/sentinel-runtime/src/lib.rs:** `emit_event()` generiert operation_id mit `SystemTime::now().as_millis()` Suffix

## Linked Issues

Fixes #267
Fixes #269

## Test Plan

- [x] `cargo remote -- test --workspace` — alle Tests gruen
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Deploy + Verify: AgentSpawned Events == active_agents nach Restart

## Benchmarks

Einzeilige Aenderung, keine Performance-Relevanz.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 (#267) | UNTESTED | Deploy pending: `sqlite3 events.db "SELECT count(*) FROM events WHERE event_type='agent_spawned' AND timestamp_ms > ..."` |
| AC-2 (#267) | UNTESTED | Deploy pending: `sqlite3 projection.db "SELECT count(*) FROM agent_live_view WHERE status='active'"` |
| AC-3 (#267) | UNTESTED | Deploy pending: Dashboard API agent count |

```
$ cargo remote -- test --workspace 2>&1 | grep "test result" | head -20
test result: ok. 47 passed; 0 failed
test result: ok. 6 passed; 0 failed
test result: ok. 3 passed; 0 failed
(alle crates gruen)
```

## Checklist

- [x] Tests gruen
- [x] Clippy clean
- [x] CHANGELOG.md aktualisiert
- [x] Conventional Commit Format
- [x] Keine Secrets