### PR TITLE
fix: close verified room chat forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Room-Chat-Forwarding: `heard_text` bleibt bei Gateway-Fehlern bis zur Bridge erhalten** (#282)
+  - urgenter Room-Chat (`heard_text`, direkte Ansprache, Gaia) wird im Daemon jetzt bei offenem Circuit, `429/503`, Parse-Fehlern und Request-Timeouts fuer Retry gepuffert statt verloren zu gehen
+  - dadurch bleibt der Pfad `Operator-Chat -> RoomChatBuffer -> heard_text -> LLM bridge has_heard=true` auch unter Upstream-Fehlern live nachweisbar
+  - gezielte Regressionstests fuer Retry-Eligibility im LLM-Bridge-Modul wurden nachgezogen
+
 - **MITM Follow-ups: Dashboard-Legacy-Schema, Anthropic-Streaming/Blocks, Observability, Redaction** (#296)
   - Dashboard-Queries waehlen Event-Spalten jetzt schema-robust, so dass lokale DBs ohne `compensation_type` weder `cockpit` noch `events` brechen
   - Gateway erhaelt rohe Anthropic-Content-Blocks ueber `/v1/messages`, beantwortet SSE-Streaming direkt und behaelt den Anthropic-Wire-Shape bei

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,7 +17,7 @@
 - `#296` ist jetzt formal geschlossen; Dashboard-/Streaming-/Observability-/Redaction-Follow-ups sind verifiziert und nicht mehr mit der frueheren Parity-Luecke vermischt.
 - `#289` ist jetzt formal geschlossen; `status:verified` ist gesetzt, `status:triage` und `quality:needs-spec` sind entfernt.
 - `#298` ist jetzt formal geschlossen; `/v1/messages`, request-scoped Anthropic-Passthrough, path-spezifische Anthropic-Responses und die zugehoerigen Smoke-Tests sind wiederhergestellt.
-- `#282` ist jetzt formal geschlossen; die historische Auto-Reopen-Lage wurde mit frischer VM-Evidence und `status:verified` bereinigt.
+- `#282` ist jetzt formal geschlossen; die historische Auto-Reopen-Situation wurde mit frischer VM-Evidence und `status:verified` bereinigt.
 - Der aktuelle Closure-/Parity-Stand ist jetzt auf GitHub publiziert:
   Draft-PR `#299` von `feat/issue-289-room-phase2-closure` nach `main`.
 - Der alte PR `#297` von `fix/issue-296-mitm-followups` ist jetzt geschlossen und explizit als superseded markiert.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,7 +5,7 @@
 - Plan source: `User-Freigabe: PR-Stack #299/#300/#301 mergen, danach Vollbetriebs-/Soak-Test, alles nach $start`
 - Overall status: `IN_PROGRESS`
 - Current task: `Task 3 - PR-Stack #299 -> #300 -> #301 freigeben und mergen`
-- Current branch: `feat/issue-296-mitm-followups-clean`
+- Current branch: `feat/issue-282-room-chat-forwarding`
 - Pull policy: `Kein Pull von main in den aktuellen Branch ohne explizite User-Freigabe`
 - Last refresh: `2026-04-03`
 
@@ -14,12 +14,15 @@
 - GitHub `origin/main` stand zu Task-Start auf `4e69d4f`; der historische MITM-Vertrag aus `e4f8769` ist jetzt wieder im aktuellen Gateway-Code und auf der VM deployed.
 - `#288` ist formal geschlossen; `status:verified` ist gesetzt und der Close-Kommentar grenzt die getrennte Parity-Luecke sauber ab.
 - `#295` ist formal geschlossen; `status:verified` ist gesetzt und der Close-Kommentar verweist korrekt auf den provider-unabhaengigen `baseGate`-/`heard`-Fix.
-- `#296` bleibt offen als echtes Follow-up fuer Dashboard/Streaming/Blocks/Observability/Redaction; die Parity-Luecke liegt separat in `#298`.
+- `#296` ist jetzt formal geschlossen; Dashboard-/Streaming-/Observability-/Redaction-Follow-ups sind verifiziert und nicht mehr mit der frueheren Parity-Luecke vermischt.
 - `#289` ist jetzt formal geschlossen; `status:verified` ist gesetzt, `status:triage` und `quality:needs-spec` sind entfernt.
 - `#298` ist jetzt formal geschlossen; `/v1/messages`, request-scoped Anthropic-Passthrough, path-spezifische Anthropic-Responses und die zugehoerigen Smoke-Tests sind wiederhergestellt.
+- `#282` ist jetzt formal geschlossen; die historische Auto-Reopen-Lage wurde mit frischer VM-Evidence und `status:verified` bereinigt.
 - Der aktuelle Closure-/Parity-Stand ist jetzt auf GitHub publiziert:
   Draft-PR `#299` von `feat/issue-289-room-phase2-closure` nach `main`.
 - Der alte PR `#297` von `fix/issue-296-mitm-followups` ist jetzt geschlossen und explizit als superseded markiert.
+- Der neue `#296`-Arbeitsbranch ist jetzt `feat/issue-296-mitm-followups-clean` und zeigt exakt auf den publizierten Basis-Commit `fb019f0`.
+- Auf `#282` gab es nach dem ersten Live-Test einen echten Runtime-Gap: `heard_text` wurde im ECS korrekt erzeugt, aber bei Gateway-Fehlern vor dem Bridge-Retry verloren. Das ist jetzt im Daemon gefixt und live nachverifiziert.
 - TOGAF und lokale Artefakte sind auf den verifizierten Room-Phase-2-Stand angeglichen: realistische Transit-Zeiten `15s-120s`, Transit-Perception mit Zwischen-Raum und adaptiver Heartbeat ohne separaten Async-Task.
 - Alle drei Stack-PRs sind Stand Task-Start noch `DRAFT` und nicht mergebar.
 - Gemeinsamer harter Merge-Blocker: PR-Lint verlangt Conventional-Commit-Titel fuer `#299`, `#300` und `#301`.
@@ -220,6 +223,67 @@
     - `tail /tmp/gateway296.log`
       -> `pipeline request completed","provider":"anthropic-direct"`
   - Damit ist der komplette `/v1/messages -> anthropic-direct -> upstream`-Pfad fuer die aktuelle Binary auf der VM belegt, unabhaengig vom blockierten `claude -p`-Prozess.
+
+## Task 4 evidence summary
+
+- Erster Live-Befund auf `#282`:
+  - `POST /operator/chat` wurde im ECS korrekt gehoert, aber der spaetere Bridge-Log lief fuer denselben Room-Chat noch mit `has_heard=false`
+  - Ursache: urgente Perceptions (`heard_text`, direkte Ansprache, Gaia) wurden bei Circuit-Open bzw. `429/503` im Daemon nicht fuer Retry behalten
+
+- Umgesetzter Fix:
+  - `services/sentinel-daemon/src/llm_bridge.rs`
+  - neuer Retry-Puffer fuer urgente Perceptions bei Circuit-Open, Semaphore-Timeout, HTTP-Fehlern, Parse-Fehlern und Request-Fehlern
+  - bestehende Priorisierung `insert_prefer_heard()` merged Retry-State und neue Perceptions desselben Agents weiterhin deterministisch
+
+- Gezielte Regressionen gruen:
+  - `cargo remote -c -- test -p sentinel-daemon insert_prefer_heard -- --nocapture`
+    -> `3` Tests PASS
+  - `cargo remote -c -- test -p sentinel-daemon should_retry_perception -- --nocapture`
+    -> PASS
+  - `cargo remote -c -- test -p sentinel-ecs get_recent_empty_after_set_heard -- --nocapture`
+    -> PASS
+  - `cargo remote -c -- test -p sentinel-ecs new_chat_visible_after_set_heard -- --nocapture`
+    -> PASS
+  - `cargo remote -c -- test -p sentinel-daemon build_gateway_request_formats_perception_for_gateway_compiler -- --nocapture`
+    -> PASS
+  - `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
+    -> PASS
+
+- VM-Deploy:
+  - `systemctl cat sentinel-daemon | grep ExecStart`
+    -> `/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`
+  - neues Release-Binary nach `/opt/sentinel/bin/sentinel-daemon` kopiert und Dienst neu gestartet
+  - `systemctl is-active sentinel-daemon`
+    -> `active`
+
+- Live-Evidence nach Deploy:
+  - Raumbelegung:
+    `curl -s localhost:8000/api/agents | ... current_room == buero-dev-1`
+    -> `ROOM_COUNT 5` (`Andreas Wolff`, `Julia Neumann`, `Kai Fischer`, `Lena Hoffmann`, `Hannah Meier`)
+  - Operator-Chat:
+    `POST localhost:8084/operator/chat`
+    -> `{"accepted":true,"message":"Chat in RoomChatBuffer eingefuegt"}`
+  - ECS-Wahrnehmung:
+    `journalctl -u sentinel-daemon --since '2026-04-03 13:56:10' ...`
+    -> `Operator-Chat in RoomChatBuffer eingefuegt`
+    -> `output_system: heard_text gefunden` fuer alle `5` aktuellen Agents in `buero-dev-1`
+  - Bridge-/Retry-Nachweis:
+    derselbe Journal-Ausschnitt zeigt danach wiederholt `LLM call triggered ... has_heard=true` fuer die Live-Raumbesetzung (`AGENT-05`, `AGENT-06`, `AGENT-07`, `AGENT-08`, `AGENT-15`)
+    -> Room-Chat bleibt jetzt bis zur Bridge erhalten, auch wenn der Upstream weiter `429/503` liefert
+  - Error-Level:
+    `journalctl -u sentinel-daemon --since '5 min ago' -p err --no-pager`
+    und
+    `journalctl _PID=$(pgrep cortex-gate) --since '5 min ago' -p err --no-pager`
+    -> jeweils `-- No entries --`
+  - Event-Store:
+    `sqlite3 /opt/sentinel/data/events.db "SELECT event_type, COUNT(*) ... last 60s ..."`
+    -> nur bestehende Event-Typen (`bio_state_updated`, `room_physics_updated`, `judge_alert_received`, `agent_action_received`, `hallway_encounter_detected`, `tick_snapshot`, `transit_started`), keine neue Room-Chat-spezifische Disk-Event-Klasse
+
+- Formale GitHub-Abschluss-Schritte:
+  - Kommentar mit kompletter Evidence auf `#282` hinterlegt
+  - `gh issue edit 282 --repo silentspike/project-sentinel --add-label status:verified --remove-label status:backlog`
+  - `gh issue close 282 --repo silentspike/project-sentinel`
+  - Ergebnis: `#282` ist `CLOSED`
 
 ## Task 6 evidence summary
 

--- a/services/sentinel-daemon/src/llm_bridge.rs
+++ b/services/sentinel-daemon/src/llm_bridge.rs
@@ -19,7 +19,7 @@ pub mod bridge {
     use std::time::{Duration, Instant};
 
     use serde::{Deserialize, Serialize};
-    use tokio::sync::Semaphore;
+    use tokio::sync::{Mutex as AsyncMutex, Semaphore};
     use tracing::{debug, error, info, instrument, warn};
 
     use sentinel_common::{ActionType, AgentAction, AgentId, Perception, Tick, Timestamp};
@@ -202,6 +202,7 @@ pub mod bridge {
             config.circuit_breaker_threshold,
             config.circuit_breaker_reset,
         )));
+        let pending_retries = Arc::new(AsyncMutex::new(HashMap::<AgentId, Perception>::new()));
         let mut last_call_tick: HashMap<AgentId, u64> = HashMap::new();
         // Debounce: Operator-Impulse (Gaia/Broadcast) nur beim ERSTEN Tick urgent,
         // danach 60 Ticks Cooldown. Verhindert Semaphore-Starvation bei 300-Tick TTL.
@@ -224,7 +225,10 @@ pub mod bridge {
         while let Some(first) = async_rx.recv().await {
             // Drain: Alle sofort verfuegbaren Perceptions lesen.
             // Pro Agent: neueste behalten, heard_text bevorzugen.
-            let mut batch: HashMap<AgentId, Perception> = HashMap::new();
+            let mut batch: HashMap<AgentId, Perception> = {
+                let mut pending = pending_retries.lock().await;
+                std::mem::take(&mut *pending)
+            };
             insert_prefer_heard(&mut batch, first);
             while let Ok(p) = async_rx.try_recv() {
                 insert_prefer_heard(&mut batch, p);
@@ -277,6 +281,9 @@ pub mod bridge {
                     telemetry
                         .calls_skipped_circuit_open
                         .fetch_add(1, Ordering::Relaxed);
+                    if should_retry_perception(&perception) {
+                        queue_retry(&pending_retries, perception).await;
+                    }
                     continue;
                 }
 
@@ -300,6 +307,8 @@ pub mod bridge {
                 let action_tx = action_tx.clone();
                 let telemetry = Arc::clone(&telemetry);
                 let cb = Arc::clone(&circuit_breaker);
+                let retry_queue = Arc::clone(&pending_retries);
+                let retry_perception = perception.clone();
                 let request = build_gateway_request(&perception, &state_store);
 
                 telemetry.calls_total.fetch_add(1, Ordering::Relaxed);
@@ -321,6 +330,7 @@ pub mod bridge {
                             Ok(Ok(permit)) => permit,
                             Ok(Err(_)) => {
                                 warn!(agent = %agent_id, "URGENT Semaphore closed");
+                                queue_retry(&retry_queue, retry_perception.clone()).await;
                                 return;
                             }
                             Err(_) => {
@@ -329,6 +339,7 @@ pub mod bridge {
                                     timeout_ms = acquire_timeout.as_millis(),
                                     "URGENT Semaphore timeout"
                                 );
+                                queue_retry(&retry_queue, retry_perception.clone()).await;
                                 return;
                             }
                         };
@@ -372,12 +383,15 @@ pub mod bridge {
                                             warn!(agent = %agent_id, error = %e, "Gateway Response Parse-Fehler");
                                             telemetry.calls_failed.fetch_add(1, Ordering::Relaxed);
                                             cb.lock().unwrap().record_failure();
+                                            queue_retry(&retry_queue, retry_perception.clone())
+                                                .await;
                                         }
                                     }
                                 } else {
                                     warn!(agent = %agent_id, status = status.as_u16(), "Gateway HTTP Fehler");
                                     telemetry.calls_failed.fetch_add(1, Ordering::Relaxed);
                                     cb.lock().unwrap().record_failure();
+                                    queue_retry(&retry_queue, retry_perception.clone()).await;
                                 }
                             }
                             Err(e) => {
@@ -385,6 +399,7 @@ pub mod bridge {
                                 warn!(agent = %agent_id, error = %e, is_timeout = is_timeout, "Gateway Request fehlgeschlagen");
                                 telemetry.calls_failed.fetch_add(1, Ordering::Relaxed);
                                 cb.lock().unwrap().record_failure();
+                                queue_retry(&retry_queue, retry_perception.clone()).await;
                             }
                         }
                         drop(permit);
@@ -483,6 +498,24 @@ pub mod bridge {
                 }
             })
             .or_insert(p);
+    }
+
+    fn should_retry_perception(perception: &Perception) -> bool {
+        !perception.heard_text.is_empty()
+            || perception.is_directly_addressed
+            || perception.has_operator_impulse
+    }
+
+    async fn queue_retry(
+        queue: &Arc<AsyncMutex<HashMap<AgentId, Perception>>>,
+        perception: Perception,
+    ) {
+        if !should_retry_perception(&perception) {
+            return;
+        }
+
+        let mut pending = queue.lock().await;
+        insert_prefer_heard(&mut pending, perception);
     }
 
     /// Baut den Gateway-Request aus einer Perception + Evolution-Daten aus redb.
@@ -830,6 +863,18 @@ pub mod bridge {
                 merged.heard_text, "Besucher sagte: Hallo",
                 "heard_text darf nicht durch leere Perception ueberschrieben werden"
             );
+        }
+
+        #[test]
+        fn should_retry_perception_for_room_chat() {
+            let perception = make_perception(21, "Besucher sagte: Hallo", false);
+            assert!(should_retry_perception(&perception));
+        }
+
+        #[test]
+        fn should_not_retry_plain_heartbeat() {
+            let perception = make_perception(22, "", false);
+            assert!(!should_retry_perception(&perception));
         }
     }
 }


### PR DESCRIPTION
## Summary
Closes the lingering `#282` room-chat-forwarding gap by preserving urgent room-chat perceptions through bridge retries and re-verifying the live operator-chat path on the VM.

## Changes
- keep urgent `heard_text`, direct-address and Gaia perceptions queued for retry when the bridge sees circuit-open, semaphore pressure, request errors or `429/503`
- preserve deterministic preference for `heard_text` while merging retry state and new perceptions
- re-document the verified VM path from `/operator/chat` through ECS output to the daemon bridge

## Linked Issues
- Closes #282

## Test Plan
- `cargo remote -c -- test -p sentinel-ecs get_recent_empty_after_set_heard -- --nocapture`
- `cargo remote -c -- test -p sentinel-ecs new_chat_visible_after_set_heard -- --nocapture`
- `cargo remote -c -- test -p sentinel-daemon build_gateway_request_formats_perception_for_gateway_compiler -- --nocapture`
- `cargo remote -c -- test -p sentinel-daemon insert_prefer_heard -- --nocapture`
- `cargo remote -c -- test -p sentinel-daemon should_retry_perception -- --nocapture`
- `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
- VM runtime verification on `10.0.0.240` via `/operator/chat`, daemon logs, and event store

## Benchmarks
- no new benchmark budget in `#282`
- verified no panic/drift regression during the live retry test window

## Evidence (AC Mapping)
| AC | Evidence | Result |
| --- | --- | --- |
| AC-1 | `POST /operator/chat` returned `accepted=true` and daemon logs showed room-chat ingestion into `RoomChatBuffer` | PASS |
| AC-2 | `output_system: heard_text gefunden` appeared for all current room occupants in `buero-dev-1` | PASS |
| AC-3 | daemon journal showed repeated `LLM call triggered ... has_heard=true` for the live room occupants despite upstream `429/503` pressure | PASS |
| AC-4 | `journalctl -u sentinel-daemon -p err --since '5 min ago'` and gateway error-level log check stayed empty | PASS |

```bash
cargo remote -c -- test -p sentinel-daemon insert_prefer_heard -- --nocapture
cargo remote -c -- test -p sentinel-daemon should_retry_perception -- --nocapture
cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings
ssh ubuntu@10.0.0.240 "curl -s -X POST localhost:8084/operator/chat -H 'Content-Type: application/json' -d '{\"room_id\":\"buero-dev-1\",\"message\":\"Andreas, Julia, gebt mir bitte ein kurzes Update.\",\"sender_name\":\"Besucher\"}'"
ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '2 min ago' --no-pager"
```

## Checklist
- [x] code written
- [x] targeted remote tests green
- [x] clippy green where applicable
- [x] runtime artifact deployed
- [x] runtime evidence captured on the VM
- [x] changelog updated

