### PR TITLE
[codex] deps: refresh cargo lock for pending dependency bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aya"
 version = "0.13.2"
-source = "git+https://github.com/aya-rs/aya#c42157f0b566940b849b699109d1c660a0733fd3"
+source = "git+https://github.com/aya-rs/aya#b93ee8c26e96af85d77b040fa4fae8447c8fd7f8"
 dependencies = [
  "assert_matches",
  "aya-obj",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "aya-log"
 version = "0.2.2"
-source = "git+https://github.com/aya-rs/aya#c42157f0b566940b849b699109d1c660a0733fd3"
+source = "git+https://github.com/aya-rs/aya#b93ee8c26e96af85d77b040fa4fae8447c8fd7f8"
 dependencies = [
  "aya",
  "aya-log-common",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "aya-log-common"
 version = "0.1.16"
-source = "git+https://github.com/aya-rs/aya#c42157f0b566940b849b699109d1c660a0733fd3"
+source = "git+https://github.com/aya-rs/aya#b93ee8c26e96af85d77b040fa4fae8447c8fd7f8"
 dependencies = [
  "num_enum",
 ]
@@ -380,7 +380,7 @@ dependencies = [
 [[package]]
 name = "aya-obj"
 version = "0.2.2"
-source = "git+https://github.com/aya-rs/aya#c42157f0b566940b849b699109d1c660a0733fd3"
+source = "git+https://github.com/aya-rs/aya#b93ee8c26e96af85d77b040fa4fae8447c8fd7f8"
 dependencies = [
  "bytes",
  "hashbrown 0.16.1",
@@ -403,9 +403,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bevy_ecs"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -2719,9 +2719,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -3720,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
+checksum = "ef99362319c782aa4639ad3a306b64c3bb90e12874e99b8df124cb679d988611"
 dependencies = [
  "libc",
 ]
@@ -4269,7 +4269,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -4303,7 +4303,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4345,7 +4345,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -4422,7 +4422,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -5195,9 +5195,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5295,9 +5295,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
@@ -5641,9 +5641,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,7 +4020,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -4083,7 +4083,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7016,7 +7016,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "secrecy",
  "serde",
  "socket2 0.5.10",
@@ -7047,7 +7047,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pemfile",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "secrecy",
  "time",
  "tokio",
@@ -7071,7 +7071,7 @@ dependencies = [
  "async-trait",
  "quinn",
  "rustls",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "time",
  "tokio",
  "tokio-util",
@@ -7112,7 +7112,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "secrecy",
  "socket2 0.5.10",
  "time",


### PR DESCRIPTION
## Summary
Refresh `Cargo.lock` on top of current `main` so the stale dependency PR backlog can be collapsed into one current-base PR and the repository can return to a clean `main` line with no open dependency PRs.

## Changes
- consolidate the effective Rust dependency bumps from the stale dependency backlog onto current `main`
- keep the delivery scoped to `Cargo.lock`
- lift `rustls-webpki 0.103.9 -> 0.103.10` where the existing manifest constraints allow it
- supersede stale PR heads `#213`, `#214`, and `#215`

## Linked Issues
Closes #305

Superseded dependency PRs: #213, #214, #215
Known follow-up security issues outside this lockfile-only scope: #291, #292, #293

## Test Plan
- inspect the consolidated `Cargo.lock` diff on current `main`
- run targeted remote Rust verification for the affected daemon / zenoh path
- rely on PR CI for final current-base validation

## Benchmarks
- not applicable for a lockfile-only dependency refresh

## Evidence (AC Mapping)
| AC-1 | One current-base PR carries the effective dependency refresh | `#304` was created from `origin/main` and replaces the stale dependency backlog with one branch headed at `66fee7a`. |
| AC-2 | Stale dependency PRs are closed as superseded | `gh pr close 213 --comment 'Superseded by #304 ...'`, `gh pr close 214 --comment 'Superseded by #304 ...'`, `gh pr close 215 --comment 'Superseded by #304 ...'` |
| AC-3 | No dependency PRs remain open after merge | `gh pr list --repo silentspike/project-sentinel --state open --json number,title` showed only `#304` before final merge. |
| AC-4 | Delivery is validated on the current base | ```bash
$ cargo update -p rustls-webpki@0.103.9 --precise 0.103.10
    Updating rustls-webpki v0.103.9 -> v0.103.10

$ cargo remote -c -- test -p sentinel-daemon -p sentinel-zenoh
# targeted daemon/zenoh verification on the updated lockfile state
``` |

## Checklist
- [x] scope limited to `Cargo.lock`
- [x] stale dependency PRs closed as superseded
- [x] replacement PR created from current `origin/main`
- [x] targeted remote verification run for the affected Rust path
- [ ] final PR CI green on refreshed head
- [ ] merge to `main`
