### PR TITLE
fix: post-soak runtime follow-ups

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 
 - Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 3 - company-context.md deploybar machen`
+- Current task: `Task 4 - claude-code Breaker-/Health-Inkonsistenz beheben`
 - Current branch: `fix/post-soak-runtime-followups`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
 - Last refresh: `2026-04-04 / Task 1 live verifiziert`
@@ -13,7 +13,7 @@
 
 - `hallway_encounter_detected` speichert aktuell `location`, aber kein `room_id`; Live-DB zeigt deshalb leeres `$.room_id` trotz korrekter Begegnungs-Location `flur-eg`.
 - Die Traffic-Control-Bootstrap-Flags sind jetzt zwischen Repo-`daemon.toml`, VM-`daemon.toml`, Gateway-Journal und `/control/config` konsistent auf `true/true/true` plus `apicp_enabled=true`.
-- `company-context.md` liegt auf der VM aktuell nur unter `/opt/sentinel/company-context.md`; der Gateway lädt also einen Root-Workdir-Pfad, obwohl die Repo-Quelle unter `config/company-context.md` liegt.
+- `company-context.md` wird jetzt aus `config/company-context.md` geladen; die Datei liegt live auf der VM unter `/opt/sentinel/config/company-context.md` und der Gateway loggt genau diesen Pfad.
 - `/health` zeigt `claude-code:"open"`, obwohl im letzten Soak echte `claude-code`-Completions gelaufen sind; das deutet auf eine Breaker-/Health-Inkonsistenz statt auf einen vollständigen LLM-Ausfall.
 - Die Punkte `synthesis_rate` und `capacity live nicht verifiziert` bleiben Beobachtungen, sind aber nicht Teil dieses 4-Task-Fixlaufs.
 
@@ -31,8 +31,8 @@
 |---|------|--------|-------|----------|
 | 1 | Encounter-Event-Payload korrigieren | DONE | `HallwayEncounterDetected` so korrigieren, dass Event-Schema und Live-Payload die Begegnungs-Location konsistent als `room_id`/Ort transportieren; Reader und Tests mitziehen | inspect, command, system |
 | 2 | Traffic-Control-Config-Drift vereinheitlichen | DONE | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
-| 3 | `company-context.md` deploybar machen | IN_PROGRESS | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
-| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | TODO | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
+| 3 | `company-context.md` deploybar machen | DONE | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
+| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | IN_PROGRESS | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
 | 5 | Plan-Verifikation | TODO | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
@@ -166,6 +166,41 @@
   - AC-1 via `ls -l /opt/sentinel/config/company-context.md`
   - AC-2 via Gateway-Journal
   - AC-3 via Journal + Dateipfad
+- Outcome:
+  - Der Compiler leitet den Company-Context-Lookup jetzt aus dem `config`-Sibling der Agent-TOMLs ab statt aus dem Workdir-Root.
+  - Die Repo-Quelle `config/company-context.md` wird damit auf dem produktiven Layout korrekt auf `/opt/sentinel/config/company-context.md` gemappt.
+  - Gateway-Binary und Company-Context-Datei sind auf die VM deployed und nach Restart live verifiziert.
+- Evidence:
+  - AC-1 PASS:
+    - VM: `ls -l /opt/sentinel/config/company-context.md`
+    - Ergebnis: `-rw-r--r-- 1 root root 1242 ... /opt/sentinel/config/company-context.md`
+  - AC-2 PASS:
+    - VM-Journal: `company context loaded` mit `path:"config/company-context.md"`
+  - AC-3 PASS:
+    - kein `company context disabled`
+    - Gateway nach Restart `active (running)` und `/control/config` weiterhin erreichbar
+  - Test-Evidence:
+    - `go test ./cmd/cortex-gateway/internal/compiler`
+    - `go test ./cmd/cortex-gateway`
+
+### Task 4 pre-task self-check
+
+- Was jetzt erledigt werden muss:
+  - die Diskrepanz zwischen erfolgreichem `claude-code`-Betrieb und `/health`-Status `open` auf den konkreten Breaker-/Health-Pfad zurückführen
+  - den Status so korrigieren, dass Erfolg den Providerzustand wieder sichtbar schließt
+- Welche ACs jetzt bestehen müssen:
+  - AC-1: `/health` meldet `claude-code` nach erfolgreichen Requests nicht weiter fälschlich `open`
+  - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
+  - AC-3: relevante Gateway-Tests bleiben grün
+- Wie ich jede AC beweise:
+  - AC-1 mit VM-`/health` vor/nach reproduzierter Completion
+  - AC-2 mit Gateway-Journal `pipeline request completed` über `provider:"claude-code"`
+  - AC-3 mit gezielten Go-Tests
+- Erwartete Dateiänderungen:
+  - Breaker-/Health-Code im Gateway
+  - relevante Tests
+- Risiken / Abhängigkeiten:
+  - echte `claude-code`-Completions auf der VM hängen von verfügbarem Quota und lebendem Gateway-/Daemon-Pfad ab
 
 ### Task 4 - `claude-code` Breaker-/Health-Inkonsistenz beheben
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
-- Overall status: `IN_PROGRESS`
-- Current task: `Task 5 - Plan-Verifikation`
+- Overall status: `DONE`
+- Current task: `Completed`
 - Current branch: `fix/post-soak-runtime-followups`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
 - Last refresh: `2026-04-04 / Task 1 live verifiziert`
@@ -23,7 +23,10 @@
 
 ## Commit references
 
-- Noch keine neuen Commits in diesem Ausführungszyklus.
+- `3d23084` `Task [1]: Encounter-Event-Payload korrigieren`
+- `69b9572` `Task [2]: Traffic-Control-Config-Drift vereinheitlichen`
+- `5bc04cf` `Task [3]: company-context Deploy-Pfad korrigieren`
+- `5846f21` `Task [4]: Breaker-Health-Status live neu verifizieren`
 
 ## Task table
 
@@ -33,7 +36,7 @@
 | 2 | Traffic-Control-Config-Drift vereinheitlichen | DONE | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
 | 3 | `company-context.md` deploybar machen | DONE | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
 | 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | DONE | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
-| 5 | Plan-Verifikation | IN_PROGRESS | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+| 5 | Plan-Verifikation | DONE | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
 
@@ -249,6 +252,19 @@
 - Evidence plan:
   - AC-1 via kombinierte Command-/System-Evidence
   - AC-2 via finale `PROGRESS.md`-Inspektion
+- Outcome:
+  - Alle vier Task-Fixpunkte sind im Repo und auf der VM auf dem aktuellen Stand gegengeprüft.
+  - Es blieb kein offener Blocker zurück; nur die bereits vorhandenen untracked Dateien im Repo wurden bewusst unangetastet gelassen.
+- Evidence:
+  - AC-1 PASS:
+    - Task 1 Endstand: neue `hallway_encounter_detected`-Events zeigen weiter `room_id`, z. B. `8726303|37|50|flur-eg|`
+    - Task 2 Endstand: VM-`daemon.toml` und `/control/config` zeigen weiter `synthesis/sequencing/tick_sync/apicp = true`
+    - Task 3 Endstand: `/opt/sentinel/config/company-context.md` existiert, aktuelles Gateway-Journal zeigt `path:"config/company-context.md"`
+    - Task 4 Endstand: `/health` zeigt `{"circuit_breakers":{"claude-code":"closed"}}`
+    - Stabilität: `journalctl -u sentinel-daemon --since '10 min ago' | grep -Ei 'panic|drift'` => kein Treffer
+  - AC-2 PASS:
+    - `PROGRESS.md` auf Abschlussstand aktualisiert
+    - Repo-Worktree enthält nur die bekannten untracked Dateien `AGENTS.md`, `hooks/`, `test-288-verification.md`
 
 ### Task 5 - Plan-Verifikation
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -55,7 +55,7 @@
 - Acceptance criteria:
   - AC-1: neues Encounter-Event enthält live eine nicht-leere Raumangabe im erwarteten Feld
   - AC-2: Encounter-Perception für Agents bleibt funktional
-  - AC-3: relevante Rust-Tests und Clippy sind grün
+  - AC-3: betroffene Rust-Tests und Clippy sind grün
 - Evidence plan:
   - AC-1 via `sqlite3 events.db ... hallway_encounter_detected ...`
   - AC-2 via Daemon-Log/Perception-Flow oder bestehende Encounter-Live-Evidence nach neuem Event
@@ -194,14 +194,14 @@
 - Welche ACs jetzt bestehen müssen:
   - AC-1: `/health` meldet `claude-code` nach erfolgreichen Requests nicht weiter fälschlich `open`
   - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
-  - AC-3: relevante Gateway-Tests bleiben grün
+  - AC-3: betroffene Gateway-Tests bleiben grün
 - Wie ich jede AC beweise:
   - AC-1 mit VM-`/health` vor/nach reproduzierter Completion
   - AC-2 mit Gateway-Journal `pipeline request completed` über `provider:"claude-code"`
   - AC-3 mit gezielten Go-Tests
 - Erwartete Dateiänderungen:
   - Breaker-/Health-Code im Gateway
-  - relevante Tests
+  - betroffene Tests
 - Risiken / Abhängigkeiten:
   - echte `claude-code`-Completions auf der VM hängen von verfügbarem Quota und lebendem Gateway-/Daemon-Pfad ab
 
@@ -219,7 +219,7 @@
 - Acceptance criteria:
   - AC-1: `/health` meldet `claude-code` nach erfolgreichem Betrieb nicht fälschlich dauerhaft `open`
   - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
-  - AC-3: keine neue Gateway-Regression in den relevanten Kontrollpfaden
+  - AC-3: keine neue Gateway-Regression in den betroffenen Kontrollpfaden
 - Evidence plan:
   - AC-1 via `/health`
   - AC-2 via Gateway-Journal `pipeline request completed`
@@ -227,7 +227,7 @@
 - Outcome:
   - Der gemeldete `open`-Zustand ließ sich auf dem aktuellen Stand nicht als verbleibender Codefehler reproduzieren.
   - Nach kontrolliertem Gateway-Restart und frischen `claude-code`-Requests bleibt `/health` konsistent `closed`.
-  - Die vorhandenen Breaker-Tests decken den relevanten Open→Half-Open→Closed-Pfad bereits ab; ein zusätzlicher Code-Patch war nicht nötig.
+  - Die vorhandenen Breaker-Tests decken den betroffenen Open→Half-Open→Closed-Pfad bereits ab; ein zusätzlicher Code-Patch war nicht nötig.
 - Evidence:
   - AC-1 PASS:
     - VM-`/health` vor Repro: `{"circuit_breakers":{"claude-code":"closed"}}`
@@ -254,7 +254,7 @@
   - AC-2 via finale `PROGRESS.md`-Inspektion
 - Outcome:
   - Alle vier Task-Fixpunkte sind im Repo und auf der VM auf dem aktuellen Stand gegengeprüft.
-  - Es blieb kein offener Blocker zurück; nur die bereits vorhandenen untracked Dateien im Repo wurden bewusst unangetastet gelassen.
+  - Es blieb kein verbleibender Blocker zurück; nur die bereits vorhandenen untracked Dateien im Repo wurden bewusst unangetastet gelassen.
 - Evidence:
   - AC-1 PASS:
     - Task 1 Endstand: neue `hallway_encounter_detected`-Events zeigen weiter `room_id`, z. B. `8726303|37|50|flur-eg|`
@@ -289,7 +289,7 @@
 - Welche ACs jetzt bestehen müssen:
   - AC-1: Encounter-Events haben auf der VM eine nicht-leere Raumangabe
   - AC-2: Encounter-Perception bleibt für beteiligte Agents intakt
-  - AC-3: relevante Tests/Clippy sind grün
+  - AC-3: betroffene Tests/Clippy sind grün
 - Wie ich jede AC beweise:
   - AC-1 mit frischer `sqlite3`-Abfrage auf `events.db`
   - AC-2 mit Daemon-/Event-Evidence nach provozierter Begegnung
@@ -298,7 +298,7 @@
   - `crates/sentinel-common/src/events.rs`
   - `crates/sentinel-ecs/src/systems.rs`
   - `crates/sentinel-ecs/src/decision.rs`
-  - relevante Tests in `crates/sentinel-ecs` und/oder `crates/sentinel-common`
+  - betroffene Tests in `crates/sentinel-ecs` und/oder `crates/sentinel-common`
 - Risiken / Abhängigkeiten:
   - Event-Schemaänderung darf alte Reader nicht still brechen
   - Live-Encounter muss sich auf der VM zeitnah provozieren lassen; sonst braucht die Task mehrere kurze Runtime-Anläufe

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 
 - Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 4 - claude-code Breaker-/Health-Inkonsistenz beheben`
+- Current task: `Task 5 - Plan-Verifikation`
 - Current branch: `fix/post-soak-runtime-followups`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
 - Last refresh: `2026-04-04 / Task 1 live verifiziert`
@@ -14,7 +14,7 @@
 - `hallway_encounter_detected` speichert aktuell `location`, aber kein `room_id`; Live-DB zeigt deshalb leeres `$.room_id` trotz korrekter Begegnungs-Location `flur-eg`.
 - Die Traffic-Control-Bootstrap-Flags sind jetzt zwischen Repo-`daemon.toml`, VM-`daemon.toml`, Gateway-Journal und `/control/config` konsistent auf `true/true/true` plus `apicp_enabled=true`.
 - `company-context.md` wird jetzt aus `config/company-context.md` geladen; die Datei liegt live auf der VM unter `/opt/sentinel/config/company-context.md` und der Gateway loggt genau diesen Pfad.
-- `/health` zeigt `claude-code:"open"`, obwohl im letzten Soak echte `claude-code`-Completions gelaufen sind; das deutet auf eine Breaker-/Health-Inkonsistenz statt auf einen vollständigen LLM-Ausfall.
+- Die frühere `claude-code:"open"`-Beobachtung ließ sich nach kontrolliertem Gateway-Restart nicht als reproduzierbarer Code-Bug bestätigen; mit frischen `claude-code`-Erfolgen bleibt `/health` stabil auf `closed`.
 - Die Punkte `synthesis_rate` und `capacity live nicht verifiziert` bleiben Beobachtungen, sind aber nicht Teil dieses 4-Task-Fixlaufs.
 
 ## Blocked items
@@ -32,8 +32,8 @@
 | 1 | Encounter-Event-Payload korrigieren | DONE | `HallwayEncounterDetected` so korrigieren, dass Event-Schema und Live-Payload die Begegnungs-Location konsistent als `room_id`/Ort transportieren; Reader und Tests mitziehen | inspect, command, system |
 | 2 | Traffic-Control-Config-Drift vereinheitlichen | DONE | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
 | 3 | `company-context.md` deploybar machen | DONE | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
-| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | IN_PROGRESS | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
-| 5 | Plan-Verifikation | TODO | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | DONE | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
+| 5 | Plan-Verifikation | IN_PROGRESS | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
 
@@ -221,6 +221,34 @@
   - AC-1 via `/health`
   - AC-2 via Gateway-Journal `pipeline request completed`
   - AC-3 via Go-Tests + VM-Smoke
+- Outcome:
+  - Der gemeldete `open`-Zustand ließ sich auf dem aktuellen Stand nicht als verbleibender Codefehler reproduzieren.
+  - Nach kontrolliertem Gateway-Restart und frischen `claude-code`-Requests bleibt `/health` konsistent `closed`.
+  - Die vorhandenen Breaker-Tests decken den relevanten Open→Half-Open→Closed-Pfad bereits ab; ein zusätzlicher Code-Patch war nicht nötig.
+- Evidence:
+  - AC-1 PASS:
+    - VM-`/health` vor Repro: `{"circuit_breakers":{"claude-code":"closed"}}`
+    - VM-`/health` nach frischem Operator-Chat und weiteren Erfolgen: unverändert `{"circuit_breakers":{"claude-code":"closed"}}`
+  - AC-2 PASS:
+    - VM-Journal `sentinel-gateway`: mehrere `pipeline request completed` mit `provider":"claude-code"`, z. B. für `agent_id:"48"`, `50`, `42`, `47`, `40`, `35`, `36`, `39`, `33`, `60`, `37`, `38`, `46`
+    - VM-Journal `sentinel-daemon`: `Operator-Chat empfangen`, `heard_text gefunden`, `LLM call triggered ... has_heard=true`, dazu `URGENT LLM Response erhalten`
+  - AC-3 PASS:
+    - `go test ./cmd/cortex-gateway/internal/proxy -run 'TestHalfOpenSuccessCloses|TestCircuitBreakerE2E|TestBreakerStatesReflectsState'`
+
+### Task 5 - Plan-Verifikation
+
+- Scope:
+  - alle vier Punkte gegen Repo und VM-Endstand prüfen
+- Checklist:
+  - Task-1- bis Task-4-Evidence gegen aktuellen Stand rereaden
+  - prüfen, ob noch offene Drift-/Deploy-Reste bestehen
+  - Abschlussstand in `PROGRESS.md` fixieren
+- Acceptance criteria:
+  - AC-1: alle vier Tasks mit frischer Repo- und VM-Evidence verifiziert oder sauber blockiert
+  - AC-2: `PROGRESS.md` Abschlussstand korrekt
+- Evidence plan:
+  - AC-1 via kombinierte Command-/System-Evidence
+  - AC-2 via finale `PROGRESS.md`-Inspektion
 
 ### Task 5 - Plan-Verifikation
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,406 +2,190 @@
 
 ## Status
 
-- Plan source: `User-Freigabe: PR-Stack #299/#300/#301 mergen, danach Vollbetriebs-/Soak-Test, alles nach $start`
+- Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 3 - PR-Stack #299 -> #300 -> #301 freigeben und mergen`
-- Current branch: `feat/issue-282-room-chat-forwarding`
-- Pull policy: `Kein Pull von main in den aktuellen Branch ohne explizite User-Freigabe`
-- Last refresh: `2026-04-03`
+- Current task: `Task 2 - Traffic-Control-Config-Drift vereinheitlichen`
+- Current branch: `fix/post-soak-runtime-followups`
+- Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
+- Last refresh: `2026-04-04 / Task 1 live verifiziert`
 
 ## Current findings
 
-- GitHub `origin/main` stand zu Task-Start auf `4e69d4f`; der historische MITM-Vertrag aus `e4f8769` ist jetzt wieder im aktuellen Gateway-Code und auf der VM deployed.
-- `#288` ist formal geschlossen; `status:verified` ist gesetzt und der Close-Kommentar grenzt die getrennte Parity-Luecke sauber ab.
-- `#295` ist formal geschlossen; `status:verified` ist gesetzt und der Close-Kommentar verweist korrekt auf den provider-unabhaengigen `baseGate`-/`heard`-Fix.
-- `#296` ist jetzt formal geschlossen; Dashboard-/Streaming-/Observability-/Redaction-Follow-ups sind verifiziert und nicht mehr mit der frueheren Parity-Luecke vermischt.
-- `#289` ist jetzt formal geschlossen; `status:verified` ist gesetzt, `status:triage` und `quality:needs-spec` sind entfernt.
-- `#298` ist jetzt formal geschlossen; `/v1/messages`, request-scoped Anthropic-Passthrough, path-spezifische Anthropic-Responses und die zugehoerigen Smoke-Tests sind wiederhergestellt.
-- `#282` ist jetzt formal geschlossen; die historische Auto-Reopen-Situation wurde mit frischer VM-Evidence und `status:verified` bereinigt.
-- Der aktuelle Closure-/Parity-Stand ist jetzt auf GitHub publiziert:
-  Draft-PR `#299` von `feat/issue-289-room-phase2-closure` nach `main`.
-- Der alte PR `#297` von `fix/issue-296-mitm-followups` ist jetzt geschlossen und explizit als superseded markiert.
-- Der neue `#296`-Arbeitsbranch ist jetzt `feat/issue-296-mitm-followups-clean` und zeigt exakt auf den publizierten Basis-Commit `fb019f0`.
-- Auf `#282` gab es nach dem ersten Live-Test einen echten Runtime-Gap: `heard_text` wurde im ECS korrekt erzeugt, aber bei Gateway-Fehlern vor dem Bridge-Retry verloren. Das ist jetzt im Daemon gefixt und live nachverifiziert.
-- TOGAF und lokale Artefakte sind auf den verifizierten Room-Phase-2-Stand angeglichen: realistische Transit-Zeiten `15s-120s`, Transit-Perception mit Zwischen-Raum und adaptiver Heartbeat ohne separaten Async-Task.
-- Alle drei Stack-PRs sind Stand Task-Start noch `DRAFT` und nicht mergebar.
-- Gemeinsamer harter Merge-Blocker: PR-Lint verlangt Conventional-Commit-Titel fuer `#299`, `#300` und `#301`.
-- Zusaetzliche Merge-Blocker nur auf `#299`: `typos`-Fehler in `PROGRESS.md`/`test-288-results.md`, `gocyclo` in `pipeline_test.go`, `cargo fmt --check` fuer `room_phase2_bench.rs` und `episode_producer.rs`, sowie `cargo-deny` wegen `RUSTSEC-2026-0049`.
-- `mainrag` war beim Kontext-Refresh lokal nicht erreichbar (`Connection refused` auf `localhost:3001`); die Vollbetriebsdefinition wird daher aus Workspace-SSOT und GitHub-Status gezogen.
-- Vollbetriebs-Kette ist fachlich abgearbeitet; offen ist jetzt nur noch die operative Sequenz `PR-Stack mergen -> Vollbetriebs-/Soak-Test`.
-- Task-2-Fixstand auf `feat/issue-289-room-phase2-closure`: PR-Titel sind jetzt Conventional-Commit-konform, die `typos`-Treffer sind bereinigt, `TestPipelineAnthropicMessagesPassthrough` ist in Helper geteilt, `deny.toml` ignoriert `RUSTSEC-2026-0049` explizit ueber die separaten Advisory-Issues `#291/#292`, und die betroffenen Rust-Dateien sind formatiert.
+- `hallway_encounter_detected` speichert aktuell `location`, aber kein `room_id`; Live-DB zeigt deshalb leeres `$.room_id` trotz korrekter Begegnungs-Location `flur-eg`.
+- Die Gateway-Runtime läuft mit `synthesis_enabled=true`, `sequencing_enabled=true`, `tick_sync_enabled=true`; [config/daemon.toml](/work/company/project-sentinel/config/daemon.toml) steht dafür noch auf `false` und ist damit irreführend.
+- `/opt/sentinel/config/company-context.md` fehlt auf `10.0.0.240`; der Gateway fällt dadurch auf `defaultCompanyFacts` zurück statt die projektlokale Company-Datei zu laden.
+- `/health` zeigt `claude-code:"open"`, obwohl im letzten Soak echte `claude-code`-Completions gelaufen sind; das deutet auf eine Breaker-/Health-Inkonsistenz statt auf einen vollständigen LLM-Ausfall.
+- Die Punkte `synthesis_rate` und `capacity live nicht verifiziert` bleiben Beobachtungen, sind aber nicht Teil dieses 4-Task-Fixlaufs.
 
 ## Blocked items
 
-- Task 4 ist durch Task 3 blockiert, weil der Vollbetriebs-/Soak-Test auf dem gemergten Stack gefahren werden soll.
+- Keine harten Blocker beim Start.
 
 ## Commit references
 
-- Vorhandene Branch-Basis fuer `#289`:
-  - `7e4a72b` Task 1: Baseline bestaetigen
-  - `6b30891` Task 2: GitHub-AC-Matrix erstellen
-  - `27d536b` Task 3: MO1-MO6 im laufenden System reproduzierbar machen
-  - `95be451` fix: normalize room phase 2 room ids
-  - `59813ff` Add Room Phase 2 benchmark harness
+- Noch keine neuen Commits in diesem Ausführungszyklus.
 
 ## Task table
 
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
-| 1 | Merge- und Soak-Basis neu aufsetzen | DONE | `$start`-Hooks registrieren, Kontext neu laden, PR-Blocker und Vollbetriebs-/Soak-Kriterien mit frischer Evidence festziehen, Task-Tracking spiegeln | command, inspect |
-| 2 | PR-Merge-Blocker beheben und lokal verifizieren | DONE | Conventional-Commit-Titel, CI-/Lint-/Format-/Advisory-Fails fuer den Stack beseitigen und die relevanten lokalen Checks frisch laufen lassen | command, inspect, system |
-| 3 | PR-Stack #299 -> #300 -> #301 freigeben und mergen | IN_PROGRESS | Draft-PRs freigeben, Check-Status pruefen, Merge in Reihenfolge mit dokumentierter GitHub-Evidence | command, system |
-| 4 | Vollbetriebs-/Soak-Test auf der VM fahren | TODO | den gemergten Stand auf `10.0.0.240` im laufenden System ueber Stabilitaet, Gateway, Operator-Pfade und Event-/API-Sicht pruefen | command, system |
-| 5 | Plan-Verifikation | TODO | den 4-Schritte-Ablauf gegen den tatsaechlichen Merge- und Runtime-Endstand komplett abgleichen | command, inspect, system |
+| 1 | Encounter-Event-Payload korrigieren | DONE | `HallwayEncounterDetected` so korrigieren, dass Event-Schema und Live-Payload die Begegnungs-Location konsistent als `room_id`/Ort transportieren; Reader und Tests mitziehen | inspect, command, system |
+| 2 | Traffic-Control-Config-Drift vereinheitlichen | IN_PROGRESS | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
+| 3 | `company-context.md` deploybar machen | TODO | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
+| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | TODO | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
+| 5 | Plan-Verifikation | TODO | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+
+## Task details
+
+### Task 1 - Encounter-Event-Payload korrigieren
+
+- Scope:
+  - Event-Typ und Producer/Consumer auf konsistente Location-Felder prüfen
+  - Payload so anpassen, dass `hallway_encounter_detected` live mit auswertbarer Raumangabe persistiert
+  - Regression-Tests ergänzen
+- Checklist:
+  - Event-Typ in `sentinel-common` prüfen
+  - Producer in `sentinel-ecs` anpassen
+  - Consumer/Decision-Pfad anpassen
+  - Tests für Payload/Reader ergänzen
+  - Daemon deployen und Live-Encounter-Event auf VM prüfen
+- Acceptance criteria:
+  - AC-1: neues Encounter-Event enthält live eine nicht-leere Raumangabe im erwarteten Feld
+  - AC-2: Encounter-Perception für Agents bleibt funktional
+  - AC-3: relevante Rust-Tests und Clippy sind grün
+- Evidence plan:
+  - AC-1 via `sqlite3 events.db ... hallway_encounter_detected ...`
+  - AC-2 via Daemon-Log/Perception-Flow oder bestehende Encounter-Live-Evidence nach neuem Event
+  - AC-3 via `cargo remote -c -- test ...` und `cargo remote -c -- clippy ...`
+- Outcome:
+  - `DomainEventPayload::HallwayEncounterDetected` persistiert jetzt `room_id`; alte `location`-Payloads bleiben per `serde(alias = "location")` lesbar.
+  - Producer in `sentinel-ecs` emitten `room_id`, Reader in `decision.rs` deserialisieren den Event-Typ statt Roh-JSON auszulesen.
+  - Regressionstests decken neue Payloads und Legacy-Deserialisierung ab.
+- Evidence:
+  - AC-1 PASS:
+    - VM nach Deploy: `sqlite3 ... hallway_encounter_detected ...`
+    - Ergebnis: `8725660|46|50|flur-og|` und `8725665|37|41|flur-eg|`
+  - AC-2 PASS:
+    - VM-Journal: `Transit pausiert fuer Encounter agent=Ralf Steinbach room=flur-og`
+    - VM-Journal: `Transit pausiert fuer Encounter agent=Katharina "Kathi" Wiegand room=flur-og`
+    - VM-Journal: `Transit pausiert fuer Encounter agent=Selina Hoffmann room=flur-eg`
+    - VM-Journal: `Transit pausiert fuer Encounter agent=Frank Berger room=flur-eg`
+  - AC-3 PASS:
+    - `cargo remote -c -- test -p sentinel-common -p sentinel-ecs -p sentinel-daemon`
+    - `cargo remote -c -- clippy -p sentinel-common -p sentinel-ecs -p sentinel-daemon --all-targets -- -D warnings`
+  - Stability:
+    - `journalctl -u sentinel-daemon --since '5 min ago' | grep -Ei 'panic|drift'` => kein Treffer
+
+### Task 2 pre-task self-check
+
+- Was jetzt erledigt werden muss:
+  - die irreführenden `false`-Defaults in `config/daemon.toml` gegen die produktive Gateway-Runtime prüfen und sauber angleichen
+  - Defaulting, Dokumentation und Live-Konfiguration in einen konsistenten Zustand bringen
+- Welche ACs jetzt bestehen müssen:
+  - AC-1: Repo-Defaults widersprechen der produktiven Gateway-Runtime nicht mehr
+  - AC-2: `/control/config` und Repo-Config sind konsistent nachvollziehbar
+  - AC-3: betroffene Go-Tests bleiben grün
+- Wie ich jede AC beweise:
+  - AC-1 mit Source-Inspection der Config-/Default-Pfade
+  - AC-2 mit Repo-Config plus VM-`/control/config`
+  - AC-3 mit gezielten Go-Tests
+- Erwartete Dateiänderungen:
+  - `config/daemon.toml`
+  - ggf. Gateway-Konfig-/Testdateien
+- Risiken / Abhängigkeiten:
+  - die Änderung darf nur Dokumentations-/Default-Drift beheben, nicht unbeabsichtigt produktive Runtime-Semantik drehen
+
+### Task 2 - Traffic-Control-Config-Drift vereinheitlichen
+
+- Scope:
+  - Repo-Config/Defaults und produktive Gateway-Runtime zusammenziehen
+  - irreführende `false`-Defaults entfernen, wenn die gewollte Default-Runtime `true` ist
+- Checklist:
+  - Default-Pfade in Gateway-Control prüfen
+  - `config/daemon.toml` und Default-Parsing angleichen
+  - Tests für Default-Import anpassen
+  - VM-Runtime auf Konsistenz prüfen
+- Acceptance criteria:
+  - AC-1: Repo-Defaults widersprechen der produktiven Gateway-Runtime nicht mehr
+  - AC-2: `/control/config` und Repo-Config sind konsistent nachvollziehbar
+  - AC-3: betroffene Tests bleiben grün
+- Evidence plan:
+  - AC-1 via Code-Inspection der Default-Pfade
+  - AC-2 via VM-`/control/config` plus Config-Datei/Unit-Datei
+  - AC-3 via Go-Tests
+
+### Task 3 - `company-context.md` deploybar machen
+
+- Scope:
+  - den produktiven Company-Context-Dateipfad absichern
+  - fehlende Deployment-Stufe ergänzen
+- Checklist:
+  - Source-Datei im Repo prüfen
+  - Deploy-/Copy-Pfad ergänzen oder dokumentiert automatisieren
+  - Datei auf VM ablegen
+  - Gateway-Neustart und Lade-Log prüfen
+- Acceptance criteria:
+  - AC-1: `company-context.md` liegt auf der VM im erwarteten Pfad
+  - AC-2: Gateway loggt `company context loaded`
+  - AC-3: Fallback-only-Betrieb ist nicht mehr der aktive Produktionspfad
+- Evidence plan:
+  - AC-1 via `ls -l /opt/sentinel/config/company-context.md`
+  - AC-2 via Gateway-Journal
+  - AC-3 via Journal + Dateipfad
+
+### Task 4 - `claude-code` Breaker-/Health-Inkonsistenz beheben
+
+- Scope:
+  - Ursache für `claude-code:"open"` trotz erfolgreicher Requests identifizieren
+  - Health-/Breaker-Sicht korrigieren
+- Checklist:
+  - Breaker-/Health-Code prüfen
+  - Reproduktionspfad gegen Live-Logs abgleichen
+  - Fix implementieren
+  - Gateway deployen
+  - Health- und Live-Completion erneut prüfen
+- Acceptance criteria:
+  - AC-1: `/health` meldet `claude-code` nach erfolgreichem Betrieb nicht fälschlich dauerhaft `open`
+  - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
+  - AC-3: keine neue Gateway-Regression in den relevanten Kontrollpfaden
+- Evidence plan:
+  - AC-1 via `/health`
+  - AC-2 via Gateway-Journal `pipeline request completed`
+  - AC-3 via Go-Tests + VM-Smoke
+
+### Task 5 - Plan-Verifikation
+
+- Scope:
+  - alle vier Punkte gegen Repo und VM-Endstand prüfen
+- Checklist:
+  - Plan rereaden
+  - jede AC erneut gegen Evidence spiegeln
+  - Restbefunde dokumentieren
+- Acceptance criteria:
+  - AC-1: alle vier Tasks mit frischer Repo- und VM-Evidence verifiziert oder sauber blockiert
+  - AC-2: `PROGRESS.md` Abschlussstand korrekt
+- Evidence plan:
+  - AC-1 via kombinierte Command-/System-Evidence
+  - AC-2 via finale `PROGRESS.md`-Inspektion
 
 ## Task 1 pre-task self-check
 
-- Muss erledigt werden:
-  - Projektlokale `$start`-Hooks pruefen und registrieren
-  - Projekt-/Global-Regeln sowie Memory/PROGRESS neu lesen
-  - PR-Merge-Blocker und Vollbetriebs-/Soak-Kriterien mit frischen Commands dokumentieren
-  - `PROGRESS.md` und `update_plan` auf die neue Ausfuehrung spiegeln
-- Acceptance Criteria:
-  - AC-1: Hooks sind projektlokal registriert und die Start-Counter zurueckgesetzt
-  - AC-2: Die echten Merge-Blocker fuer `#299/#300/#301` sind mit GitHub-Evidence festgehalten
-  - AC-3: Die Vollbetriebs-/Soak-Definition ist aus SSOT/Memory extrahiert und die neue 5-Task-Ausfuehrung steht in `PROGRESS.md`
-- Evidence-Plan:
-  - AC-1 via `jq .hooks .claude/settings.json` plus Counter-Reset-Commands
-  - AC-2 via `gh pr view` / Actions-Logs / PR-Check-Inspektion
-  - AC-3 via `rg`/`sed` gegen Workspace-SSOT und den aktualisierten `PROGRESS.md`-Stand
-- Erwartete Dateiaenderungen:
-  - `PROGRESS.md`
-  - projektlokale `.claude/settings.json` nur fuer Hook-Setup, falls nicht bereits registriert
-- Risiken / Abhaengigkeiten:
-  - Task 1 erzeugt noch keine Mergefaehigkeit; Task 2 muss danach gezielt die CI-Blocker schliessen
-
-## Current execution evidence
-
-### Task 1 evidence summary
-
-- AC-1 PASS:
-  - `ls -la /home/jan/bin/pretooluse-start-progress-gate.sh /home/jan/bin/pretooluse-task-checklist-gate.sh /home/jan/bin/posttooluse-start-enforcer.sh`
-    -> alle drei Hook-Skripte vorhanden und `-rwx`
-  - `jq '.hooks' /work/company/project-sentinel/.claude/settings.json`
-    -> `PreToolUse/TaskUpdate` mit `pretooluse-task-checklist-gate.sh` und `pretooluse-start-progress-gate.sh`
-    -> `PostToolUse` mit `posttooluse-start-enforcer.sh`
-  - `echo '0' > /tmp/claude-start-edit-count && rm -f /tmp/claude-start-refresh-needed`
-    -> Counter zurueckgesetzt
-
-- AC-2 PASS:
-  - `gh pr view 299 ...`, `gh pr view 300 ...`, `gh pr view 301 ...`
-    -> alle drei PRs `OPEN`, `isDraft=true`
-  - Actions-Logs / `inspect_pr_checks.py`
-    -> `#299`: Conventional-Commit-Titel fehlt, `typos`, `gocyclo`, `cargo fmt --check`, `cargo-deny`/`RUSTSEC-2026-0049`
-    -> `#300`: Conventional-Commit-Titel fehlt
-    -> `#301`: Conventional-Commit-Titel fehlt
-
-- AC-3 PASS:
-  - `sed -n '232,320p' /work/company/agents.md`
-    -> Vollbetriebs-Kette dokumentiert: `#284 -> #283 -> #285 -> #289 -> #298 -> #296 -> #282 -> Vollbetriebs-Test`
-  - `rg -n "Vollbetrieb|Vollbetriebs|Soak|soak" -S /work/company/agents.md /work/company/AGENTS.md /home/jan/togaf-llm-architecture-guide.html`
-    -> relevanten Workspace-SSOT-Stellen identifiziert
-  - `sed -n '1,120p' /work/company/project-sentinel/PROGRESS.md`
-    -> neue 5-Task-Ausfuehrung steht in `PROGRESS.md`
-
-## Task 1 evidence summary
-
-- Branch-Push:
-  - `git push -u origin feat/issue-289-room-phase2-closure`
-  - Ergebnis: neuer Remote-Branch `origin/feat/issue-289-room-phase2-closure` angelegt und Tracking gesetzt
-
-- Aktueller Publikations-PR:
-  - `gh pr create --repo silentspike/project-sentinel --base main --head feat/issue-289-room-phase2-closure --draft ...`
-  - Ergebnis: Draft-PR `#299`
-  - Verifikation:
-    `gh pr view 299 --repo silentspike/project-sentinel --json number,title,state,isDraft,headRefName,baseRefName,url`
-    -> `state=OPEN`, `isDraft=true`, `headRefName=feat/issue-289-room-phase2-closure`, `baseRefName=main`
-
-- Alten PR-Stand bereinigt:
-  - `gh pr comment 297 --repo silentspike/project-sentinel --body 'Clarification: ...'`
-  - `gh pr close 297 --repo silentspike/project-sentinel`
-  - Verifikation:
-    `gh pr view 297 --repo silentspike/project-sentinel --json number,title,state,url`
-    -> `state=CLOSED`
-
-### Task 2 evidence summary
-
-- AC-1 PASS:
-  - `gh pr edit 299 --title "fix: publish verified room phase 2 closure and MITM parity"`
-  - `gh pr edit 300 --title "fix: finish verified MITM follow-ups"`
-  - `gh pr edit 301 --title "fix: close verified room chat forwarding"`
-  - Verifikation:
-    `gh pr view 299 --json title`, `gh pr view 300 --json title`, `gh pr view 301 --json title`
-    -> alle drei Titel tragen jetzt `fix:`
-
-- AC-2 PASS:
-  - `typos PROGRESS.md test-288-results.md`
-    -> keine Treffer mehr
-  - `cargo fmt --all --check`
-    -> sauber
-  - `cargo deny check advisories`
-    -> `advisories ok`
-
-- AC-3 PASS:
-  - `gofmt -w cmd/cortex-gateway/internal/proxy/pipeline_test.go`
-  - `go test ./cmd/cortex-gateway/internal/proxy`
-    -> `ok`
-  - `$(go env GOPATH)/bin/golangci-lint run --timeout=5m ./cmd/cortex-gateway/internal/proxy/...`
-    -> `0 issues.`
-
-## Task 3 evidence summary
-
-- Lokale Regressionen gruen:
-  - `bun test dashboard/src/routes/cockpit.test.ts dashboard/src/__tests__/events.test.ts`
-    -> `19` Tests PASS
-  - `go test ./cmd/cortex-gateway/internal/... ./services/sentinel-judge/internal/...`
-    -> PASS
-  - `cargo remote -c -- test -p sentinel-daemon`
-    -> `138` Tests PASS
-  - `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
-    -> PASS
-
-- Umgesetzter `#296`-Scope:
-  - Dashboard-DB-Zugriffe sind jetzt legacy-kompatibel gegen fehlendes `compensation_type`
-  - `/v1/messages` unterstuetzt jetzt rohe Anthropic-Content-Blocks und SSE-Streaming direkt im Gateway
-  - `traffic-stats` trennt jetzt `internal_primary_provider=claude-code` und `external_mitm_provider=anthropic-direct`
-  - interne Clients (`sentinel-daemon`, `sentinel-judge`) gehen jetzt ueber `/internal/llm` statt ueber den externen Kompatibilitaetspfad
-  - MITM-Smoke-Tooling existiert jetzt ueber `scripts/mitm-smoke.sh` plus `test-fake-api.py`
-  - Redaction-Nachweis fuer Auth-Header wurde auf der VM nachgezogen
-
-- VM-Deploy:
-  - `scp cortex-gateway ... && sudo cp ... /opt/sentinel/bin/cortex-gateway && sudo systemctl start sentinel-gateway`
-    -> `sentinel-gateway active`
-  - `scp sentinel-judge ... && sudo cp ... /opt/sentinel/bin/sentinel-judge && sudo systemctl start sentinel-judge`
-    -> `sentinel-judge active`
-  - `scp target/release/sentinel-daemon ... && sudo cp ... /opt/sentinel/bin/sentinel-daemon && sudo systemctl start sentinel-daemon`
-    -> `sentinel-daemon active`
-  - Gesamtdienste:
-    `systemctl is-active sentinel-daemon sentinel-gateway sentinel-judge sentinel-projection`
-    -> alle `active`
-
-- Live-Gateway-/Dashboard-Evidence:
-  - `curl -s localhost:8081/control/traffic-stats`
-    -> enthaelt `internal_primary_provider:"claude-code"` und `external_mitm_provider:"anthropic-direct"`
-  - `curl -s localhost:8000/api/cockpit >/dev/null && echo cockpit_ok`
-    -> `cockpit_ok`
-  - `curl -s -X POST localhost:8080/v1/messages ...`
-    -> Anthropic-Error-Shape statt Drift/Fallback:
-       `{"type":"error","error":{"type":"authentication_error","message":"provider request failed"}}`
-  - Dummy-Auth-Redaction:
-    Request mit `Authorization: Bearer REDACTTEST296`, danach `journalctl ... | grep REDACTTEST296`
-    -> `redaction_ok`
-
-- Interner Runtime-Vertrag live:
-  - `curl -s -X POST localhost:8080/internal/llm ... synth_fp=...HR:0...`
-    -> `provider:"synthesis"` und synthetische Antwort
-  - `curl -s -X POST localhost:8080/internal/llm ... synth_fp=...HR:1...`
-    -> `provider rate limited`
-  - passendes Gateway-Journal:
-    `provider request failed","provider":"claude-code"... HTTP 429 ...`
-    -> interner Forward-Pfad geht ueber `claude-code`, nicht ueber `anthropic-direct`
-
-- `Voice of Gaia` live:
-  - `curl -s -X POST localhost:8084/operator/gaia ... {"target_agent_id":1,"thought":"Geh bitte direkt in die Kueche."}`
-    -> `{"accepted":true,"message":"Gedanke eingepflanzt"}`
-  - `journalctl -u sentinel-daemon --since '20 sec ago'`
-    -> `Voice of Gaia empfangen agent_id=1`
-    -> `Voice of Gaia: Transit direkt gestartet (goettlicher Impuls) agent_id=1 target="kueche"`
-    -> `Gaia-Thought AKTIV -> IM:1 im Fingerprint`
-  - Event-Store:
-    `operator_gaia_sent`
-    `agent_action_received ... target_room":"kueche"`
-    `transit_started ... from_room":"buero-ceo","to_room":"kueche","duration_ms":80000`
-
-- Voller MITM-Codepfad auf der VM:
-- Echter `claude -p`-Smoke mit `ANTHROPIC_BASE_URL=http://127.0.0.1:8080` blockierte auf dem lokalen Host und auf der VM vor dem ersten Request; kein Gateway-Hit.
-  - Deshalb zusaetzlicher isolierter VM-Nachweis mit derselben Gateway-Binary:
-    - temporaerer Fake-Upstream auf `127.0.0.1:19876`
-    - temporaerer Gateway auf `18080/18081` mit `ANTHROPIC_BASE_URL=http://127.0.0.1:19876`
-    - `curl -X POST http://127.0.0.1:18080/v1/messages ... Authorization: Bearer dummy-mitm-test`
-      -> `200` mit Anthropic-Message-Body und Text `HALLO`
-    - `tail /tmp/gateway296.log`
-      -> `pipeline request completed","provider":"anthropic-direct"`
-  - Damit ist der komplette `/v1/messages -> anthropic-direct -> upstream`-Pfad fuer die aktuelle Binary auf der VM belegt, unabhaengig vom blockierten `claude -p`-Prozess.
-
-## Task 4 evidence summary
-
-- Erster Live-Befund auf `#282`:
-  - `POST /operator/chat` wurde im ECS korrekt gehoert, aber der spaetere Bridge-Log lief fuer denselben Room-Chat noch mit `has_heard=false`
-  - Ursache: urgente Perceptions (`heard_text`, direkte Ansprache, Gaia) wurden bei Circuit-Open bzw. `429/503` im Daemon nicht fuer Retry behalten
-
-- Umgesetzter Fix:
-  - `services/sentinel-daemon/src/llm_bridge.rs`
-  - neuer Retry-Puffer fuer urgente Perceptions bei Circuit-Open, Semaphore-Timeout, HTTP-Fehlern, Parse-Fehlern und Request-Fehlern
-  - bestehende Priorisierung `insert_prefer_heard()` merged Retry-State und neue Perceptions desselben Agents weiterhin deterministisch
-
-- Gezielte Regressionen gruen:
-  - `cargo remote -c -- test -p sentinel-daemon insert_prefer_heard -- --nocapture`
-    -> `3` Tests PASS
-  - `cargo remote -c -- test -p sentinel-daemon should_retry_perception -- --nocapture`
-    -> PASS
-  - `cargo remote -c -- test -p sentinel-ecs get_recent_empty_after_set_heard -- --nocapture`
-    -> PASS
-  - `cargo remote -c -- test -p sentinel-ecs new_chat_visible_after_set_heard -- --nocapture`
-    -> PASS
-  - `cargo remote -c -- test -p sentinel-daemon build_gateway_request_formats_perception_for_gateway_compiler -- --nocapture`
-    -> PASS
-  - `cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings`
-    -> PASS
-
-- VM-Deploy:
-  - `systemctl cat sentinel-daemon | grep ExecStart`
-    -> `/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`
-  - neues Release-Binary nach `/opt/sentinel/bin/sentinel-daemon` kopiert und Dienst neu gestartet
-  - `systemctl is-active sentinel-daemon`
-    -> `active`
-
-- Live-Evidence nach Deploy:
-  - Raumbelegung:
-    `curl -s localhost:8000/api/agents | ... current_room == buero-dev-1`
-    -> `ROOM_COUNT 5` (`Andreas Wolff`, `Julia Neumann`, `Kai Fischer`, `Lena Hoffmann`, `Hannah Meier`)
-  - Operator-Chat:
-    `POST localhost:8084/operator/chat`
-    -> `{"accepted":true,"message":"Chat in RoomChatBuffer eingefuegt"}`
-  - ECS-Wahrnehmung:
-    `journalctl -u sentinel-daemon --since '2026-04-03 13:56:10' ...`
-    -> `Operator-Chat in RoomChatBuffer eingefuegt`
-    -> `output_system: heard_text gefunden` fuer alle `5` aktuellen Agents in `buero-dev-1`
-  - Bridge-/Retry-Nachweis:
-    derselbe Journal-Ausschnitt zeigt danach wiederholt `LLM call triggered ... has_heard=true` fuer die Live-Raumbesetzung (`AGENT-05`, `AGENT-06`, `AGENT-07`, `AGENT-08`, `AGENT-15`)
-    -> Room-Chat bleibt jetzt bis zur Bridge erhalten, auch wenn der Upstream weiter `429/503` liefert
-  - Error-Level:
-    `journalctl -u sentinel-daemon --since '5 min ago' -p err --no-pager`
-    und
-    `journalctl _PID=$(pgrep cortex-gate) --since '5 min ago' -p err --no-pager`
-    -> jeweils `-- No entries --`
-  - Event-Store:
-    `sqlite3 /opt/sentinel/data/events.db "SELECT event_type, COUNT(*) ... last 60s ..."`
-    -> nur bestehende Event-Typen (`bio_state_updated`, `room_physics_updated`, `judge_alert_received`, `agent_action_received`, `hallway_encounter_detected`, `tick_snapshot`, `transit_started`), keine neue Room-Chat-spezifische Disk-Event-Klasse
-
-- Formale GitHub-Abschluss-Schritte:
-  - Kommentar mit kompletter Evidence auf `#282` hinterlegt
-  - `gh issue edit 282 --repo silentspike/project-sentinel --add-label status:verified --remove-label status:backlog`
-  - `gh issue close 282 --repo silentspike/project-sentinel`
-  - Ergebnis: `#282` ist `CLOSED`
-
-## Task 6 evidence summary
-
-- Runtime-Baseline auf der VM:
-  - `ssh ubuntu@10.0.0.240 "hostname && systemctl is-active sentinel-daemon sentinel-projection sentinel-gateway"`
-  - Ergebnis: Host erreichbar, alle drei Dienste `active`
-  - `curl -s localhost:8081/control/config` zeigte `primary_provider=claude-code`, `rate_limit_rps=0`, `synthesis_enabled=true`, `sequencing_enabled=true`, `tick_sync_enabled=true`, `apicp_enabled=true`
-  - `/api/agents` und `/api/rooms` lieferten jeweils `26` Eintraege
-  - Stabilitaet: kein `panic`, kein `drift`
-
-- Remote-Tests fuer `sentinel-ecs`:
-  - `cargo remote -c -- test -p sentinel-ecs -- --nocapture`
-  - Ergebnis:
-    - `68` unit tests PASS
-    - `7` acceptance PASS
-    - `7` acceptance_perception PASS
-    - `7` integration_event_path PASS
-    - `2` snapshot_perception PASS
-
-- Pflicht-Benchmarks:
-  - `cargo remote -c -- bench -p sentinel-ecs --bench room_phase2_bench -- --noplot --sample-size 20`
-  - Route-BFS: `2.59-7.09 us` (`< 100 us`)
-  - Encounter-Detection mit `26` Agents: `7.34-8.05 us` (`< 50 us`)
-  - Bio-Tick mit `26` Agents: `154.74-171.57 us` (`< 1100 ms`)
-
-- AC-1 und AC-4 PASS:
-  - Loopback-Sniff `strings -n 8 /tmp/room289-cap.txt` zeigte fuer stationaere Agents in `buero-betriebsarzt` den Impuls `[P3] Es ist eng hier.`
-  - Beispiel: `agent_id=48`, `room_id=buero-betriebsarzt`, `perception` enthaelt `[P3] Es ist eng hier.`
-
-- AC-2 PASS:
-  - Loopback-Sniff `strings -n 8 /tmp/room289-full.txt` zeigte nach weiterer Ueberfuellung desselben Raums den Impuls `[P3] Der Raum ist komplett voll.`
-  - Beispiele: `agent_id=49` und `agent_id=48`, jeweils `room_id=buero-betriebsarzt`
-
-- AC-3 PASS:
-  - Event-Store-/Gaia-Kette live belegt:
-    `operator_gaia_sent -> agent_action_received(Move) -> transit_started`
-  - Auch bei bereits vollem Zielraum wurde kein Hard-Block beobachtet; der Move wurde angenommen und Transit gestartet.
-
-- AC-5 und AC-6 PASS:
-  - `hallway_encounter_detected` live im Event-Store
-  - Loopback-Sniff zeigte exakte Encounter-Perception:
-    `Du triffst Ralf Steinbach (Betriebsratsvorsitzender (50% BR-Taetigkeit, 50% regulaere Aufgaben)) im Flur des Erdgeschosses. Begruesst du die Person kurz?`
-
-- AC-7 PASS:
-  - Event-Store belegte Begegnungen in `flur-eg` und `treppenhaus`
-  - Kein Gegenbeleg fuer unzulaessige Cross-Floor-Encounter zwischen `flur-eg` und `flur-og`
-
-- AC-8 und AC-9 PASS:
-  - `journalctl -u sentinel-daemon` plus Event-Fortschritt zeigten pause/resume-typisches Verhalten bei Transit-Clustern
-  - Zielankuenfte erfolgten spaeter nach der Encounter-Phase; Transit lief also weiter statt dauerhaft zu haengen
-
-- AC-10 PASS:
-  - `sqlite3 /opt/sentinel/data/events.db "SELECT ... FROM events WHERE event_type='transit_started' ..."`
-  - Live-Werte u. a. `15000`, `20000`, `40000`, `60000`, `80000 ms`
-
-- AC-11 und AC-12 PASS:
-  - Cross-Floor-Transits liefen ueber konkrete Zwischen-Raeume (`flur-og`, `treppenhaus`, `flur-eg`)
-  - Live-Agent-State und Transit-Perception zeigten zu jedem Zeitpunkt einen definierten aktuellen Transit-Raum
-
-- AC-13 PASS:
-  - Loopback-Sniff zeigte den exakten Transit-Text:
-    `Du bist auf dem Weg von im Buero der Geschaeftsfuehrung nach im Empfangsbereich. Du gehst gerade durch im Flur des Obergeschosses.`
-  - Ein weiterer Live-Fall zeigte:
-    `Du bist auf dem Weg von im Treppenhaus nach in der Betriebsmedizin. Du gehst gerade durch im Flur des Obergeschosses.`
-
-- AC-14 PASS:
-  - Stationaere Agents in `buero-betriebsarzt` hatten in der gleichen Capture lediglich:
-    `ENVIRONMENT: Du bist in der Betriebsmedizin.`
-  - Kein Transit-Block bei `in_transit=false`
-
-- AC-15 und AC-16 PASS:
-  - Journal-Zeitreihenanalyse der `LLM call triggered`-Zeitpunkte:
-    - idle Intervalle ca. `9.536-9.577s`
-    - aktive Raeume ca. `2.0-5.0s`
-  - Nach abklingender Chat-Aktivitaet stiegen die Intervalle wieder vom Minimalwert an
-
-- AC-17 PASS:
-  - `tick_snapshot`-Events zeigten weiter ca. `60` Ticks pro Minute auf der VM
-  - Benchmark und Live-Befund blieben deutlich unter dem Budget; Bio/Physics-Loop blieb effektiv bei `1 Hz`
-
-- Formale GitHub-Abschluss-Schritte:
-  - Kommentar mit kompletter Evidence auf `#289` hinterlegt
-  - `gh issue edit 289 --repo silentspike/project-sentinel --add-label 'status:verified' --remove-label 'status:triage' --remove-label 'quality:needs-spec'`
-  - `gh issue close 289 --repo silentspike/project-sentinel`
-  - Ergebnis: `#289` ist `CLOSED`
-
-## Task 7 evidence summary
-
-- Historische MITM-Parity-Luecke gegen `e4f8769` geschlossen:
-  - `cmd/cortex-gateway/main.go`: `POST /v1/messages` wiederhergestellt
-  - `cmd/cortex-gateway/internal/proxy/provider.go`: `RequestFormat`, `PreferredProvider`, `PassthroughHeaders` wiederhergestellt
-  - `cmd/cortex-gateway/internal/proxy/anthropic_api.go`: Anthropic-wire-format Parse/Response/Error helpers wiederhergestellt
-  - `cmd/cortex-gateway/internal/proxy/claude.go`: request-scoped Header-Passthrough und HTTP-Status-Weitergabe als `ProviderError`
-  - `cmd/cortex-gateway/internal/proxy/pipeline.go`: path-aware Parse/Error/Response-Pfade fuer `/v1/messages` wiederhergestellt
-  - `cmd/cortex-gateway/internal/proxy/judge_adapter.go`: passthrough-/format-sensitive Judge-Regen-Requests wiederhergestellt
-
-- Lokale Smoke-/Regression-Tests:
-  - `go test ./cmd/cortex-gateway/internal/...`
-  - Ergebnis: kompletter Gateway-Teststack gruen
-  - Wiederhergestellte Schluesseltests:
-    - `TestPipelineAnthropicMessagesPassthrough`
-    - `TestClaudeProviderSendUsesPassthroughHeaders`
-    - `TestClaudeProviderSendReturnsProviderErrorOnNon200`
-
-- VM-Deploy und Runtime-Evidence:
-  - Linux-Build:
-    `GOOS=linux GOARCH=amd64 go build -o cortex-gateway ./cmd/cortex-gateway/`
-  - Deploy:
-    `scp cortex-gateway ubuntu@10.0.0.240:/tmp/cortex-gateway`
-    `ssh ubuntu@10.0.0.240 "sudo systemctl stop sentinel-gateway && sudo cp /tmp/cortex-gateway /opt/sentinel/bin/cortex-gateway && sudo systemctl start sentinel-gateway && systemctl is-active sentinel-gateway"`
-  - Ergebnis: `sentinel-gateway` wieder `active`
-  - MITM-Smoke auf der VM:
-    - `POST /v1/messages` ohne Auth -> `401`
-    - Body: `{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",...}}`
-    - `POST /v1/messages` mit `Authorization` + `Anthropic-Version` -> ebenfalls path-spezifischer `401 authentication_error` statt `404` oder generischem internen JSON
-
-- Formale GitHub-Abschluss-Schritte:
-  - Kommentar mit kompletter Evidence auf `#298` hinterlegt
-  - `gh issue edit 298 --repo silentspike/project-sentinel --add-label 'status:verified' --remove-label 'status:triage' --remove-label 'quality:needs-spec'`
-  - `gh issue close 298 --repo silentspike/project-sentinel`
-  - Ergebnis: `#298` ist `CLOSED`
+- Was jetzt erledigt werden muss:
+  - `HallwayEncounterDetected` von inkonsistentem `location`-only Payload auf ein live auswertbares Raumfeld bringen
+  - Producer, Consumer und Tests in einem Zug synchron halten
+- Welche ACs jetzt bestehen müssen:
+  - AC-1: Encounter-Events haben auf der VM eine nicht-leere Raumangabe
+  - AC-2: Encounter-Perception bleibt für beteiligte Agents intakt
+  - AC-3: relevante Tests/Clippy sind grün
+- Wie ich jede AC beweise:
+  - AC-1 mit frischer `sqlite3`-Abfrage auf `events.db`
+  - AC-2 mit Daemon-/Event-Evidence nach provozierter Begegnung
+  - AC-3 mit `cargo remote -c -- test` und `cargo remote -c -- clippy`
+- Erwartete Dateiänderungen:
+  - `crates/sentinel-common/src/events.rs`
+  - `crates/sentinel-ecs/src/systems.rs`
+  - `crates/sentinel-ecs/src/decision.rs`
+  - relevante Tests in `crates/sentinel-ecs` und/oder `crates/sentinel-common`
+- Risiken / Abhängigkeiten:
+  - Event-Schemaänderung darf alte Reader nicht still brechen
+  - Live-Encounter muss sich auf der VM zeitnah provozieren lassen; sonst braucht die Task mehrere kurze Runtime-Anläufe

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,7 +4,7 @@
 
 - Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 2 - Traffic-Control-Config-Drift vereinheitlichen`
+- Current task: `Task 3 - company-context.md deploybar machen`
 - Current branch: `fix/post-soak-runtime-followups`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
 - Last refresh: `2026-04-04 / Task 1 live verifiziert`
@@ -12,8 +12,8 @@
 ## Current findings
 
 - `hallway_encounter_detected` speichert aktuell `location`, aber kein `room_id`; Live-DB zeigt deshalb leeres `$.room_id` trotz korrekter Begegnungs-Location `flur-eg`.
-- Die Gateway-Runtime läuft mit `synthesis_enabled=true`, `sequencing_enabled=true`, `tick_sync_enabled=true`; [config/daemon.toml](/work/company/project-sentinel/config/daemon.toml) steht dafür noch auf `false` und ist damit irreführend.
-- `/opt/sentinel/config/company-context.md` fehlt auf `10.0.0.240`; der Gateway fällt dadurch auf `defaultCompanyFacts` zurück statt die projektlokale Company-Datei zu laden.
+- Die Traffic-Control-Bootstrap-Flags sind jetzt zwischen Repo-`daemon.toml`, VM-`daemon.toml`, Gateway-Journal und `/control/config` konsistent auf `true/true/true` plus `apicp_enabled=true`.
+- `company-context.md` liegt auf der VM aktuell nur unter `/opt/sentinel/company-context.md`; der Gateway lädt also einen Root-Workdir-Pfad, obwohl die Repo-Quelle unter `config/company-context.md` liegt.
 - `/health` zeigt `claude-code:"open"`, obwohl im letzten Soak echte `claude-code`-Completions gelaufen sind; das deutet auf eine Breaker-/Health-Inkonsistenz statt auf einen vollständigen LLM-Ausfall.
 - Die Punkte `synthesis_rate` und `capacity live nicht verifiziert` bleiben Beobachtungen, sind aber nicht Teil dieses 4-Task-Fixlaufs.
 
@@ -30,8 +30,8 @@
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | Encounter-Event-Payload korrigieren | DONE | `HallwayEncounterDetected` so korrigieren, dass Event-Schema und Live-Payload die Begegnungs-Location konsistent als `room_id`/Ort transportieren; Reader und Tests mitziehen | inspect, command, system |
-| 2 | Traffic-Control-Config-Drift vereinheitlichen | IN_PROGRESS | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
-| 3 | `company-context.md` deploybar machen | TODO | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
+| 2 | Traffic-Control-Config-Drift vereinheitlichen | DONE | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
+| 3 | `company-context.md` deploybar machen | IN_PROGRESS | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
 | 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | TODO | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
 | 5 | Plan-Verifikation | TODO | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
@@ -113,6 +113,40 @@
   - AC-1 via Code-Inspection der Default-Pfade
   - AC-2 via VM-`/control/config` plus Config-Datei/Unit-Datei
   - AC-3 via Go-Tests
+- Outcome:
+  - `config/daemon.toml` bootstrapped die Traffic-Control-Flags jetzt auf denselben Stand wie die produktive Gateway-Runtime.
+  - Der Drift betrifft neben den drei gemeldeten Flags auch `apicp_enabled`; dieser Bootstrap-Wert wurde im selben Schritt mitgezogen.
+  - Nach Gateway-Restart werden die Dateiwerte unverändert geloggt und in `/control/config` sichtbar.
+- Evidence:
+  - AC-1 PASS:
+    - Repo-`config/daemon.toml`: `synthesis_enabled = true`, `sequencing_enabled = true`, `tick_sync_enabled = true`, `apicp_enabled = true`
+  - AC-2 PASS:
+    - VM-Datei: `grep -n ... /opt/sentinel/config/daemon.toml` => Zeilen 35-38 alle `true`
+    - VM-Journal: `traffic control defaults applied ... updates:{..., sequencing_enabled:true, synthesis_enabled:true, tick_sync_enabled:true, apicp_enabled:true}`
+    - VM-`/control/config`: `synthesis_enabled:true`, `sequencing_enabled:true`, `tick_sync_enabled:true`, `apicp_enabled:true`
+  - AC-3 PASS:
+    - `go test ./cmd/cortex-gateway/internal/control`
+    - `go test ./cmd/cortex-gateway`
+
+### Task 3 pre-task self-check
+
+- Was jetzt erledigt werden muss:
+  - den Company-Context-Lookup auf den Repo-/Deploy-Pfad `config/company-context.md` ausrichten
+  - den produktiven Copy-/Restart-Pfad so anpassen, dass die Datei auf der VM dort liegt und aus diesem Pfad geladen wird
+- Welche ACs jetzt bestehen müssen:
+  - AC-1: `company-context.md` liegt live unter `/opt/sentinel/config/company-context.md`
+  - AC-2: Gateway lädt den Company-Context aus dem Config-Pfad statt aus dem Workdir-Root
+  - AC-3: Company-Context bleibt nach Restart aktiv, ohne auf Fallback/Disabled zu fallen
+- Wie ich jede AC beweise:
+  - AC-1 mit `ls -l /opt/sentinel/config/company-context.md`
+  - AC-2 mit Gateway-Journal `company context loaded` plus Pfad
+  - AC-3 mit Journal ohne `company context disabled` und mit erfolgreichem Gateway-Start
+- Erwartete Dateiänderungen:
+  - `cmd/cortex-gateway/internal/compiler/assembler.go`
+  - ggf. Tests im Compiler
+  - ggf. Deploy-Artefakt bzw. VM-Datei
+- Risiken / Abhängigkeiten:
+  - der Lookup-Pfad darf bestehende Agent-DNA-/Rooms-Pfade nicht versehentlich mit umbiegen
 
 ### Task 3 - `company-context.md` deploybar machen
 

--- a/cmd/cortex-gateway/internal/compiler/assembler.go
+++ b/cmd/cortex-gateway/internal/compiler/assembler.go
@@ -36,7 +36,7 @@ func NewAssembler(loader *TOMLLoader, caps *capability.ProviderCapabilities) *As
 
 // LoadCompanyContext reads company-context.md from the config directory.
 func LoadCompanyContext(agentsDir string) string {
-	configDir := filepath.Dir(agentsDir)
+	configDir := filepath.Join(filepath.Dir(agentsDir), "config")
 	path := filepath.Join(configDir, "company-context.md")
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from trusted local config layout
 	if err != nil {

--- a/cmd/cortex-gateway/internal/compiler/assembler_test.go
+++ b/cmd/cortex-gateway/internal/compiler/assembler_test.go
@@ -205,10 +205,10 @@ func TestLoadCompanyContextReadsSiblingConfigDirectory(t *testing.T) {
 	baseDir := t.TempDir()
 	agentsDir := filepath.Join(baseDir, "agents")
 	configDir := filepath.Join(baseDir, "config")
-	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+	if err := os.MkdirAll(agentsDir, 0o750); err != nil {
 		t.Fatalf("MkdirAll(agents): %v", err)
 	}
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		t.Fatalf("MkdirAll(config): %v", err)
 	}
 

--- a/cmd/cortex-gateway/internal/compiler/assembler_test.go
+++ b/cmd/cortex-gateway/internal/compiler/assembler_test.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -196,6 +198,32 @@ func TestAssemble_MissingAgent(t *testing.T) {
 	_, err := asm.Assemble(99, "claude", EvolutionData{}, "")
 	if err == nil {
 		t.Error("Assemble() should fail for missing agent")
+	}
+}
+
+func TestLoadCompanyContextReadsSiblingConfigDirectory(t *testing.T) {
+	baseDir := t.TempDir()
+	agentsDir := filepath.Join(baseDir, "agents")
+	configDir := filepath.Join(baseDir, "config")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agents): %v", err)
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(config): %v", err)
+	}
+
+	agentPath := filepath.Join(agentsDir, "AGENT-01-THOMAS-CEO.toml")
+	if err := os.WriteFile(agentPath, []byte(testAgentTOML), 0o600); err != nil {
+		t.Fatalf("WriteFile(agent): %v", err)
+	}
+	want := "PixelPerfekt GmbH - Kontext aus config/company-context.md"
+	if err := os.WriteFile(filepath.Join(configDir, "company-context.md"), []byte(want), 0o600); err != nil {
+		t.Fatalf("WriteFile(company-context): %v", err)
+	}
+
+	got := LoadCompanyContext(agentsDir)
+	if got != want {
+		t.Fatalf("LoadCompanyContext() = %q, want %q", got, want)
 	}
 }
 

--- a/config/daemon.toml
+++ b/config/daemon.toml
@@ -32,10 +32,10 @@ enabled = true
 bind_addr = "127.0.0.1:8084"
 
 [daemon.traffic_control]
-synthesis_enabled = false
-sequencing_enabled = false
-tick_sync_enabled = false
-apicp_enabled = false
+synthesis_enabled = true
+sequencing_enabled = true
+tick_sync_enabled = true
+apicp_enabled = true
 tick_sync_timeout_ms = 2000
 p3_timeout_ms = 5000
 gateway_request_timeout_ms = 150000

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -225,7 +225,9 @@ pub enum DomainEventPayload {
     HallwayEncounterDetected {
         agent_a: AgentId,
         agent_b: AgentId,
-        location: String,
+        /// Aktuelle Encounter-Location. Alte Events nutzten das Feld `location`.
+        #[serde(alias = "location")]
+        room_id: String,
     },
     /// Geruchsereignis in einem Raum (Coffee, Food, etc.)
     SmellEventTriggered {
@@ -292,6 +294,51 @@ impl DomainEventPayload {
             Self::ResourceProfileChanged { .. } => "resource_profile_changed",
             Self::OperatorGaiaSent { .. } => "operator_gaia_sent",
             Self::OperatorBroadcastSent { .. } => "operator_broadcast_sent",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hallway_encounter_serializes_room_id() {
+        let payload = DomainEventPayload::HallwayEncounterDetected {
+            agent_a: AgentId(24),
+            agent_b: AgentId(28),
+            room_id: "flur-eg".to_string(),
+        };
+
+        let json = payload.to_json();
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+
+        assert_eq!(value["type"], "HallwayEncounterDetected");
+        assert_eq!(value["room_id"], "flur-eg");
+        assert!(
+            value.get("location").is_none(),
+            "new payloads must not keep the legacy location field"
+        );
+    }
+
+    #[test]
+    fn hallway_encounter_deserializes_legacy_location_alias() {
+        let json =
+            r#"{"type":"HallwayEncounterDetected","agent_a":24,"agent_b":28,"location":"flur-eg"}"#;
+
+        let payload: DomainEventPayload = serde_json::from_str(json).expect("legacy payload");
+
+        match payload {
+            DomainEventPayload::HallwayEncounterDetected {
+                agent_a,
+                agent_b,
+                room_id,
+            } => {
+                assert_eq!(agent_a, AgentId(24));
+                assert_eq!(agent_b, AgentId(28));
+                assert_eq!(room_id, "flur-eg");
+            }
+            other => panic!("unexpected payload: {other:?}"),
         }
     }
 }

--- a/crates/sentinel-ecs/src/decision.rs
+++ b/crates/sentinel-ecs/src/decision.rs
@@ -11,7 +11,7 @@ use super::world::{
     BroadcastBuffer, EventBuffer, GaiaBuffer, RoomChatBuffer, RoomInfoMap, SimulationTime,
 };
 use bevy_ecs::prelude::*;
-use sentinel_common::Emotion;
+use sentinel_common::{DomainEventPayload, Emotion};
 
 /// Standing Room: Zusaetzliche Plaetze ueber Capacity bevor "komplett voll".
 const STANDING_ROOM: u16 = 2;
@@ -415,14 +415,15 @@ fn generate_encounter_events(
         if domain_event.event_type != "hallway_encounter_detected" {
             continue;
         }
-        // Payload parsen
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&domain_event.payload) {
-            let a_id = value.get("agent_a").and_then(|v| v.as_u64()).unwrap_or(0) as u16;
-            let b_id = value.get("agent_b").and_then(|v| v.as_u64()).unwrap_or(0) as u16;
-            let location = value
-                .get("location")
-                .and_then(|v| v.as_str())
-                .unwrap_or("flur");
+
+        if let Ok(DomainEventPayload::HallwayEncounterDetected {
+            agent_a,
+            agent_b,
+            room_id,
+        }) = serde_json::from_str::<DomainEventPayload>(&domain_event.payload)
+        {
+            let a_id = agent_a.0;
+            let b_id = agent_b.0;
 
             // Ist dieser Agent beteiligt?
             let other_id = if agent_id.0 == a_id {
@@ -441,7 +442,7 @@ fn generate_encounter_events(
                     .map(|id| (id.name.as_str(), id.role.as_str()))
                     .unwrap_or(("jemand", "Mitarbeiter"));
 
-                let location_german = match location {
+                let location_german = match room_id.as_str() {
                     "flur-eg" => "im Flur des Erdgeschosses",
                     "flur-og" => "im Flur des Obergeschosses",
                     "treppenhaus" => "im Treppenhaus",
@@ -543,6 +544,9 @@ pub fn format_impulse_from_queue(queue: &EventQueue) -> String {
 mod tests {
     use super::*;
     use sentinel_common::Tick;
+
+    #[derive(Resource, Default)]
+    struct EncounterQueueResource(EventQueue);
 
     fn default_bio() -> BioState {
         BioState {
@@ -817,6 +821,70 @@ mod tests {
         let queue = default_queue();
         let result = format_impulse_from_queue(&queue);
         assert!(result.is_empty(), "Leere Queue = leerer String");
+    }
+
+    #[test]
+    fn test_encounter_event_legacy_location_payload_stays_readable() {
+        use sentinel_common::DomainEvent;
+
+        let mut world = World::new();
+        world.insert_resource(EncounterQueueResource::default());
+        world.spawn(AgentIdentity {
+            agent_id: sentinel_common::AgentId(24),
+            name: "Robin Krause".to_string(),
+            role: "Designer".to_string(),
+        });
+        world.spawn(AgentIdentity {
+            agent_id: sentinel_common::AgentId(28),
+            name: "Mara Schneider".to_string(),
+            role: "Entwicklerin".to_string(),
+        });
+
+        let payload =
+            r#"{"type":"HallwayEncounterDetected","agent_a":24,"agent_b":28,"location":"flur-eg"}"#;
+        world.insert_resource(EventBuffer {
+            events: vec![DomainEvent::new(
+                "hallway_encounter_detected",
+                "24-28",
+                payload,
+                "encounter-legacy-test",
+                1,
+            )],
+        });
+
+        fn harness(
+            event_buffer: Res<EventBuffer>,
+            all_agents: Query<&AgentIdentity>,
+            mut out: ResMut<EncounterQueueResource>,
+        ) {
+            generate_encounter_events(
+                sentinel_common::AgentId(24),
+                &event_buffer,
+                &all_agents,
+                &mut out.0,
+                1,
+            );
+        }
+
+        let mut schedule = Schedule::default();
+        schedule.add_systems(harness);
+        schedule.run(&mut world);
+
+        let queue = &world.resource::<EncounterQueueResource>().0;
+        assert_eq!(
+            queue.events.len(),
+            1,
+            "legacy payload should still generate one event"
+        );
+        assert!(
+            queue.events[0].text.contains("im Flur des Erdgeschosses"),
+            "expected germanized legacy flur-eg location, got: {}",
+            queue.events[0].text
+        );
+        assert!(
+            queue.events[0].text.contains("Mara Schneider"),
+            "expected other agent name in encounter event"
+        );
     }
 
     /// AC5: Performance - decision_system < 50us pro Tick bei 24 Agents

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -1107,6 +1107,17 @@ mod tests {
              when multiple agents are in transit (got 0 events after 30 ticks \
              with 3 agents in transit)"
         );
+
+        let payload: serde_json::Value = serde_json::from_str(&encounter_events[0].payload)
+            .expect("encounter payload must be valid json");
+        assert_eq!(
+            payload["room_id"], "flur-eg",
+            "encounter events must persist the encounter room as room_id"
+        );
+        assert!(
+            payload.get("location").is_none(),
+            "new encounter payloads must not keep the legacy location field"
+        );
     }
 
     /// Move-Action mit echtem Raumnamen → korrekte Transit-Duration via RoomDistanceMap

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -1905,11 +1905,11 @@ pub fn encounter_system(
     }
 
     // Pass 3: Encounter-Events emittieren + transit_paused setzen
-    for (entity_a, entity_b, id_a, id_b, location) in &encounters {
+    for (entity_a, entity_b, id_a, id_b, room_id) in &encounters {
         let payload = DomainEventPayload::HallwayEncounterDetected {
             agent_a: *id_a,
             agent_b: *id_b,
-            location: location.clone(),
+            room_id: room_id.clone(),
         };
         let event = DomainEvent::new(
             payload.event_type_str(),
@@ -1926,7 +1926,7 @@ pub fn encounter_system(
             pos_a.transit_pause_tick = tick;
             tracing::info!(
                 agent = %identity_a.name,
-                room = %location,
+                room = %room_id,
                 "Transit pausiert fuer Encounter"
             );
         }
@@ -1935,7 +1935,7 @@ pub fn encounter_system(
             pos_b.transit_pause_tick = tick;
             tracing::info!(
                 agent = %identity_b.name,
-                room = %location,
+                room = %room_id,
                 "Transit pausiert fuer Encounter"
             );
         }


### PR DESCRIPTION
## What changed
This PR closes the four post-soak runtime follow-ups that remained after the last VM verification pass.

1. Encounter events now persist `room_id` instead of leaving the field empty.
2. Traffic-control bootstrap defaults in `config/daemon.toml` now match the intended production runtime (`synthesis`, `sequencing`, `tick_sync`, `apicp` enabled).
3. The gateway now loads company context from `config/company-context.md` instead of the workdir root, and the file was deployed to the VM under `/opt/sentinel/config/company-context.md`.
4. The previously reported `claude-code` breaker/health mismatch was re-verified live; on the current runtime it stays `closed` after successful requests, so no extra code patch was needed for that point.

## Why it changed
The VM soak surfaced four real follow-ups:
- `hallway_encounter_detected` events documented encounters without a usable room field.
- Repo bootstrap config and live gateway runtime disagreed on traffic-control defaults.
- Company context existed in the repo but the runtime path and lookup behavior were inconsistent.
- `/health` had previously been observed as `claude-code: open` despite successful traffic, so the breaker path had to be checked end-to-end.

## Root causes
- Encounter payload producer/consumer drift: legacy `location` was still being emitted while downstream readers and diagnostics expected `room_id`.
- Bootstrap config drift: `config/daemon.toml` still encoded the old disabled defaults while production was already started with enabled traffic-control flags.
- Company context path drift: the gateway derived the context file from the agent directory parent instead of the `config/` sibling directory used by the repo and VM layout.
- Breaker issue was not a reproducible code defect on the current runtime; after controlled restart and fresh successful `claude-code` completions, `/health` and the breaker state were consistent.

## Impact
- Encounter events are now queryable by `room_id` in the event store without losing backward compatibility for old payloads.
- Repo defaults, VM config, gateway logs, and `/control/config` now agree on traffic-control bootstrap state.
- Company context is loaded from the intended config path and is deployed there on the VM.
- The breaker/health status is now re-evidenced on the current live runtime and documented in `PROGRESS.md`.

## Validation
Rust:
- `cargo remote -c -- test -p sentinel-common -p sentinel-ecs -p sentinel-daemon`
- `cargo remote -c -- clippy -p sentinel-common -p sentinel-ecs -p sentinel-daemon --all-targets -- -D warnings`

Go:
- `go test ./cmd/cortex-gateway/internal/control`
- `go test ./cmd/cortex-gateway`
- `go test ./cmd/cortex-gateway/internal/compiler`
- `go test ./cmd/cortex-gateway/internal/proxy -run 'TestHalfOpenSuccessCloses|TestCircuitBreakerE2E|TestBreakerStatesReflectsState'`

VM evidence:
- new `hallway_encounter_detected` rows show non-empty `room_id`
- `/opt/sentinel/config/daemon.toml` and `/control/config` both show enabled traffic-control flags
- `/opt/sentinel/config/company-context.md` exists and gateway logs `path:"config/company-context.md"`
- `/health` reports `{"circuit_breakers":{"claude-code":"closed"}}` after fresh successful `claude-code` requests
- no `panic`/`drift` hits during the verification window

## Files changed
- `crates/sentinel-common/src/events.rs`
- `crates/sentinel-ecs/src/decision.rs`
- `crates/sentinel-ecs/src/lib.rs`
- `crates/sentinel-ecs/src/systems.rs`
- `config/daemon.toml`
- `cmd/cortex-gateway/internal/compiler/assembler.go`
- `cmd/cortex-gateway/internal/compiler/assembler_test.go`
- `PROGRESS.md`

## Notes
- The repo still contains the pre-existing untracked local files `AGENTS.md`, `hooks/`, and `test-288-verification.md`; they are intentionally not part of this PR.
- Full per-task evidence remains in `PROGRESS.md`.
