### PR TITLE
fix: finish verified MITM follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MITM Follow-ups: Dashboard-Legacy-Schema, Anthropic-Streaming/Blocks, Observability, Redaction** (#296)
+  - Dashboard-Queries waehlen Event-Spalten jetzt schema-robust, so dass lokale DBs ohne `compensation_type` weder `cockpit` noch `events` brechen
+  - Gateway erhaelt rohe Anthropic-Content-Blocks ueber `/v1/messages`, beantwortet SSE-Streaming direkt und behaelt den Anthropic-Wire-Shape bei
+  - `traffic-stats` trennt jetzt internen Runtime-Provider (`internal_primary_provider`) und externen MITM-Provider (`external_mitm_provider`)
+  - interne Runtime-Clients (`sentinel-daemon`, `sentinel-judge`) nutzen jetzt `/internal/llm` statt den externen Kompatibilitaetspfad
+  - MITM-Smoke-Tooling wurde mit `scripts/mitm-smoke.sh` und erweiterter Fake-Anthropic-API nachgezogen; Auth-Dummywerte bleiben in Logs redigiert
+
 - **Canonical main parity: verified MITM contract restored on `/v1/messages`** (#298)
   - Gateway exposes `POST /v1/messages` again on the canonical line, not only on drifted deploys or historical branches
   - Anthropic wire-format parsing, path-specific error/response shaping and request-scoped passthrough headers are restored

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,8 @@
 
 - Plan source: `User-freigegebener 4-Schritte-Ablauf nach $start`
 - Overall status: `IN_PROGRESS`
-- Current task: `2. Frischen #296-Arbeitsbranch von der korrigierten Basis anlegen`
-- Current branch: `feat/issue-289-room-phase2-closure`
+- Current task: `3. Echten verbleibenden #296-Scope bearbeiten`
+- Current branch: `feat/issue-296-mitm-followups-clean`
 - Pull policy: `Kein Pull von main in den aktuellen Branch ohne explizite User-Freigabe`
 - Last refresh: `2026-04-03`
 
@@ -20,6 +20,7 @@
 - Der aktuelle Closure-/Parity-Stand ist jetzt auf GitHub publiziert:
   Draft-PR `#299` von `feat/issue-289-room-phase2-closure` nach `main`.
 - Der alte PR `#297` von `fix/issue-296-mitm-followups` ist jetzt geschlossen und explizit als superseded markiert.
+- Der neue `#296`-Arbeitsbranch ist jetzt `feat/issue-296-mitm-followups-clean` und zeigt exakt auf den publizierten Basis-Commit `fb019f0`.
 - TOGAF und lokale Artefakte sind auf den verifizierten Room-Phase-2-Stand angeglichen: realistische Transit-Zeiten `15s-120s`, Transit-Perception mit Zwischen-Raum und adaptiver Heartbeat ohne separaten Async-Task.
 
 ## Blocked items
@@ -42,8 +43,8 @@
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | Aktuellen #289/#298-Stand publizieren | DONE | aktuellen Branch pushen, PR-Lage bereinigen, verifizierten Closure-/Parity-Stand auf GitHub sichtbar machen | command, system |
-| 2 | Frischen #296-Arbeitsbranch von der korrigierten Basis anlegen | IN_PROGRESS | neuen Branch fuer #296 auf Basis des publizierten Stands erzeugen; alten `fix/issue-296-mitm-followups` nicht weiterverwenden | command |
-| 3 | Echten verbleibenden #296-Scope bearbeiten | TODO | Dashboard/Streaming/Blocks/Observability/Redaction nach aktuellem Issue-Scope umsetzen, verifizieren, dokumentieren | command, system, inspect |
+| 2 | Frischen #296-Arbeitsbranch von der korrigierten Basis anlegen | DONE | neuen Branch fuer #296 auf Basis des publizierten Stands erzeugen; alten `fix/issue-296-mitm-followups` nicht weiterverwenden | command |
+| 3 | Echten verbleibenden #296-Scope bearbeiten | IN_PROGRESS | Dashboard/Streaming/Blocks/Observability/Redaction nach aktuellem Issue-Scope umsetzen, verifizieren, dokumentieren | command, system, inspect |
 | 4 | Anschließend #282 starten | TODO | Room-Chat-Forwarding auf derselben verifizierten Basis bearbeiten und live belegen | command, system, inspect |
 | 5 | Plan-Verifikation | TODO | Vier-Schritte-Ablauf gegen Ergebnis und Runtime-Stand komplett abgleichen | command, inspect, system |
 
@@ -66,6 +67,18 @@
   - Verifikation:
     `gh pr view 297 --repo silentspike/project-sentinel --json number,title,state,url`
     -> `state=CLOSED`
+
+## Task 2 evidence summary
+
+- Frischer `#296`-Branch erstellt:
+  - `git switch -c feat/issue-296-mitm-followups-clean`
+  - Verifikation:
+    `git rev-parse --abbrev-ref HEAD` -> `feat/issue-296-mitm-followups-clean`
+
+- Korrigierte Basis bestaetigt:
+  - `git rev-parse --short HEAD` -> `fb019f0`
+  - `git rev-parse --short feat/issue-289-room-phase2-closure` -> `fb019f0`
+  - `git merge-base --is-ancestor feat/issue-289-room-phase2-closure HEAD && echo $?` -> `0`
 
 ## Task 6 evidence summary
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 
 - Plan source: `User-freigegebener 4-Schritte-Ablauf nach $start`
 - Overall status: `IN_PROGRESS`
-- Current task: `3. Echten verbleibenden #296-Scope bearbeiten`
+- Current task: `4. Anschließend #282 starten`
 - Current branch: `feat/issue-296-mitm-followups-clean`
 - Pull policy: `Kein Pull von main in den aktuellen Branch ohne explizite User-Freigabe`
 - Last refresh: `2026-04-03`
@@ -44,8 +44,8 @@
 |---|------|--------|-------|----------|
 | 1 | Aktuellen #289/#298-Stand publizieren | DONE | aktuellen Branch pushen, PR-Lage bereinigen, verifizierten Closure-/Parity-Stand auf GitHub sichtbar machen | command, system |
 | 2 | Frischen #296-Arbeitsbranch von der korrigierten Basis anlegen | DONE | neuen Branch fuer #296 auf Basis des publizierten Stands erzeugen; alten `fix/issue-296-mitm-followups` nicht weiterverwenden | command |
-| 3 | Echten verbleibenden #296-Scope bearbeiten | IN_PROGRESS | Dashboard/Streaming/Blocks/Observability/Redaction nach aktuellem Issue-Scope umsetzen, verifizieren, dokumentieren | command, system, inspect |
-| 4 | Anschließend #282 starten | TODO | Room-Chat-Forwarding auf derselben verifizierten Basis bearbeiten und live belegen | command, system, inspect |
+| 3 | Echten verbleibenden #296-Scope bearbeiten | DONE | Dashboard/Streaming/Blocks/Observability/Redaction nach aktuellem Issue-Scope umsetzen, verifizieren, dokumentieren | command, system, inspect |
+| 4 | Anschließend #282 starten | IN_PROGRESS | Room-Chat-Forwarding auf derselben verifizierten Basis bearbeiten und live belegen | command, system, inspect |
 | 5 | Plan-Verifikation | TODO | Vier-Schritte-Ablauf gegen Ergebnis und Runtime-Stand komplett abgleichen | command, inspect, system |
 
 ## Task 1 evidence summary
@@ -79,6 +79,81 @@
   - `git rev-parse --short HEAD` -> `fb019f0`
   - `git rev-parse --short feat/issue-289-room-phase2-closure` -> `fb019f0`
   - `git merge-base --is-ancestor feat/issue-289-room-phase2-closure HEAD && echo $?` -> `0`
+
+## Task 3 evidence summary
+
+- Lokale Regressionen gruen:
+  - `bun test dashboard/src/routes/cockpit.test.ts dashboard/src/__tests__/events.test.ts`
+    -> `19` Tests PASS
+  - `go test ./cmd/cortex-gateway/internal/... ./services/sentinel-judge/internal/...`
+    -> PASS
+  - `cargo remote -c -- test -p sentinel-daemon`
+    -> `138` Tests PASS
+  - `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
+    -> PASS
+
+- Umgesetzter `#296`-Scope:
+  - Dashboard-DB-Zugriffe sind jetzt legacy-kompatibel gegen fehlendes `compensation_type`
+  - `/v1/messages` unterstuetzt jetzt rohe Anthropic-Content-Blocks und SSE-Streaming direkt im Gateway
+  - `traffic-stats` trennt jetzt `internal_primary_provider=claude-code` und `external_mitm_provider=anthropic-direct`
+  - interne Clients (`sentinel-daemon`, `sentinel-judge`) gehen jetzt ueber `/internal/llm` statt ueber den externen Kompatibilitaetspfad
+  - MITM-Smoke-Tooling existiert jetzt ueber `scripts/mitm-smoke.sh` plus `test-fake-api.py`
+  - Redaction-Nachweis fuer Auth-Header wurde auf der VM nachgezogen
+
+- VM-Deploy:
+  - `scp cortex-gateway ... && sudo cp ... /opt/sentinel/bin/cortex-gateway && sudo systemctl start sentinel-gateway`
+    -> `sentinel-gateway active`
+  - `scp sentinel-judge ... && sudo cp ... /opt/sentinel/bin/sentinel-judge && sudo systemctl start sentinel-judge`
+    -> `sentinel-judge active`
+  - `scp target/release/sentinel-daemon ... && sudo cp ... /opt/sentinel/bin/sentinel-daemon && sudo systemctl start sentinel-daemon`
+    -> `sentinel-daemon active`
+  - Gesamtdienste:
+    `systemctl is-active sentinel-daemon sentinel-gateway sentinel-judge sentinel-projection`
+    -> alle `active`
+
+- Live-Gateway-/Dashboard-Evidence:
+  - `curl -s localhost:8081/control/traffic-stats`
+    -> enthaelt `internal_primary_provider:"claude-code"` und `external_mitm_provider:"anthropic-direct"`
+  - `curl -s localhost:8000/api/cockpit >/dev/null && echo cockpit_ok`
+    -> `cockpit_ok`
+  - `curl -s -X POST localhost:8080/v1/messages ...`
+    -> Anthropic-Error-Shape statt Drift/Fallback:
+       `{"type":"error","error":{"type":"authentication_error","message":"provider request failed"}}`
+  - Dummy-Auth-Redaction:
+    Request mit `Authorization: Bearer REDACTTEST296`, danach `journalctl ... | grep REDACTTEST296`
+    -> `redaction_ok`
+
+- Interner Runtime-Vertrag live:
+  - `curl -s -X POST localhost:8080/internal/llm ... synth_fp=...HR:0...`
+    -> `provider:"synthesis"` und synthetische Antwort
+  - `curl -s -X POST localhost:8080/internal/llm ... synth_fp=...HR:1...`
+    -> `provider rate limited`
+  - passendes Gateway-Journal:
+    `provider request failed","provider":"claude-code"... HTTP 429 ...`
+    -> interner Forward-Pfad geht ueber `claude-code`, nicht ueber `anthropic-direct`
+
+- `Voice of Gaia` live:
+  - `curl -s -X POST localhost:8084/operator/gaia ... {"target_agent_id":1,"thought":"Geh bitte direkt in die Kueche."}`
+    -> `{"accepted":true,"message":"Gedanke eingepflanzt"}`
+  - `journalctl -u sentinel-daemon --since '20 sec ago'`
+    -> `Voice of Gaia empfangen agent_id=1`
+    -> `Voice of Gaia: Transit direkt gestartet (goettlicher Impuls) agent_id=1 target="kueche"`
+    -> `Gaia-Thought AKTIV -> IM:1 im Fingerprint`
+  - Event-Store:
+    `operator_gaia_sent`
+    `agent_action_received ... target_room":"kueche"`
+    `transit_started ... from_room":"buero-ceo","to_room":"kueche","duration_ms":80000`
+
+- Voller MITM-Codepfad auf der VM:
+  - Echter `claude -p`-Smoke mit `ANTHROPIC_BASE_URL=http://127.0.0.1:8080` blockierte auf lokaler Maschine und auf der VM vor dem ersten Request; kein Gateway-Hit.
+  - Deshalb zusaetzlicher isolierter VM-Nachweis mit derselben Gateway-Binary:
+    - temporaerer Fake-Upstream auf `127.0.0.1:19876`
+    - temporaerer Gateway auf `18080/18081` mit `ANTHROPIC_BASE_URL=http://127.0.0.1:19876`
+    - `curl -X POST http://127.0.0.1:18080/v1/messages ... Authorization: Bearer dummy-mitm-test`
+      -> `200` mit Anthropic-Message-Body und Text `HALLO`
+    - `tail /tmp/gateway296.log`
+      -> `pipeline request completed","provider":"anthropic-direct"`
+  - Damit ist der komplette `/v1/messages -> anthropic-direct -> upstream`-Pfad fuer die aktuelle Binary auf der VM belegt, unabhaengig vom blockierten `claude -p`-Prozess.
 
 ## Task 6 evidence summary
 

--- a/cmd/cortex-gateway/internal/proxy/anthropic_api.go
+++ b/cmd/cortex-gateway/internal/proxy/anthropic_api.go
@@ -12,6 +12,7 @@ const anthropicMessagesPath = "/v1/messages"
 type anthropicInboundRequest struct {
 	Model       string                    `json:"model"`
 	MaxTokens   int                       `json:"max_tokens"`
+	Stream      bool                      `json:"stream,omitempty"`
 	System      json.RawMessage           `json:"system,omitempty"`
 	Messages    []anthropicInboundMessage `json:"messages"`
 	Temperature float64                   `json:"temperature,omitempty"`
@@ -32,7 +33,7 @@ type anthropicMessageResponse struct {
 	ID           string                        `json:"id"`
 	Type         string                        `json:"type"`
 	Role         string                        `json:"role"`
-	Content      []anthropicInboundTextBlock   `json:"content"`
+	Content      []json.RawMessage             `json:"content"`
 	Model        string                        `json:"model"`
 	StopReason   string                        `json:"stop_reason"`
 	StopSequence *string                       `json:"stop_sequence"`
@@ -73,13 +74,14 @@ func decodeAnthropicRequest(body []byte) (LLMRequest, error) {
 
 	messages := make([]Message, 0, len(raw.Messages))
 	for _, msg := range raw.Messages {
-		content, err := decodeAnthropicContent(msg.Content)
+		content, blocks, err := decodeAnthropicContent(msg.Content)
 		if err != nil {
 			return LLMRequest{}, fmt.Errorf("decode anthropic message content: %w", err)
 		}
 		messages = append(messages, Message{
-			Role:    msg.Role,
-			Content: content,
+			Role:          msg.Role,
+			Content:       content,
+			ContentBlocks: blocks,
 		})
 	}
 
@@ -88,6 +90,7 @@ func decodeAnthropicRequest(body []byte) (LLMRequest, error) {
 		SystemBlocks:      systemBlocks,
 		Temperature:       raw.Temperature,
 		MaxTokens:         raw.MaxTokens,
+		Stream:            raw.Stream,
 		Model:             raw.Model,
 		Metadata:          raw.Metadata,
 		Format:            RequestFormatAnthropic,
@@ -136,29 +139,22 @@ func decodeAnthropicSystem(raw json.RawMessage) ([]SystemBlock, error) {
 	return nil, fmt.Errorf("unsupported anthropic system payload")
 }
 
-func decodeAnthropicContent(raw json.RawMessage) (string, error) {
+func decodeAnthropicContent(raw json.RawMessage) (string, []json.RawMessage, error) {
 	if len(raw) == 0 || string(raw) == "null" {
-		return "", nil
+		return "", nil, nil
 	}
 
 	var asString string
 	if err := json.Unmarshal(raw, &asString); err == nil {
-		return asString, nil
+		return asString, nil, nil
 	}
 
-	var blocks []anthropicInboundTextBlock
+	var blocks []json.RawMessage
 	if err := json.Unmarshal(raw, &blocks); err == nil {
-		var b strings.Builder
-		for _, block := range blocks {
-			if block.Type != "" && block.Type != "text" {
-				continue
-			}
-			b.WriteString(block.Text)
-		}
-		return b.String(), nil
+		return anthropicContentProjection(blocks), cloneRawMessages(blocks), nil
 	}
 
-	return "", fmt.Errorf("unsupported anthropic content payload")
+	return "", nil, fmt.Errorf("unsupported anthropic content payload")
 }
 
 func extractAnthropicPassthroughHeaders(header http.Header) map[string]string {
@@ -200,10 +196,7 @@ func buildAnthropicMessageResponse(resp PipelineResponse) anthropicMessageRespon
 		ID:   id,
 		Type: "message",
 		Role: "assistant",
-		Content: []anthropicInboundTextBlock{{
-			Type: "text",
-			Text: resp.Content,
-		}},
+		Content: anthropicResponseBlocks(resp),
 		Model:        resp.Model,
 		StopReason:   stopReason,
 		StopSequence: nil,
@@ -238,4 +231,38 @@ func writeAnthropicError(w http.ResponseWriter, status int, message string) {
 			Message: message,
 		},
 	})
+}
+
+func anthropicContentProjection(blocks []json.RawMessage) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, raw := range blocks {
+		var block anthropicInboundTextBlock
+		if err := json.Unmarshal(raw, &block); err != nil {
+			continue
+		}
+		if block.Type != "" && block.Type != "text" {
+			continue
+		}
+		b.WriteString(block.Text)
+	}
+	return b.String()
+}
+
+func anthropicTextBlockRaw(text string) json.RawMessage {
+	payload, _ := json.Marshal(anthropicInboundTextBlock{
+		Type: "text",
+		Text: text,
+	})
+	return payload
+}
+
+func anthropicResponseBlocks(resp PipelineResponse) []json.RawMessage {
+	if len(resp.ContentBlocks) > 0 {
+		return cloneRawMessages(resp.ContentBlocks)
+	}
+	return []json.RawMessage{anthropicTextBlockRaw(resp.Content)}
 }

--- a/cmd/cortex-gateway/internal/proxy/claude.go
+++ b/cmd/cortex-gateway/internal/proxy/claude.go
@@ -37,12 +37,13 @@ type claudeRequest struct {
 	System      []claudeSystemBlock `json:"system,omitempty"`
 	Messages    []claudeMessage     `json:"messages"`
 	Temperature float64             `json:"temperature,omitempty"`
+	Stream      bool                `json:"stream,omitempty"`
 }
 
 // claudeMessage is a single message in the Anthropic format.
 type claudeMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"`
 }
 
 // claudeSystemBlock is a structured system content block for Anthropic Messages.
@@ -55,14 +56,12 @@ type claudeSystemBlock struct {
 // claudeCacheControl mirrors Anthropic cache control hints.
 type claudeCacheControl struct {
 	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
 }
 
 // claudeResponse is the Anthropic Messages API response format.
 type claudeResponse struct {
-	Content []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	} `json:"content"`
+	Content    []json.RawMessage `json:"content"`
 	Model      string      `json:"model"`
 	StopReason string      `json:"stop_reason"`
 	Usage      claudeUsage `json:"usage"`
@@ -140,6 +139,7 @@ func (p *ClaudeProvider) Send(ctx context.Context, req *LLMRequest) (*LLMRespons
 		System:      systemBlocks,
 		Messages:    messages,
 		Temperature: req.Temperature,
+		Stream:      false,
 	}
 
 	body, err := json.Marshal(cReq)
@@ -182,20 +182,16 @@ func (p *ClaudeProvider) Send(ctx context.Context, req *LLMRequest) (*LLMRespons
 		return nil, fmt.Errorf("unmarshal claude response: %w", err)
 	}
 
-	content := ""
-	for _, c := range cResp.Content {
-		if c.Type == "text" {
-			content += c.Text
-		}
-	}
+	content := anthropicContentProjection(cResp.Content)
 
 	return &LLMResponse{
-		Content:      content,
-		Model:        cResp.Model,
-		TokensUsed:   cResp.Usage.InputTokens + cResp.Usage.OutputTokens,
-		InputTokens:  cResp.Usage.InputTokens,
-		OutputTokens: cResp.Usage.OutputTokens,
-		FinishReason: cResp.StopReason,
+		Content:       content,
+		ContentBlocks: cloneRawMessages(cResp.Content),
+		Model:         cResp.Model,
+		TokensUsed:    cResp.Usage.InputTokens + cResp.Usage.OutputTokens,
+		InputTokens:   cResp.Usage.InputTokens,
+		OutputTokens:  cResp.Usage.OutputTokens,
+		FinishReason:  cResp.StopReason,
 	}, nil
 }
 
@@ -210,7 +206,10 @@ func splitAnthropicMessages(req *LLMRequest) ([]claudeSystemBlock, []claudeMessa
 			entry.Type = "text"
 		}
 		if block.CacheControl != nil {
-			entry.CacheControl = &claudeCacheControl{Type: block.CacheControl.Type}
+			entry.CacheControl = &claudeCacheControl{
+				Type: block.CacheControl.Type,
+				TTL:  block.CacheControl.TTL,
+			}
 		}
 		systemBlocks = append(systemBlocks, entry)
 	}
@@ -224,10 +223,104 @@ func splitAnthropicMessages(req *LLMRequest) ([]claudeSystemBlock, []claudeMessa
 			})
 			continue
 		}
-		messages = append(messages, claudeMessage(m))
+		entry := claudeMessage{Role: m.Role, Content: m.Content}
+		if len(m.ContentBlocks) > 0 {
+			entry.Content = cloneRawMessages(m.ContentBlocks)
+		}
+		messages = append(messages, entry)
 	}
 
 	return systemBlocks, messages
+}
+
+// StreamHTTP forwards an Anthropic streaming request and relays the SSE stream.
+func (p *ClaudeProvider) StreamHTTP(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error {
+	if req != nil && req.ProviderTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.ProviderTimeout)
+		defer cancel()
+	}
+
+	systemBlocks, messages := splitAnthropicMessages(req)
+
+	model := p.model
+	if req != nil && req.Model != "" {
+		model = req.Model
+	}
+
+	maxTokens := p.maxTokens
+	if req != nil && req.MaxTokens > 0 {
+		maxTokens = req.MaxTokens
+	}
+
+	cReq := claudeRequest{
+		Model:       model,
+		MaxTokens:   maxTokens,
+		System:      systemBlocks,
+		Messages:    messages,
+		Temperature: req.Temperature,
+		Stream:      true,
+	}
+
+	body, err := json.Marshal(cReq)
+	if err != nil {
+		return fmt.Errorf("marshal claude streaming request: %w", err)
+	}
+
+	endpoint, err := url.JoinPath(p.baseURL, anthropicMessagesPath)
+	if err != nil {
+		return fmt.Errorf("build claude endpoint URL: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body)) //nolint:gosec // baseURL from trusted config
+	if err != nil {
+		return fmt.Errorf("create streaming http request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	applyAnthropicForwardHeaders(httpReq.Header, req, p.apiKey)
+
+	resp, err := p.client.Do(httpReq) //nolint:gosec // URL from trusted config
+	if err != nil {
+		return fmt.Errorf("claude streaming API call: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+		return &ProviderError{
+			StatusCode: resp.StatusCode,
+			Message:    strings.TrimSpace(string(respBody)),
+		}
+	}
+
+	copyAnthropicStreamHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+
+	if flusher, ok := w.(http.Flusher); ok {
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+					return fmt.Errorf("relay streaming response: %w", writeErr)
+				}
+				flusher.Flush()
+			}
+			if readErr != nil {
+				if readErr == io.EOF {
+					return nil
+				}
+				return fmt.Errorf("read streaming response: %w", readErr)
+			}
+		}
+	}
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return fmt.Errorf("relay streaming response: %w", err)
+	}
+	return nil
 }
 
 // HealthCheck verifies that the Claude API is reachable.
@@ -279,5 +372,20 @@ func applyAnthropicForwardHeaders(header http.Header, req *LLMRequest, configure
 	header.Set("anthropic-version", version)
 	if beta != "" {
 		header.Set("anthropic-beta", beta)
+	}
+}
+
+func copyAnthropicStreamHeaders(dst, src http.Header) {
+	for key, values := range src {
+		lower := strings.ToLower(key)
+		switch lower {
+		case "connection", "transfer-encoding", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailers", "upgrade":
+			continue
+		case "content-length":
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
 	}
 }

--- a/cmd/cortex-gateway/internal/proxy/ollama.go
+++ b/cmd/cortex-gateway/internal/proxy/ollama.go
@@ -82,7 +82,10 @@ func (p *OllamaProvider) Send(ctx context.Context, req *LLMRequest) (*LLMRespons
 
 	messages := make([]ollamaMessage, len(req.Messages))
 	for i, m := range req.Messages {
-		messages[i] = ollamaMessage(m)
+		messages[i] = ollamaMessage{
+			Role:    m.Role,
+			Content: m.Content,
+		}
 	}
 
 	model := p.model

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -205,6 +205,7 @@ func (ph *PipelineHandler) BreakerStates() map[string]string {
 // PipelineResponse ist die erweiterte Antwort mit extrahierten Aktionen.
 type PipelineResponse struct {
 	Content      string                       `json:"content"`
+	ContentBlocks []json.RawMessage           `json:"-"`
 	Model        string                       `json:"model"`
 	Provider     string                       `json:"provider"`
 	TokensUsed   int                          `json:"tokens_used"`
@@ -414,7 +415,7 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 	ph.injectPerception(&req, agentName, agentRole, providerName, snap)
 
 	// --- Step 7.5: Traffic Control — Synthesis Check ---
-	if ph.synthesis != nil && snap.SynthesisEnabled {
+	if ph.synthesis != nil && snap.SynthesisEnabled && !isAnthropicStreamingRequest(&req) {
 		result := ph.synthesis.Decide(req.Metadata, agentName)
 		if result.Decision == synthesis.Synthesize {
 			content := result.Content
@@ -471,7 +472,7 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 			}
 		}
 	}
-	if ph.observer != nil && snap.APICPEnabled {
+	if ph.observer != nil && snap.APICPEnabled && !isAnthropicStreamingRequest(&req) {
 		fp, ctx, err := synthesis.PrepareInputs(req.Metadata)
 		if err == nil && synthesis.CanSynthesize(fp, ctx) {
 			agentID := req.Metadata["agent_id"]
@@ -556,6 +557,11 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+	}
+
+	if isAnthropicStreamingRequest(&req) {
+		ph.streamAnthropicResponse(r.Context(), w, &req, provider, providerName, breaker, requestID, start)
+		return
 	}
 
 	// --- Step 8: Provider.Send() ---
@@ -704,15 +710,16 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 	)
 
 	pipelineResp := PipelineResponse{
-		Content:      content,
-		Model:        resp.Model,
-		Provider:     providerName,
-		TokensUsed:   resp.TokensUsed,
-		InputTokens:  resp.InputTokens,
-		OutputTokens: resp.OutputTokens,
-		FinishReason: resp.FinishReason,
-		Actions:      actions,
-		RequestID:    requestID,
+		Content:       content,
+		ContentBlocks: pipelineResponseBlocks(content, resp),
+		Model:         resp.Model,
+		Provider:      providerName,
+		TokensUsed:    resp.TokensUsed,
+		InputTokens:   resp.InputTokens,
+		OutputTokens:  resp.OutputTokens,
+		FinishReason:  resp.FinishReason,
+		Actions:       actions,
+		RequestID:     requestID,
 	}
 	ph.writePipelineResponse(r.Context(), w, &req, pipelineResp)
 }
@@ -1230,6 +1237,10 @@ func responsePayloadForRequest(req *LLMRequest, resp PipelineResponse) interface
 	return resp
 }
 
+func isAnthropicStreamingRequest(req *LLMRequest) bool {
+	return req != nil && req.Format == RequestFormatAnthropic && req.Stream
+}
+
 func (ph *PipelineHandler) writePathError(w http.ResponseWriter, path, message string, status int) {
 	if isAnthropicMessagesPath(path) {
 		writeAnthropicError(w, status, message)
@@ -1264,6 +1275,90 @@ func buildSynthesisActions(actions []synthesis.Action, ext *extraction.Extractor
 		})
 	}
 	return result
+}
+
+func pipelineResponseBlocks(content string, resp *LLMResponse) []json.RawMessage {
+	if resp == nil || len(resp.ContentBlocks) == 0 {
+		return nil
+	}
+	if content != resp.Content {
+		return nil
+	}
+	return cloneRawMessages(resp.ContentBlocks)
+}
+
+type trackedResponseWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *trackedResponseWriter) WriteHeader(statusCode int) {
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *trackedResponseWriter) Write(p []byte) (int, error) {
+	w.wroteHeader = true
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *trackedResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (ph *PipelineHandler) streamAnthropicResponse(ctx context.Context, w http.ResponseWriter, req *LLMRequest, provider Provider, providerName string, breaker *CircuitBreaker, requestID string, start time.Time) {
+	streamer, ok := provider.(StreamingProvider)
+	if !ok {
+		ph.writeRequestError(w, req, "streaming not supported by provider", http.StatusBadGateway)
+		return
+	}
+
+	req.ProviderTimeout = ph.providerDeadline
+	prevState := breaker.State()
+	tracked := &trackedResponseWriter{ResponseWriter: w}
+	err := streamer.StreamHTTP(ctx, req, tracked)
+	breaker.Record(err)
+	if newState := breaker.State(); newState == "open" && prevState != "open" {
+		breakerTripsTotal.WithLabelValues(providerName).Inc()
+	}
+	ph.updateBreakerGauge(providerName, breaker)
+
+	duration := time.Since(start)
+	if err != nil {
+		pipelineRequestsTotal.WithLabelValues(providerName, "stream_error").Inc()
+		pipelineLatency.WithLabelValues(providerName).Observe(duration.Seconds())
+		ph.logger.Error("provider stream failed",
+			"provider", providerName,
+			"request_id", requestID,
+			"duration", duration,
+			"error", err,
+		)
+		if !tracked.wroteHeader {
+			statusCode := http.StatusBadGateway
+			errMsg := "provider stream failed"
+			var provErr *ProviderError
+			if errors.As(err, &provErr) {
+				if provErr.StatusCode > 0 {
+					statusCode = provErr.StatusCode
+				}
+				errMsg = provErr.Message
+			}
+			ph.writeRequestError(tracked, req, errMsg, statusCode)
+		}
+		return
+	}
+
+	pipelineRequestsTotal.WithLabelValues(providerName, "stream").Inc()
+	pipelineLatency.WithLabelValues(providerName).Observe(duration.Seconds())
+	ph.logger.Info("pipeline stream completed",
+		"provider", providerName,
+		"request_id", requestID,
+		"duration", duration,
+		"agent_id", req.Metadata["agent_id"],
+		"agent_name", req.Metadata["agent_name"],
+	)
 }
 
 // modelKey mappt Provider-Namen auf Compiler-Config-Keys.

--- a/cmd/cortex-gateway/internal/proxy/pipeline_test.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline_test.go
@@ -35,8 +35,10 @@ type pipelineMockProvider struct {
 	err       error
 	statusErr error
 	calls     int
+	streamCalls int
 	lastReq   *LLMRequest
 	sendFunc  func(ctx context.Context, req *LLMRequest) (*LLMResponse, error)
+	streamFunc func(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error
 }
 
 func (p *pipelineMockProvider) Name() string { return p.name }
@@ -55,6 +57,17 @@ func (p *pipelineMockProvider) Send(ctx context.Context, req *LLMRequest) (*LLMR
 }
 func (p *pipelineMockProvider) HealthCheck(_ context.Context) error { return nil }
 func (p *pipelineMockProvider) CurrentProviderError() error         { return p.statusErr }
+func (p *pipelineMockProvider) StreamHTTP(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error {
+	p.mu.Lock()
+	p.streamCalls++
+	p.lastReq = req
+	streamFunc := p.streamFunc
+	p.mu.Unlock()
+	if streamFunc != nil {
+		return streamFunc(ctx, req, w)
+	}
+	return errors.New("unexpected StreamHTTP call")
+}
 
 func newTestPipelineHandler(registry *Registry, controlCfg *control.Config) *PipelineHandler {
 	if controlCfg == nil {
@@ -274,6 +287,107 @@ func TestPipelineAnthropicMessagesPassthrough(t *testing.T) {
 	}
 	if usage["input_tokens"] != float64(30) || usage["output_tokens"] != float64(12) {
 		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestPipelineAnthropicMessagesPreserveRawBlocks(t *testing.T) {
+	reg := NewRegistry()
+	direct := &pipelineMockProvider{
+		name: "anthropic-direct",
+		resp: &LLMResponse{
+			Content: "visible text",
+			ContentBlocks: []json.RawMessage{
+				json.RawMessage(`{"type":"thinking","thinking":"chain","signature":"sig"}`),
+				json.RawMessage(`{"type":"text","text":"visible text"}`),
+			},
+			Model:        "claude-opus-4-6",
+			TokensUsed:   42,
+			InputTokens:  30,
+			OutputTokens: 12,
+			FinishReason: "end_turn",
+		},
+	}
+	reg.Register("anthropic-direct", direct)
+
+	cfg := control.NewConfig("anthropic-direct")
+	ph := newTestPipelineHandler(reg, cfg)
+
+	body := `{
+		"model":"claude-opus-4-6",
+		"max_tokens":128,
+		"messages":[{"role":"user","content":[{"type":"text","text":"Sag hallo"}]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	ph.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	content, ok := resp["content"].([]any)
+	if !ok || len(content) != 2 {
+		t.Fatalf("content blocks = %#v, want 2", resp["content"])
+	}
+	first, _ := content[0].(map[string]any)
+	if first["type"] != "thinking" {
+		t.Fatalf("first content block = %#v, want thinking", first)
+	}
+}
+
+func TestPipelineAnthropicMessagesStreamingUsesDirectProvider(t *testing.T) {
+	reg := NewRegistry()
+	internal := &pipelineMockProvider{name: "claude-code"}
+	direct := &pipelineMockProvider{
+		name: "anthropic-direct",
+		streamFunc: func(_ context.Context, req *LLMRequest, w http.ResponseWriter) error {
+			if !req.Stream {
+				t.Fatal("expected stream flag on forwarded request")
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, err := w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\"}\n\n"))
+			return err
+		},
+	}
+	reg.Register("claude-code", internal)
+	reg.Register("anthropic-direct", direct)
+
+	cfg := control.NewConfig("claude-code")
+	ph := newTestPipelineHandler(reg, cfg)
+
+	body := `{
+		"model":"claude-opus-4-6",
+		"max_tokens":128,
+		"stream":true,
+		"messages":[{"role":"user","content":[{"type":"text","text":"stream bitte"}]}],
+		"metadata":{"agent_name":"Thomas Mueller","agent_role":"CEO","body":"Hunger: 45%","heard":"hi","room_id":"buero-ceo"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer passthrough-token")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	ph.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if internal.calls != 0 {
+		t.Fatalf("claude-code send calls = %d, want 0", internal.calls)
+	}
+	if direct.streamCalls != 1 {
+		t.Fatalf("anthropic-direct stream calls = %d, want 1", direct.streamCalls)
+	}
+	if !strings.Contains(w.Body.String(), "message_start") {
+		t.Fatalf("expected SSE payload, got %q", w.Body.String())
 	}
 }
 

--- a/cmd/cortex-gateway/internal/proxy/provider.go
+++ b/cmd/cortex-gateway/internal/proxy/provider.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -20,6 +22,7 @@ type LLMRequest struct {
 	SystemBlocks       []SystemBlock     `json:"system,omitempty"`
 	Temperature        float64           `json:"temperature"`
 	MaxTokens          int               `json:"max_tokens"`
+	Stream             bool              `json:"stream,omitempty"`
 	Model              string            `json:"model,omitempty"`
 	Metadata           map[string]string `json:"metadata,omitempty"`
 	Format             RequestFormat     `json:"-"`
@@ -31,13 +34,15 @@ type LLMRequest struct {
 
 // Message represents a single message in an LLM conversation.
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role          string            `json:"role"`
+	Content       string            `json:"content"`
+	ContentBlocks []json.RawMessage `json:"-"`
 }
 
 // CacheControl annotates provider-side content caching hints.
 type CacheControl struct {
 	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
 }
 
 // SystemBlock is a structured system-level content block.
@@ -49,12 +54,13 @@ type SystemBlock struct {
 
 // LLMResponse represents a response from an LLM provider.
 type LLMResponse struct {
-	Content      string `json:"content"`
-	Model        string `json:"model"`
-	TokensUsed   int    `json:"tokens_used"`
-	InputTokens  int    `json:"input_tokens"`
-	OutputTokens int    `json:"output_tokens"`
-	FinishReason string `json:"finish_reason"`
+	Content       string            `json:"content"`
+	ContentBlocks []json.RawMessage `json:"-"`
+	Model         string            `json:"model"`
+	TokensUsed    int               `json:"tokens_used"`
+	InputTokens   int               `json:"input_tokens"`
+	OutputTokens  int               `json:"output_tokens"`
+	FinishReason  string            `json:"finish_reason"`
 }
 
 // Provider interface for LLM backends.
@@ -62,6 +68,12 @@ type Provider interface {
 	Name() string
 	Send(ctx context.Context, req *LLMRequest) (*LLMResponse, error)
 	HealthCheck(ctx context.Context) error
+}
+
+// StreamingProvider is an optional provider capability for relaying HTTP
+// streaming responses such as Anthropic SSE.
+type StreamingProvider interface {
+	StreamHTTP(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error
 }
 
 // ProviderStatusReporter is an optional provider capability for exposing an
@@ -163,4 +175,18 @@ func NewProviderFromConfig(cfg ProviderConfig) (Provider, error) {
 	default:
 		return nil, fmt.Errorf("unknown provider type: %q", cfg.Type)
 	}
+}
+
+func cloneRawMessages(in []json.RawMessage) []json.RawMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]json.RawMessage, len(in))
+	for i, block := range in {
+		if block == nil {
+			continue
+		}
+		out[i] = append(json.RawMessage(nil), block...)
+	}
+	return out
 }

--- a/cmd/cortex-gateway/internal/proxy/provider_test.go
+++ b/cmd/cortex-gateway/internal/proxy/provider_test.go
@@ -31,6 +31,24 @@ func (m *mockProvider) Send(_ context.Context, _ *LLMRequest) (*LLMResponse, err
 }
 func (m *mockProvider) HealthCheck(_ context.Context) error { return nil }
 
+type streamRecorderProvider struct {
+	name       string
+	lastReq    *LLMRequest
+	streamBody string
+}
+
+func (p *streamRecorderProvider) Name() string { return p.name }
+func (p *streamRecorderProvider) Send(_ context.Context, _ *LLMRequest) (*LLMResponse, error) {
+	return nil, errors.New("unexpected Send call")
+}
+func (p *streamRecorderProvider) HealthCheck(_ context.Context) error { return nil }
+func (p *streamRecorderProvider) StreamHTTP(_ context.Context, req *LLMRequest, w http.ResponseWriter) error {
+	p.lastReq = req
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, err := w.Write([]byte(p.streamBody))
+	return err
+}
+
 type timeoutAwareProvider struct {
 	name  string
 	sleep time.Duration
@@ -590,10 +608,7 @@ func TestClaudeProvider_Send_Integration(t *testing.T) {
 		}
 
 		resp := claudeResponse{
-			Content: []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			}{{Type: "text", Text: "world"}},
+			Content: []json.RawMessage{anthropicTextBlockRaw("world")},
 			Model:      "claude-sonnet-4-5-20250929",
 			StopReason: "end_turn",
 			Usage:      claudeUsage{InputTokens: 10, OutputTokens: 5},
@@ -651,10 +666,7 @@ func TestClaudeProvider_Send_WithStructuredSystemBlocks(t *testing.T) {
 		}
 
 		resp := claudeResponse{
-			Content: []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			}{{Type: "text", Text: "world"}},
+			Content: []json.RawMessage{anthropicTextBlockRaw("world")},
 			Model:      "claude-sonnet-4-5-20250929",
 			StopReason: "end_turn",
 			Usage:      claudeUsage{InputTokens: 10, OutputTokens: 5},
@@ -765,10 +777,7 @@ func TestClaudeProvider_Send_ModelOverride(t *testing.T) {
 		receivedModel = cReq.Model
 
 		resp := claudeResponse{
-			Content: []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			}{{Type: "text", Text: "ok"}},
+			Content: []json.RawMessage{anthropicTextBlockRaw("ok")},
 			Model: cReq.Model,
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -792,6 +801,136 @@ func TestClaudeProvider_Send_ModelOverride(t *testing.T) {
 	}
 	if receivedModel != "override-model" {
 		t.Errorf("expected model override %q, got %q", "override-model", receivedModel)
+	}
+}
+
+func TestClaudeProviderSendPreservesRawContentBlocks(t *testing.T) {
+	var upstreamContent any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		messages, ok := payload["messages"].([]any)
+		if !ok || len(messages) != 1 {
+			t.Fatalf("unexpected messages payload: %#v", payload["messages"])
+		}
+		first, ok := messages[0].(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected first message: %#v", messages[0])
+		}
+		upstreamContent = first["content"]
+
+		resp := claudeResponse{
+			Content: []json.RawMessage{
+				json.RawMessage(`{"type":"thinking","thinking":"chain","signature":"sig"}`),
+				anthropicTextBlockRaw("done"),
+			},
+			Model:      "claude-sonnet-4-5-20250929",
+			StopReason: "end_turn",
+			Usage:      claudeUsage{InputTokens: 10, OutputTokens: 5},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewAnthropicDirectProvider(ProviderConfig{
+		Name:    "anthropic-direct",
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+		Model:   "claude-sonnet-4-5-20250929",
+	})
+
+	resp, err := p.Send(context.Background(), &LLMRequest{
+		Messages: []Message{{
+			Role: "user",
+			ContentBlocks: []json.RawMessage{
+				json.RawMessage(`{"type":"text","text":"hello"}`),
+				json.RawMessage(`{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}`),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	blocks, ok := upstreamContent.([]any)
+	if !ok || len(blocks) != 2 {
+		t.Fatalf("upstream content = %#v, want 2 raw blocks", upstreamContent)
+	}
+	if resp.Content != "done" {
+		t.Fatalf("response content = %q, want done", resp.Content)
+	}
+	if len(resp.ContentBlocks) != 2 {
+		t.Fatalf("response content blocks = %d, want 2", len(resp.ContentBlocks))
+	}
+	if !strings.Contains(string(resp.ContentBlocks[0]), `"thinking"`) {
+		t.Fatalf("expected thinking block, got %s", string(resp.ContentBlocks[0]))
+	}
+}
+
+func TestClaudeProviderStreamHTTPRelaysSSE(t *testing.T) {
+	var gotStream bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode stream request: %v", err)
+		}
+		gotStream, _ = payload["stream"].(bool)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\"}\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewAnthropicDirectProvider(ProviderConfig{
+		Name:    "anthropic-direct",
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+		Model:   "claude-sonnet-4-5-20250929",
+	})
+
+	rec := httptest.NewRecorder()
+	err := p.StreamHTTP(context.Background(), &LLMRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+		Stream:   true,
+	}, rec)
+	if err != nil {
+		t.Fatalf("StreamHTTP() error = %v", err)
+	}
+	if !gotStream {
+		t.Fatal("expected upstream request to set stream=true")
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if !strings.Contains(rec.Body.String(), "message_start") {
+		t.Fatalf("expected SSE payload, got %q", rec.Body.String())
+	}
+}
+
+func TestLLMRequestJSONDoesNotMarshalPassthroughHeaders(t *testing.T) {
+	body, err := json.Marshal(LLMRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+		PassthroughHeaders: map[string]string{
+			"authorization": "Bearer super-secret-token",
+			"x-api-key":     "secret-key",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	encoded := string(body)
+	if strings.Contains(encoded, "super-secret-token") {
+		t.Fatalf("authorization leaked into JSON payload: %s", encoded)
+	}
+	if strings.Contains(encoded, "secret-key") {
+		t.Fatalf("x-api-key leaked into JSON payload: %s", encoded)
 	}
 }
 

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -251,7 +251,10 @@ func main() {
 	// 6. HTTP proxy server
 	proxyMux := http.NewServeMux()
 	proxyMux.Handle("POST /v1/messages", pipelineHandler)
+	// Legacy/internal JSON compatibility path. Prefer /internal/llm for service-to-service calls.
 	proxyMux.Handle("POST /v1/chat/completions", pipelineHandler)
+	// Canonical internal gateway contract for daemon/judge traffic.
+	proxyMux.Handle("POST /internal/llm", pipelineHandler)
 	proxyMux.HandleFunc("GET /health", handleHealth(pipelineHandler, guardrailsEnforcer != nil))
 	proxyMux.HandleFunc("GET /ready", handleReady)
 	proxyMux.Handle("GET /metrics", promhttp.Handler())
@@ -300,6 +303,8 @@ func main() {
 			"synthesis_rate":              costStats.SynthesisRate,
 			"cost_by_provider":            costStats.ByProvider,
 			"primary_provider":            controlConfig.Get().PrimaryProvider,
+			"internal_primary_provider":   controlConfig.Get().PrimaryProvider,
+			"external_mitm_provider":      "anthropic-direct",
 			"intercept_mode":              controlConfig.Get().InterceptMode,
 			"max_forward_concurrency":     controlConfig.Get().MaxForwardConcurrency,
 			"tick_sync_timeout_ms":        controlConfig.Get().TickSyncTimeoutMs,

--- a/dashboard/public/js/control.js
+++ b/dashboard/public/js/control.js
@@ -428,6 +428,8 @@ function renderTrafficControl(container) {
 
   const items = [
     ['Primary Provider', stats.primary_provider ?? '--'],
+    ['Internal Provider', stats.internal_primary_provider ?? stats.primary_provider ?? '--'],
+    ['External MITM Provider', stats.external_mitm_provider ?? '--'],
     ['Kosten heute', formatUSD(stats.current_cost_usd)],
     ['Ersparnis heute', formatUSD(stats.estimated_savings_usd)],
     ['Hochrechnung/Tag Kosten', formatUSD(stats.projected_daily_cost_usd)],

--- a/dashboard/src/__tests__/events.test.ts
+++ b/dashboard/src/__tests__/events.test.ts
@@ -137,6 +137,72 @@ describe("Events Routes", () => {
       expect(body.events.length).toBe(2);
       expect(body.offset).toBe(3);
     });
+
+    it("supports older event schema without compensation_type", async () => {
+      const legacyProj = new Database(":memory:");
+      const legacyEs = new Database(":memory:");
+
+      legacyEs.run(`CREATE TABLE events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        aggregate_id TEXT NOT NULL,
+        payload TEXT NOT NULL DEFAULT '{}',
+        correlation_id TEXT NOT NULL DEFAULT '',
+        causation_id TEXT,
+        tick INTEGER NOT NULL DEFAULT 0,
+        timestamp_ms INTEGER NOT NULL
+      )`);
+
+      legacyProj.run(`CREATE TABLE agent_live_view (
+        agent_id INTEGER PRIMARY KEY,
+        name TEXT, role TEXT, shift_set INTEGER DEFAULT 1,
+        status TEXT DEFAULT 'active', current_room TEXT,
+        in_transit INTEGER DEFAULT 0, transit_target TEXT,
+        last_action TEXT, last_action_tick INTEGER,
+        hunger REAL DEFAULT 0, energy REAL DEFAULT 1,
+        stress REAL DEFAULT 0, bladder REAL DEFAULT 0,
+        social_need REAL DEFAULT 0, caffeine_mg REAL DEFAULT 0,
+        mood TEXT, last_event_id INTEGER DEFAULT 0, updated_at INTEGER DEFAULT 0
+      )`);
+      legacyProj.run(`CREATE TABLE room_live_view (
+        room_id TEXT PRIMARY KEY,
+        occupant_count INTEGER DEFAULT 0, transit_count INTEGER DEFAULT 0,
+        active_chaos TEXT, active_smells TEXT, temperature REAL, co2_ppm REAL, noise_db REAL,
+        last_event_tick INTEGER, last_event_id INTEGER DEFAULT 0, updated_at INTEGER DEFAULT 0
+      )`);
+      legacyProj.run(`CREATE TABLE kpi_1m (
+        bucket_start INTEGER PRIMARY KEY,
+        active_agents INTEGER DEFAULT 0, total_actions INTEGER DEFAULT 0,
+        total_transits INTEGER DEFAULT 0, chaos_events INTEGER DEFAULT 0,
+        tick_count INTEGER DEFAULT 0, shift_changes INTEGER DEFAULT 0,
+        nightrun_events INTEGER DEFAULT 0, last_event_id INTEGER DEFAULT 0,
+        updated_at INTEGER DEFAULT 0
+      )`);
+      legacyProj.run(`CREATE TABLE projection_offsets (
+        projection_name TEXT PRIMARY KEY,
+        last_event_id INTEGER DEFAULT 0
+      )`);
+
+      const insert = legacyEs.prepare(
+        `INSERT INTO events (event_id, event_type, aggregate_id, payload, tick, timestamp_ms)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      );
+      insert.run("legacy-1", "chaos_triggered", "buero-dev-1", '{"event_type":"PhoneRing"}', 100, Date.now() - 1000);
+
+      setDatabases(legacyProj, legacyEs);
+      try {
+        const res = await app.request("/api/events");
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.events.length).toBe(1);
+        expect(body.events[0].compensation_type).toBe("none");
+      } finally {
+        setDatabases(projDb, esDb);
+        legacyProj.close();
+        legacyEs.close();
+      }
+    });
   });
 
   describe("GET /api/events/types", () => {

--- a/dashboard/src/db.ts
+++ b/dashboard/src/db.ts
@@ -18,6 +18,7 @@ import type {
 let projectionDb: Database;
 let eventStoreDb: Database;
 export const ROOM_REACTION_WINDOW_TICKS = 60;
+let _eventColumnsCache: Set<string> | null = null;
 
 interface ProjectedRoomOccupants {
   [roomId: string]: {
@@ -36,6 +37,7 @@ interface StoredEventRow {
 }
 
 export function resetCaches(): void {
+  _eventColumnsCache = null;
   _agentNameCache = null;
   _agentNameCacheTime = 0;
 }
@@ -131,6 +133,31 @@ function normalizeAgentId(rawAgentId: unknown, fallback: string): {
     agentId,
     numericId: match ? parseInt(match[1], 10) : null,
   };
+}
+
+function getEventColumnSet(): Set<string> {
+  if (_eventColumnsCache) {
+    return _eventColumnsCache;
+  }
+
+  try {
+    const rows = eventStoreDb
+      .query<{ name: string }, []>("PRAGMA table_info(events)")
+      .all();
+    _eventColumnsCache = new Set(rows.map((row) => String(row.name)));
+  } catch {
+    _eventColumnsCache = new Set();
+  }
+  return _eventColumnsCache;
+}
+
+export function eventRowSelectColumns(): string {
+  const base =
+    "id, event_id, event_type, aggregate_id, payload, correlation_id, causation_id, tick, timestamp_ms";
+  if (getEventColumnSet().has("compensation_type")) {
+    return `${base}, compensation_type`;
+  }
+  return `${base}, 'none' AS compensation_type`;
 }
 
 // ── Agent Queries ────────────────────────────────
@@ -638,8 +665,7 @@ export function getRecentIncidentEvents(hours: number, limit = 200): EventRow[] 
   const cutoff = Date.now() - hours * 3600_000;
   return eventStoreDb
     .query<EventRow, [number, number]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE event_type IN (${INCIDENT_TYPES_SQL})
          AND timestamp_ms > ?
@@ -671,8 +697,7 @@ export function getRecentEvolutionAlerts(hours: number): EvolutionRow[] {
 export function getEventsByCorrelation(correlationId: string): EventRow[] {
   return eventStoreDb
     .query<EventRow, [string]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE correlation_id = ?
        ORDER BY id ASC`,
@@ -683,8 +708,7 @@ export function getEventsByCorrelation(correlationId: string): EventRow[] {
 export function getEventsByCausation(eventId: string): EventRow[] {
   return eventStoreDb
     .query<EventRow, [string]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE causation_id = ?
        ORDER BY id ASC`,
@@ -702,8 +726,7 @@ export function getEventsNearby(
 ): EventRow[] {
   return eventStoreDb
     .query<EventRow, [number, number, string, number]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE tick BETWEEN ? AND ?
          AND event_type = 'agent_action_received'
@@ -717,8 +740,7 @@ export function getEventsNearby(
 export function getEventById(eventId: string): EventRow | null {
   return eventStoreDb
     .query<EventRow, [string]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE event_id = ?`,
     )
@@ -1104,8 +1126,7 @@ const ACTIVITY_TYPES_SQL = ACTIVITY_EVENT_TYPES.map((t) => `'${t}'`).join(",");
 export function getRecentActivityEvents(limit = 200): EventRow[] {
   return eventStoreDb
     .query<EventRow, [number]>(
-      `SELECT id, event_id, event_type, aggregate_id, payload,
-              correlation_id, causation_id, tick, timestamp_ms, compensation_type
+      `SELECT ${eventRowSelectColumns()}
        FROM events
        WHERE event_type IN (${ACTIVITY_TYPES_SQL})
        ORDER BY id DESC

--- a/dashboard/src/routes/cockpit.test.ts
+++ b/dashboard/src/routes/cockpit.test.ts
@@ -135,6 +135,35 @@ function seedEvents(db: Database): void {
   );
 }
 
+function seedLegacyEvents(db: Database): void {
+  const insert = db.prepare(`
+    INSERT INTO events (event_id, event_type, aggregate_id, payload,
+                        correlation_id, causation_id, operation_id,
+                        tick, timestamp_ms)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  insert.run(
+    "evt-chaos-legacy", "chaos_triggered", "buero-dev-1",
+    JSON.stringify({
+      type: "power_outage",
+      target_room: "buero-dev-1",
+      description: "Legacy Stromausfall",
+    }),
+    "cor-legacy", null, "op-legacy-1", 9000, now - 120_000,
+  );
+
+  insert.run(
+    "evt-action-legacy", "transit_started", "AGENT-03",
+    JSON.stringify({
+      from_room: "buero-dev-1",
+      to_room: "kueche-eg",
+      duration_ms: 5000,
+    }),
+    "cor-legacy", "evt-chaos-legacy", "op-legacy-2", 9001, now - 110_000,
+  );
+}
+
 function seedEvolution(db: Database): void {
   const insert = db.prepare(`
     INSERT INTO personality_evolution (agent_id, tick, field, change_type,
@@ -328,5 +357,46 @@ describe("empty database", () => {
 
     emptyEs.close();
     emptyProj.close();
+  });
+
+  test("supports older event schema without compensation_type", async () => {
+    const legacyEs = new Database(":memory:");
+    const legacyProj = new Database(":memory:");
+    legacyEs.exec(`
+      CREATE TABLE events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id TEXT NOT NULL UNIQUE,
+        event_type TEXT NOT NULL,
+        aggregate_id TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        correlation_id TEXT NOT NULL,
+        causation_id TEXT,
+        operation_id TEXT NOT NULL UNIQUE,
+        tick INTEGER NOT NULL,
+        timestamp_ms INTEGER NOT NULL,
+        schema_version INTEGER DEFAULT 1
+      );
+      CREATE INDEX idx_events_type ON events(event_type, id);
+      CREATE INDEX idx_events_correlation ON events(correlation_id);
+    `);
+    legacyEs.exec(EVOLUTION_SCHEMA);
+    legacyProj.exec(PROJECTION_SCHEMA);
+
+    seedLegacyEvents(legacyEs);
+    seedProjection(legacyProj);
+    setDatabases(legacyProj, legacyEs);
+
+    try {
+      const res = await app.request("/api/cockpit");
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(Array.isArray(data.incidents)).toBe(true);
+      expect(data.incidents.length).toBeGreaterThan(0);
+    } finally {
+      setDatabases(projDb, esDb);
+      legacyEs.close();
+      legacyProj.close();
+    }
   });
 });

--- a/dashboard/src/routes/events.ts
+++ b/dashboard/src/routes/events.ts
@@ -2,7 +2,7 @@
 // Unterstuetzt Typ-Filter, Agent-Filter, Limit und Offset.
 
 import { Hono } from "hono";
-import { getEventStoreDb } from "../db";
+import { eventRowSelectColumns, getEventStoreDb } from "../db";
 import type { EventRow } from "../types";
 
 export const eventRoutes = new Hono();
@@ -52,8 +52,7 @@ eventRoutes.get("/events", (c) => {
   const whereClause =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-  const query = `SELECT id, event_id, event_type, aggregate_id, payload,
-                        correlation_id, causation_id, tick, timestamp_ms, compensation_type
+  const query = `SELECT ${eventRowSelectColumns()}
                  FROM events
                  ${whereClause}
                  ORDER BY id DESC

--- a/scripts/mitm-smoke.sh
+++ b/scripts/mitm-smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+FAKE_PORT="${FAKE_ANTHROPIC_PORT:-19876}"
+GATEWAY_PORT="${MITM_GATEWAY_PORT:-18080}"
+CONTROL_PORT="${MITM_CONTROL_PORT:-18081}"
+CLAUDE_PROMPT="${CLAUDE_PROMPT:-Antworte exakt mit HALLO.}"
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "${GATEWAY_PID:-}" ]]; then
+    kill "${GATEWAY_PID}" 2>/dev/null || true
+    wait "${GATEWAY_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${FAKE_PID:-}" ]]; then
+    kill "${FAKE_PID}" 2>/dev/null || true
+    wait "${FAKE_PID}" 2>/dev/null || true
+  fi
+  if [[ "${KEEP_MITM_TMP:-0}" == "1" ]]; then
+    echo "Temporary MITM smoke artifacts kept in ${TMP_DIR}" >&2
+  else
+    rm -rf "${TMP_DIR}"
+  fi
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+
+for bin in go python3 claude curl; do
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    echo "missing required binary: ${bin}" >&2
+    exit 1
+  fi
+done
+
+pushd "${ROOT}" >/dev/null
+
+echo "[1/5] Building cortex-gateway"
+go build -o "${TMP_DIR}/cortex-gateway" ./cmd/cortex-gateway
+
+echo "[2/5] Starting fake Anthropic upstream on :${FAKE_PORT}"
+FAKE_ANTHROPIC_PORT="${FAKE_PORT}" \
+FAKE_ANTHROPIC_TEXT="HALLO." \
+python3 -u "${ROOT}/test-fake-api.py" >"${TMP_DIR}/fake.log" 2>&1 &
+FAKE_PID=$!
+
+echo "[3/5] Starting local gateway on :${GATEWAY_PORT}"
+CORTEX_PORT="${GATEWAY_PORT}" \
+CORTEX_CONTROL_PORT="${CONTROL_PORT}" \
+ANTHROPIC_BASE_URL="http://127.0.0.1:${FAKE_PORT}" \
+"${TMP_DIR}/cortex-gateway" >"${TMP_DIR}/gateway.log" 2>&1 &
+GATEWAY_PID=$!
+
+for _ in {1..40}; do
+  if curl -fsS "http://127.0.0.1:${GATEWAY_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+curl -fsS "http://127.0.0.1:${GATEWAY_PORT}/health" >/dev/null
+
+echo "[4/5] Running claude -p against gateway"
+CLAUDE_OUTPUT="$(
+  ANTHROPIC_BASE_URL="http://127.0.0.1:${GATEWAY_PORT}" \
+  NO_PROXY="127.0.0.1,localhost" \
+  claude -p "${CLAUDE_PROMPT}" --output-format json
+)"
+echo "${CLAUDE_OUTPUT}" >"${TMP_DIR}/claude.json"
+
+echo "[5/5] Verifying MITM path"
+grep -q "POST /v1/messages" "${TMP_DIR}/fake.log"
+grep -Eq 'provider.?anthropic-direct|anthropic-direct' "${TMP_DIR}/gateway.log"
+grep -q 'HALLO' "${TMP_DIR}/claude.json"
+
+echo "MITM smoke test passed"
+if [[ "${KEEP_MITM_TMP:-0}" == "1" ]]; then
+  echo "Logs:"
+  echo "  fake:    ${TMP_DIR}/fake.log"
+  echo "  gateway: ${TMP_DIR}/gateway.log"
+  echo "  claude:  ${TMP_DIR}/claude.json"
+else
+  echo "Set KEEP_MITM_TMP=1 to keep fake/gateway/claude logs."
+fi
+
+popd >/dev/null

--- a/services/sentinel-daemon/src/llm_bridge.rs
+++ b/services/sentinel-daemon/src/llm_bridge.rs
@@ -296,7 +296,7 @@ pub mod bridge {
                     "LLM call triggered");
 
                 let client = client.clone();
-                let url = format!("{}/v1/chat/completions", config.gateway_url);
+                let url = format!("{}/internal/llm", config.gateway_url);
                 let action_tx = action_tx.clone();
                 let telemetry = Arc::clone(&telemetry);
                 let cb = Arc::clone(&circuit_breaker);

--- a/services/sentinel-judge/internal/gateway/client.go
+++ b/services/sentinel-judge/internal/gateway/client.go
@@ -87,8 +87,10 @@ func (c *Client) Chat(ctx context.Context, systemPrompt, userPrompt string) (str
 		return "", fmt.Errorf("gateway marshal: %w", err)
 	}
 
+	// Judge traffic uses the internal gateway contract and must not be routed
+	// through the public Anthropic-compatible MITM endpoint.
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		c.baseURL+"/v1/chat/completions", bytes.NewReader(body))
+		c.baseURL+"/internal/llm", bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("gateway new request: %w", err)
 	}

--- a/services/sentinel-judge/internal/gateway/client_test.go
+++ b/services/sentinel-judge/internal/gateway/client_test.go
@@ -14,7 +14,7 @@ func TestClientChat(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/v1/chat/completions" {
+		if r.URL.Path != "/internal/llm" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 

--- a/test-fake-api.py
+++ b/test-fake-api.py
@@ -1,6 +1,6 @@
 """Fake Anthropic API Endpoint — testet ob claude -p synthetisierte Responses akzeptiert."""
 import json
-import time
+import os
 import uuid
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
@@ -49,7 +49,10 @@ class FakeAnthropicHandler(BaseHTTPRequestHandler):
             "content": [
                 {
                     "type": "text",
-                    "text": "Morgen wird es in Wien voraussichtlich sonnig mit Temperaturen um die 18 Grad, ideal fuer einen Spaziergang im Prater."
+                    "text": os.environ.get(
+                        "FAKE_ANTHROPIC_TEXT",
+                        "Morgen wird es in Wien voraussichtlich sonnig mit Temperaturen um die 18 Grad, ideal fuer einen Spaziergang im Prater."
+                    )
                 }
             ],
             "model": req.get("model", "claude-opus-4-6"),
@@ -84,7 +87,7 @@ class FakeAnthropicHandler(BaseHTTPRequestHandler):
         pass  # Suppress default logging
 
 if __name__ == '__main__':
-    port = 19876
+    port = int(os.environ.get("FAKE_ANTHROPIC_PORT", "19876"))
     server = HTTPServer(('127.0.0.1', port), FakeAnthropicHandler)
     print(f"Fake Anthropic API listening on http://127.0.0.1:{port}")
     print(f"Route claude with: ANTHROPIC_BASE_URL=http://127.0.0.1:{port}")


### PR DESCRIPTION
## Summary
Completes the verified `#296` MITM follow-ups by tightening the external MITM contract, moving internal traffic onto `/internal/llm`, and preserving the already-verified VM behavior.

## Changes
- fix dashboard/schema compatibility for the cockpit path
- add raw Anthropic content-block and streaming support on `/v1/messages`
- split provider observability into `internal_primary_provider` and `external_mitm_provider`
- move daemon and judge traffic onto `/internal/llm`
- add repeatable MITM smoke tooling and redaction checks

## Linked Issues
- Closes #296

## Test Plan
- `bun test dashboard/src/routes/cockpit.test.ts dashboard/src/__tests__/events.test.ts`
- `go test ./cmd/cortex-gateway/internal/... ./services/sentinel-judge/internal/...`
- `cargo remote -c -- test -p sentinel-daemon`
- `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
- VM deploy of `cortex-gateway`, `sentinel-daemon`, `sentinel-judge`
- VM checks for `/api/cockpit`, `/control/traffic-stats`, `/internal/llm`, `Voice of Gaia`, redaction, and isolated `/v1/messages -> anthropic-direct -> fake upstream`

## Benchmarks
- no new dedicated performance budget in `#296`
- verified no panic/drift regression on the VM after deploy

## Evidence (AC Mapping)
| AC | Evidence | Result |
| --- | --- | --- |
| AC-1 | `bun test dashboard/src/routes/cockpit.test.ts dashboard/src/__tests__/events.test.ts` plus `curl -s localhost:8000/api/cockpit` | PASS |
| AC-2 | `go test ./cmd/cortex-gateway/internal/... ./services/sentinel-judge/internal/...` and VM `/v1/messages` smoke with raw Anthropic blocks | PASS |
| AC-3 | `curl -s localhost:8081/control/traffic-stats` exposed `internal_primary_provider=claude-code` and `external_mitm_provider=anthropic-direct` | PASS |
| AC-4 | `curl -s -X POST localhost:8080/internal/llm ...` and gateway journal showed `HR:0` synthesis / `HR:1` forward attempts on `claude-code` | PASS |
| AC-5 | `curl -s -X POST localhost:8084/operator/gaia ...` plus daemon journal and event-store transit evidence | PASS |
| AC-6 | redaction grep plus isolated fake-upstream smoke on the VM | PASS |

```bash
bun test dashboard/src/routes/cockpit.test.ts dashboard/src/__tests__/events.test.ts
go test ./cmd/cortex-gateway/internal/... ./services/sentinel-judge/internal/...
cargo remote -c -- test -p sentinel-daemon
cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings
ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-stats"
ssh ubuntu@10.0.0.240 "curl -s -X POST localhost:8080/internal/llm -H 'content-type: application/json' -d @/tmp/internal-llm-check.json"
```

## Checklist
- [x] code written
- [x] relevant tests green
- [x] clippy green where applicable
- [x] runtime artifacts deployed
- [x] runtime evidence captured on the VM
- [x] changelog updated
