### PR TITLE
fix: validate Move target_room against RoomDistanceMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Move-Action zu ungueltigem Raum validiert** — Agent konnte in nicht-existierenden Raum (z.B. "Tuer") wechseln. Fix: input_system validiert target_room gegen RoomDistanceMap.
+
 - **Agents spawnen nicht in favorite_room** (#272)
   - ECS `spawn_agent()` hardcoded `"empfang"` statt `favorite_room` aus Agent-Config
   - Fix: `room_id` Parameter hinzugefuegt, Orchestrator uebergibt `preferences.favorite_room`

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -1171,6 +1171,95 @@ mod tests {
         assert_eq!(payload["from_room"].as_str().unwrap(), "empfang");
     }
 
+    /// Move zu ungueltigem Raum wird ignoriert (kein Transit)
+    #[test]
+    fn test_move_to_invalid_room_ignored() {
+        let (mut world, mut schedule) = create_simulation_world();
+
+        let rooms_toml = include_str!("../../../config/rooms.toml");
+        let building_config: sentinel_common::room::BuildingConfig =
+            toml::from_str(rooms_toml).expect("rooms.toml parse error");
+        let rdm = RoomDistanceMap::from_building_config(&building_config);
+        world.insert_resource(rdm);
+
+        let entity = spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1, "empfang");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        world.insert_resource(ActionReceiver(std::sync::Mutex::new(rx)));
+
+        // Move nach "Tuer" — existiert NICHT in rooms.toml
+        tx.send(AgentAction {
+            agent_id: AgentId(1),
+            action_type: ActionType::Move,
+            target_room: Some("Tuer".to_string()),
+            target_agent: None,
+            content: None,
+            timestamp: Timestamp(1000),
+            tick: Tick(1),
+        })
+        .unwrap();
+
+        {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(1);
+            time.tick_count = 1;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+        }
+        schedule.run(&mut world);
+
+        // Agent darf NICHT in Transit sein — Action wurde ignoriert
+        let pos = world.get::<Position>(entity).unwrap();
+        assert!(
+            !pos.in_transit,
+            "Agent should NOT be in transit after invalid room move"
+        );
+        assert_eq!(pos.room_id, "empfang", "Agent should still be in empfang");
+        assert!(pos.transit_target.is_none());
+    }
+
+    /// Move zu gueltigem Raum funktioniert weiterhin
+    #[test]
+    fn test_move_to_valid_room_works() {
+        let (mut world, mut schedule) = create_simulation_world();
+
+        let rooms_toml = include_str!("../../../config/rooms.toml");
+        let building_config: sentinel_common::room::BuildingConfig =
+            toml::from_str(rooms_toml).expect("rooms.toml parse error");
+        let rdm = RoomDistanceMap::from_building_config(&building_config);
+        world.insert_resource(rdm);
+
+        let entity = spawn_agent(&mut world, AgentId(1), "Test Agent", "Tester", 1, "empfang");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        world.insert_resource(ActionReceiver(std::sync::Mutex::new(rx)));
+
+        // Move nach "kueche" — gueltig
+        tx.send(AgentAction {
+            agent_id: AgentId(1),
+            action_type: ActionType::Move,
+            target_room: Some("kueche".to_string()),
+            target_agent: None,
+            content: None,
+            timestamp: Timestamp(1000),
+            tick: Tick(1),
+        })
+        .unwrap();
+
+        {
+            let mut time = world.resource_mut::<SimulationTime>();
+            time.tick = Tick(1);
+            time.tick_count = 1;
+            time.delta_seconds = 1.0;
+            time.sim_hour = 8.0;
+        }
+        schedule.run(&mut world);
+
+        let pos = world.get::<Position>(entity).unwrap();
+        assert!(pos.in_transit, "Agent should be in transit to valid room");
+        assert_eq!(pos.transit_target, Some("kueche".to_string()));
+    }
+
     /// ToolUse ohne ToolRuntime: Fallback auf WorkContext
     #[test]
     fn test_tool_dispatch_fallback_without_runtime() {

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -89,6 +89,21 @@ pub fn input_system(
             match action.action_type {
                 ActionType::Move => {
                     if let Some(target_room) = &action.target_room {
+                        // Validierung: Raum muss in rooms.toml existieren
+                        // Ohne RoomDistanceMap (Tests): alle Raeume akzeptieren
+                        let valid_room = room_distances
+                            .as_ref()
+                            .map(|rd| rd.contains(target_room))
+                            .unwrap_or(true);
+                        if !valid_room {
+                            tracing::warn!(
+                                agent = %identity.agent_id,
+                                target = %target_room,
+                                "Move zu ungueltigem Raum ignoriert"
+                            );
+                            continue;
+                        }
+
                         let from_room = position.room_id.clone();
                         let to_room = target_room.clone();
                         // Distance-basierte Transit-Dauer: 1500ms Basis + 800ms pro Hop

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -464,6 +464,11 @@ impl RoomDistanceMap {
     pub fn all_rooms(&self) -> &[String] {
         &self.room_ids
     }
+
+    /// Prueft ob ein Raum in der Distance-Map existiert (d.h. in rooms.toml definiert ist).
+    pub fn contains(&self, room_id: &str) -> bool {
+        self.room_ids.iter().any(|r| r == room_id)
+    }
 }
 
 /// Zenoh Fan-Out Bridge: Events nach Limbo-Write an async Fanout-Task senden.


### PR DESCRIPTION
## Summary

- Agents konnten in nicht-existierende Raeume wechseln (z.B. "Tuer") weil input_system target_room nicht validierte
- Fix: Pruefe target_room gegen RoomDistanceMap.contains(), ignoriere ungueltige Moves mit Warn-Log

## Changes

**crates/sentinel-ecs/src/systems.rs:** Validierung im ActionType::Move Branch
**crates/sentinel-ecs/src/world.rs:** `contains()` Methode auf RoomDistanceMap
**crates/sentinel-ecs/src/lib.rs:** 2 neue Tests (invalid + valid room move)

## Linked Issues

Partially addresses #272 (Verifikationsbefund: Aylin Demirci in room="Tuer")

## Test Plan

- [x] `cargo remote -- test --workspace` — alle Tests gruen
- [x] `cargo remote -- clippy --workspace --all-targets -- -D warnings` — clean
- [x] `test_move_to_invalid_room_ignored` — Move nach "Tuer" ignoriert
- [x] `test_move_to_valid_room_works` — Move nach "kueche" funktioniert

## Benchmarks

Keine Performance-relevanten Aenderungen.

## Evidence (AC Mapping)

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 | PASS | `test_move_to_invalid_room_ignored` — Position unveraendert nach Move zu "Tuer" |
| AC-2 | PASS | `test_move_to_valid_room_works` — Transit startet normal nach Move zu "kueche" |
| AC-3 | UNTESTED | Deploy pending: Daemon-Restart + Agent-Room-Validierung |

```
$ cargo remote -- test -p sentinel-ecs --lib test_move_to_invalid
test tests::test_move_to_invalid_room_ignored ... ok

$ cargo remote -- test -p sentinel-ecs --lib test_move_to_valid
test tests::test_move_to_valid_room_works ... ok
```

## Checklist

- [x] Tests gruen
- [x] Clippy clean
- [x] CHANGELOG.md aktualisiert
- [x] Conventional Commit Format