### PR TITLE
fix: close security issues 291, 292 and 293

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Security: Snapshot-Codec von unmaintained `bincode 1` auf `bincode 2` migriert** (#293)
+  - `WorldSnapshot`-Encode/Decode laeuft jetzt ueber einen expliziten gemeinsamen Codec statt ueber direkte `bincode::serialize`-/`deserialize`-Aufrufe
+  - der neue Codec nutzt `bincode 2` mit `serde` und `legacy()`-Konfiguration, damit bestehende Snapshot-Payloads weiter lesbar bleiben
+  - der Daemon schreibt nach der Migration weiter neue Snapshots und kann vorhandene Alt-Snapshots auf der VM erfolgreich restaurieren
+
 - **Room-Chat-Forwarding: `heard_text` bleibt bei Gateway-Fehlern bis zur Bridge erhalten** (#282)
   - urgenter Room-Chat (`heard_text`, direkte Ansprache, Gaia) wird im Daemon jetzt bei offenem Circuit, `429/503`, Parse-Fehlern und Request-Timeouts fuer Retry gepuffert statt verloren zu gehen
   - dadurch bleibt der Pfad `Operator-Chat -> RoomChatBuffer -> heard_text -> LLM bridge has_heard=true` auch unter Upstream-Fehlern live nachweisbar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,25 +272,24 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.38.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64",
  "bytes",
- "futures",
+ "futures-util",
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -299,6 +298,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
  "tokio-websockets",
  "tracing",
@@ -1026,16 +1026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2269,7 +2259,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3128,12 +3118,6 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -3858,7 +3842,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4020,22 +4004,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -4044,10 +4015,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -4075,16 +4046,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
- "security-framework 3.7.0",
+ "rustls-webpki",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4095,17 +4066,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4204,25 +4164,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5232,6 +5179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,11 +5229,11 @@ dependencies = [
  "httparse",
  "rand 0.8.5",
  "ring",
- "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6258,6 +6216,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -7016,7 +6983,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "secrecy",
  "serde",
  "socket2 0.5.10",
@@ -7024,7 +6991,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 1.0.6",
  "x509-parser",
  "zenoh-buffers",
  "zenoh-codec",
@@ -7047,13 +7014,13 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pemfile",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "secrecy",
  "time",
  "tokio",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 1.0.6",
  "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
@@ -7071,7 +7038,7 @@ dependencies = [
  "async-trait",
  "quinn",
  "rustls",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "time",
  "tokio",
  "tokio-util",
@@ -7112,7 +7079,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "secrecy",
  "socket2 0.5.10",
  "time",
@@ -7121,7 +7088,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 1.0.6",
  "x509-parser",
  "zenoh-config",
  "zenoh-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,11 +550,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -5557,6 +5568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "unzip-n"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5667,6 +5684,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ insta = { version = "1.42", features = ["yaml"] }
 sha2 = "0.10"
 blake3 = "1"
 rayon = "1"
-async-nats = "0.38"
+async-nats = "0.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
 serde_json = "1"
-bincode = "1"
+bincode = { version = "2.0.1", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 anyhow = "1"
 toml = "1.0"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -82,7 +82,7 @@
   - Runtime-Impact auf Daemon/NATS live verifizieren
 - Acceptance criteria:
   - AC-1: `cargo remote -c -- tree -i rustls-webpki@0.102.8` zeigt keinen aktiven Produktivpfad mehr
-  - AC-2: relevante Rust-Tests und Clippy sind gruen
+  - AC-2: einschlaegige Rust-Tests und Clippy sind gruen
   - AC-3: Daemon startet und der NATS-/Bridge-Pfad bleibt auf `10.0.0.240` intakt
 - Outcome:
   - Der minimale sichere Upgrade-Korridor liegt bei `async-nats 0.47.0`; `0.45.0` und `0.46.0` hängen laut `cargo info --verbose` noch an `rustls-webpki@0.102`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,20 +2,18 @@
 
 ## Status
 
-- Plan source: `User-Freigabe 2026-04-04: vier echte Runtime-Fixes nach $start umsetzen`
-- Overall status: `DONE`
-- Current task: `Completed`
-- Current branch: `fix/post-soak-runtime-followups`
+- Plan source: `User-Freigabe 2026-04-04: codex-security.md nach $start umsetzen`
+- Overall status: `IN_PROGRESS`
+- Current task: `Task 2 - #291 rustls-webpki 0.102.8 / async-nats-Pfad beheben`
+- Current branch: `feat/security-291-292-293`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-04 / Task 1 live verifiziert`
+- Last refresh: `2026-04-04 11:01 UTC / Task 1 abgeschlossen`
 
 ## Current findings
 
-- `hallway_encounter_detected` speichert aktuell `location`, aber kein `room_id`; Live-DB zeigt deshalb leeres `$.room_id` trotz korrekter Begegnungs-Location `flur-eg`.
-- Die Traffic-Control-Bootstrap-Flags sind jetzt zwischen Repo-`daemon.toml`, VM-`daemon.toml`, Gateway-Journal und `/control/config` konsistent auf `true/true/true` plus `apicp_enabled=true`.
-- `company-context.md` wird jetzt aus `config/company-context.md` geladen; die Datei liegt live auf der VM unter `/opt/sentinel/config/company-context.md` und der Gateway loggt genau diesen Pfad.
-- Die frühere `claude-code:"open"`-Beobachtung ließ sich nach kontrolliertem Gateway-Restart nicht als reproduzierbarer Code-Bug bestätigen; mit frischen `claude-code`-Erfolgen bleibt `/health` stabil auf `closed`.
-- Die Punkte `synthesis_rate` und `capacity live nicht verifiziert` bleiben Beobachtungen, sind aber nicht Teil dieses 4-Task-Fixlaufs.
+- `#292` ist auf aktuellem `main` re-verifiziert und geschlossen: `Cargo.lock` enthält kein `rustls-webpki 0.103.9`, `cargo remote -c -- tree -i rustls-webpki@0.103.9` findet keinen Paketpfad mehr, `status:verified` ist gesetzt.
+- `#291` bleibt nach Plan der echte offene `rustls-webpki`-Rest über `async-nats` im Daemon-Pfad.
+- `#293` bleibt ein migrationskritischer `bincode`-Themenblock und ist nicht als bloßer Version-Bump zu behandeln.
 
 ## Blocked items
 
@@ -23,282 +21,78 @@
 
 ## Commit references
 
-- `3d23084` `Task [1]: Encounter-Event-Payload korrigieren`
-- `69b9572` `Task [2]: Traffic-Control-Config-Drift vereinheitlichen`
-- `5bc04cf` `Task [3]: company-context Deploy-Pfad korrigieren`
-- `5846f21` `Task [4]: Breaker-Health-Status live neu verifizieren`
+- `TBD` `Task [1]: #292 re-verifizieren und formal schließen`
 
 ## Task table
 
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
-| 1 | Encounter-Event-Payload korrigieren | DONE | `HallwayEncounterDetected` so korrigieren, dass Event-Schema und Live-Payload die Begegnungs-Location konsistent als `room_id`/Ort transportieren; Reader und Tests mitziehen | inspect, command, system |
-| 2 | Traffic-Control-Config-Drift vereinheitlichen | DONE | Repo-Defaults und Runtime-Intention für `synthesis_enabled`, `sequencing_enabled`, `tick_sync_enabled` konsistent machen und auf der VM verifizieren | inspect, command, system |
-| 3 | `company-context.md` deploybar machen | DONE | Sicherstellen, dass die projektlokale Company-Datei im produktiven Config-Pfad landet und live geladen wird | inspect, command, system |
-| 4 | `claude-code` Breaker-/Health-Inkonsistenz beheben | DONE | Health-/Breaker-Zustand so korrigieren, dass erfolgreiche `claude-code`-Nutzung nicht weiter als dauerhaft `open` gemeldet wird | inspect, command, system |
-| 5 | Plan-Verifikation | DONE | die vier Fixpunkte gegen Repo- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+| 1 | `#292` re-verifizieren und formal schließen | DONE | `rustls-webpki 0.103.9` auf aktuellem `main` gegen Lockfile, Dependency-Graph und Audit neu belegen; dann GitHub-Close-Workflow ausführen | inspect, command |
+| 2 | `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben | IN_PROGRESS | minimalen belastbaren Upgrade-Pfad implementieren, remote testen, auf VM deployen und NATS-/Daemon-Verhalten live verifizieren | inspect, command, system |
+| 3 | `#293` `bincode 1.3.3` ablösen | TODO | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
+| 4 | Plan-Verifikation | TODO | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
 
-### Task 1 - Encounter-Event-Payload korrigieren
+### Task 1 - `#292` re-verifizieren und formal schließen
 
 - Scope:
-  - Event-Typ und Producer/Consumer auf konsistente Location-Felder prüfen
-  - Payload so anpassen, dass `hallway_encounter_detected` live mit auswertbarer Raumangabe persistiert
-  - Regression-Tests ergänzen
+  - Lockfile und Dependency-Graph auf `rustls-webpki 0.103.9` prüfen
+  - frische Security-Evidence sammeln
+  - GitHub-Issue `#292` mit `status:verified` schließen
 - Checklist:
-  - Event-Typ in `sentinel-common` prüfen
-  - Producer in `sentinel-ecs` anpassen
-  - Consumer/Decision-Pfad anpassen
-  - Tests für Payload/Reader ergänzen
-  - Daemon deployen und Live-Encounter-Event auf VM prüfen
+  - `Cargo.lock` auf `0.103.9` vs `0.103.10` prüfen
+  - Dependency-Graph mit `cargo remote -c -- tree` prüfen
+  - wenn sinnvoll Audit-/Advisory-Evidence ergänzen
+  - Kommentar im Issue mit Evidence posten
+  - Label setzen und Issue schließen
 - Acceptance criteria:
-  - AC-1: neues Encounter-Event enthält live eine nicht-leere Raumangabe im erwarteten Feld
-  - AC-2: Encounter-Perception für Agents bleibt funktional
-  - AC-3: betroffene Rust-Tests und Clippy sind grün
+  - AC-1: `rustls-webpki 0.103.9` kommt im aktuellen Repo-Stand nicht mehr vor
+  - AC-2: `rustls-webpki 0.103.10` ist der aktive gepflegte Pfad
+  - AC-3: `#292` ist mit frischer Evidence und `status:verified` geschlossen
 - Evidence plan:
-  - AC-1 via `sqlite3 events.db ... hallway_encounter_detected ...`
-  - AC-2 via Daemon-Log/Perception-Flow oder bestehende Encounter-Live-Evidence nach neuem Event
-  - AC-3 via `cargo remote -c -- test ...` und `cargo remote -c -- clippy ...`
+  - AC-1 via `rg`/`Cargo.lock` und `cargo remote -c -- tree`
+  - AC-2 via `cargo remote -c -- tree -i rustls-webpki@0.103.10`
+  - AC-3 via GitHub-Issue-Kommentar, Label und Closed-State
 - Outcome:
-  - `DomainEventPayload::HallwayEncounterDetected` persistiert jetzt `room_id`; alte `location`-Payloads bleiben per `serde(alias = "location")` lesbar.
-  - Producer in `sentinel-ecs` emitten `room_id`, Reader in `decision.rs` deserialisieren den Event-Typ statt Roh-JSON auszulesen.
-  - Regressionstests decken neue Payloads und Legacy-Deserialisierung ab.
+  - `#292` ist formal geschlossen und mit frischer Evidence kommentiert.
+  - `Cargo.lock` zeigt nur noch `rustls-webpki 0.102.8` und `0.103.10`; `0.103.9` ist aus dem aktiven Repo-Stand verschwunden.
+  - Der verbliebene `rustls-webpki`-Rest wurde sauber auf `#291` eingegrenzt.
 - Evidence:
   - AC-1 PASS:
-    - VM nach Deploy: `sqlite3 ... hallway_encounter_detected ...`
-    - Ergebnis: `8725660|46|50|flur-og|` und `8725665|37|41|flur-eg|`
+    - `rg -n "rustls-webpki" Cargo.lock` => nur `0.102.8` und `0.103.10`
+    - `cargo remote -c -- tree -i rustls-webpki@0.103.9` => `did not match any packages`
   - AC-2 PASS:
-    - VM-Journal: `Transit pausiert fuer Encounter agent=Ralf Steinbach room=flur-og`
-    - VM-Journal: `Transit pausiert fuer Encounter agent=Katharina "Kathi" Wiegand room=flur-og`
-    - VM-Journal: `Transit pausiert fuer Encounter agent=Selina Hoffmann room=flur-eg`
-    - VM-Journal: `Transit pausiert fuer Encounter agent=Frank Berger room=flur-eg`
+    - `cargo remote -c -- tree -i rustls-webpki@0.103.10` => aktiver Pfad über `rustls 0.23.37`, `reqwest 0.12.28`, `quinn 0.11.9`, `zenoh-*` und `sentinel-daemon`
   - AC-3 PASS:
-    - `cargo remote -c -- test -p sentinel-common -p sentinel-ecs -p sentinel-daemon`
-    - `cargo remote -c -- clippy -p sentinel-common -p sentinel-ecs -p sentinel-daemon --all-targets -- -D warnings`
-  - Stability:
-    - `journalctl -u sentinel-daemon --since '5 min ago' | grep -Ei 'panic|drift'` => kein Treffer
+    - Kommentar: `issuecomment-4186940547`
+    - `gh issue edit 292 --add-label status:verified`
+    - `gh issue close 292`
 
-### Task 2 pre-task self-check
-
-- Was jetzt erledigt werden muss:
-  - die irreführenden `false`-Defaults in `config/daemon.toml` gegen die produktive Gateway-Runtime prüfen und sauber angleichen
-  - Defaulting, Dokumentation und Live-Konfiguration in einen konsistenten Zustand bringen
-- Welche ACs jetzt bestehen müssen:
-  - AC-1: Repo-Defaults widersprechen der produktiven Gateway-Runtime nicht mehr
-  - AC-2: `/control/config` und Repo-Config sind konsistent nachvollziehbar
-  - AC-3: betroffene Go-Tests bleiben grün
-- Wie ich jede AC beweise:
-  - AC-1 mit Source-Inspection der Config-/Default-Pfade
-  - AC-2 mit Repo-Config plus VM-`/control/config`
-  - AC-3 mit gezielten Go-Tests
-- Erwartete Dateiänderungen:
-  - `config/daemon.toml`
-  - ggf. Gateway-Konfig-/Testdateien
-- Risiken / Abhängigkeiten:
-  - die Änderung darf nur Dokumentations-/Default-Drift beheben, nicht unbeabsichtigt produktive Runtime-Semantik drehen
-
-### Task 2 - Traffic-Control-Config-Drift vereinheitlichen
+### Task 2 - `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben
 
 - Scope:
-  - Repo-Config/Defaults und produktive Gateway-Runtime zusammenziehen
-  - irreführende `false`-Defaults entfernen, wenn die gewollte Default-Runtime `true` ist
-- Checklist:
-  - Default-Pfade in Gateway-Control prüfen
-  - `config/daemon.toml` und Default-Parsing angleichen
-  - Tests für Default-Import anpassen
-  - VM-Runtime auf Konsistenz prüfen
+  - minimalen Upgrade-Korridor fuer `async-nats` finden
+  - verbleibenden `rustls-webpki 0.102.8`-Pfad aus dem aktiven Graph entfernen
+  - Runtime-Impact auf Daemon/NATS live verifizieren
 - Acceptance criteria:
-  - AC-1: Repo-Defaults widersprechen der produktiven Gateway-Runtime nicht mehr
-  - AC-2: `/control/config` und Repo-Config sind konsistent nachvollziehbar
-  - AC-3: betroffene Tests bleiben grün
-- Evidence plan:
-  - AC-1 via Code-Inspection der Default-Pfade
-  - AC-2 via VM-`/control/config` plus Config-Datei/Unit-Datei
-  - AC-3 via Go-Tests
-- Outcome:
-  - `config/daemon.toml` bootstrapped die Traffic-Control-Flags jetzt auf denselben Stand wie die produktive Gateway-Runtime.
-  - Der Drift betrifft neben den drei gemeldeten Flags auch `apicp_enabled`; dieser Bootstrap-Wert wurde im selben Schritt mitgezogen.
-  - Nach Gateway-Restart werden die Dateiwerte unverändert geloggt und in `/control/config` sichtbar.
-- Evidence:
-  - AC-1 PASS:
-    - Repo-`config/daemon.toml`: `synthesis_enabled = true`, `sequencing_enabled = true`, `tick_sync_enabled = true`, `apicp_enabled = true`
-  - AC-2 PASS:
-    - VM-Datei: `grep -n ... /opt/sentinel/config/daemon.toml` => Zeilen 35-38 alle `true`
-    - VM-Journal: `traffic control defaults applied ... updates:{..., sequencing_enabled:true, synthesis_enabled:true, tick_sync_enabled:true, apicp_enabled:true}`
-    - VM-`/control/config`: `synthesis_enabled:true`, `sequencing_enabled:true`, `tick_sync_enabled:true`, `apicp_enabled:true`
-  - AC-3 PASS:
-    - `go test ./cmd/cortex-gateway/internal/control`
-    - `go test ./cmd/cortex-gateway`
+  - AC-1: `cargo remote -c -- tree -i rustls-webpki@0.102.8` zeigt keinen aktiven Produktivpfad mehr
+  - AC-2: relevante Rust-Tests und Clippy sind gruen
+  - AC-3: Daemon startet und der NATS-/Bridge-Pfad bleibt auf `10.0.0.240` intakt
 
-### Task 3 pre-task self-check
-
-- Was jetzt erledigt werden muss:
-  - den Company-Context-Lookup auf den Repo-/Deploy-Pfad `config/company-context.md` ausrichten
-  - den produktiven Copy-/Restart-Pfad so anpassen, dass die Datei auf der VM dort liegt und aus diesem Pfad geladen wird
-- Welche ACs jetzt bestehen müssen:
-  - AC-1: `company-context.md` liegt live unter `/opt/sentinel/config/company-context.md`
-  - AC-2: Gateway lädt den Company-Context aus dem Config-Pfad statt aus dem Workdir-Root
-  - AC-3: Company-Context bleibt nach Restart aktiv, ohne auf Fallback/Disabled zu fallen
-- Wie ich jede AC beweise:
-  - AC-1 mit `ls -l /opt/sentinel/config/company-context.md`
-  - AC-2 mit Gateway-Journal `company context loaded` plus Pfad
-  - AC-3 mit Journal ohne `company context disabled` und mit erfolgreichem Gateway-Start
-- Erwartete Dateiänderungen:
-  - `cmd/cortex-gateway/internal/compiler/assembler.go`
-  - ggf. Tests im Compiler
-  - ggf. Deploy-Artefakt bzw. VM-Datei
-- Risiken / Abhängigkeiten:
-  - der Lookup-Pfad darf bestehende Agent-DNA-/Rooms-Pfade nicht versehentlich mit umbiegen
-
-### Task 3 - `company-context.md` deploybar machen
+### Task 3 - `#293` `bincode 1.3.3` ablösen
 
 - Scope:
-  - den produktiven Company-Context-Dateipfad absichern
-  - fehlende Deployment-Stufe ergänzen
-- Checklist:
-  - Source-Datei im Repo prüfen
-  - Deploy-/Copy-Pfad ergänzen oder dokumentiert automatisieren
-  - Datei auf VM ablegen
-  - Gateway-Neustart und Lade-Log prüfen
+  - Serialisierungs-/Snapshot-Grenzen explizit aufnehmen
+  - Migrationsstrategie `dual-read / new-write` oder gleichwertig implementieren
+  - Restore/Snapshot live verifizieren
 - Acceptance criteria:
-  - AC-1: `company-context.md` liegt auf der VM im erwarteten Pfad
-  - AC-2: Gateway loggt `company context loaded`
-  - AC-3: Fallback-only-Betrieb ist nicht mehr der aktive Produktionspfad
-- Evidence plan:
-  - AC-1 via `ls -l /opt/sentinel/config/company-context.md`
-  - AC-2 via Gateway-Journal
-  - AC-3 via Journal + Dateipfad
-- Outcome:
-  - Der Compiler leitet den Company-Context-Lookup jetzt aus dem `config`-Sibling der Agent-TOMLs ab statt aus dem Workdir-Root.
-  - Die Repo-Quelle `config/company-context.md` wird damit auf dem produktiven Layout korrekt auf `/opt/sentinel/config/company-context.md` gemappt.
-  - Gateway-Binary und Company-Context-Datei sind auf die VM deployed und nach Restart live verifiziert.
-- Evidence:
-  - AC-1 PASS:
-    - VM: `ls -l /opt/sentinel/config/company-context.md`
-    - Ergebnis: `-rw-r--r-- 1 root root 1242 ... /opt/sentinel/config/company-context.md`
-  - AC-2 PASS:
-    - VM-Journal: `company context loaded` mit `path:"config/company-context.md"`
-  - AC-3 PASS:
-    - kein `company context disabled`
-    - Gateway nach Restart `active (running)` und `/control/config` weiterhin erreichbar
-  - Test-Evidence:
-    - `go test ./cmd/cortex-gateway/internal/compiler`
-    - `go test ./cmd/cortex-gateway`
+  - AC-1: `bincode 1.3.3` ist nicht mehr im aktiven Graph
+  - AC-2: Snapshot-Erzeugung und -Restore funktionieren im Test
+  - AC-3: der Daemon liest/schreibt Snapshots auf der VM ohne Regression
 
-### Task 4 pre-task self-check
-
-- Was jetzt erledigt werden muss:
-  - die Diskrepanz zwischen erfolgreichem `claude-code`-Betrieb und `/health`-Status `open` auf den konkreten Breaker-/Health-Pfad zurückführen
-  - den Status so korrigieren, dass Erfolg den Providerzustand wieder sichtbar schließt
-- Welche ACs jetzt bestehen müssen:
-  - AC-1: `/health` meldet `claude-code` nach erfolgreichen Requests nicht weiter fälschlich `open`
-  - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
-  - AC-3: betroffene Gateway-Tests bleiben grün
-- Wie ich jede AC beweise:
-  - AC-1 mit VM-`/health` vor/nach reproduzierter Completion
-  - AC-2 mit Gateway-Journal `pipeline request completed` über `provider:"claude-code"`
-  - AC-3 mit gezielten Go-Tests
-- Erwartete Dateiänderungen:
-  - Breaker-/Health-Code im Gateway
-  - betroffene Tests
-- Risiken / Abhängigkeiten:
-  - echte `claude-code`-Completions auf der VM hängen von verfügbarem Quota und lebendem Gateway-/Daemon-Pfad ab
-
-### Task 4 - `claude-code` Breaker-/Health-Inkonsistenz beheben
+### Task 4 - Plan-Verifikation
 
 - Scope:
-  - Ursache für `claude-code:"open"` trotz erfolgreicher Requests identifizieren
-  - Health-/Breaker-Sicht korrigieren
-- Checklist:
-  - Breaker-/Health-Code prüfen
-  - Reproduktionspfad gegen Live-Logs abgleichen
-  - Fix implementieren
-  - Gateway deployen
-  - Health- und Live-Completion erneut prüfen
-- Acceptance criteria:
-  - AC-1: `/health` meldet `claude-code` nach erfolgreichem Betrieb nicht fälschlich dauerhaft `open`
-  - AC-2: erfolgreiche `claude-code`-Completions bleiben möglich
-  - AC-3: keine neue Gateway-Regression in den betroffenen Kontrollpfaden
-- Evidence plan:
-  - AC-1 via `/health`
-  - AC-2 via Gateway-Journal `pipeline request completed`
-  - AC-3 via Go-Tests + VM-Smoke
-- Outcome:
-  - Der gemeldete `open`-Zustand ließ sich auf dem aktuellen Stand nicht als verbleibender Codefehler reproduzieren.
-  - Nach kontrolliertem Gateway-Restart und frischen `claude-code`-Requests bleibt `/health` konsistent `closed`.
-  - Die vorhandenen Breaker-Tests decken den betroffenen Open→Half-Open→Closed-Pfad bereits ab; ein zusätzlicher Code-Patch war nicht nötig.
-- Evidence:
-  - AC-1 PASS:
-    - VM-`/health` vor Repro: `{"circuit_breakers":{"claude-code":"closed"}}`
-    - VM-`/health` nach frischem Operator-Chat und weiteren Erfolgen: unverändert `{"circuit_breakers":{"claude-code":"closed"}}`
-  - AC-2 PASS:
-    - VM-Journal `sentinel-gateway`: mehrere `pipeline request completed` mit `provider":"claude-code"`, z. B. für `agent_id:"48"`, `50`, `42`, `47`, `40`, `35`, `36`, `39`, `33`, `60`, `37`, `38`, `46`
-    - VM-Journal `sentinel-daemon`: `Operator-Chat empfangen`, `heard_text gefunden`, `LLM call triggered ... has_heard=true`, dazu `URGENT LLM Response erhalten`
-  - AC-3 PASS:
-    - `go test ./cmd/cortex-gateway/internal/proxy -run 'TestHalfOpenSuccessCloses|TestCircuitBreakerE2E|TestBreakerStatesReflectsState'`
-
-### Task 5 - Plan-Verifikation
-
-- Scope:
-  - alle vier Punkte gegen Repo und VM-Endstand prüfen
-- Checklist:
-  - Task-1- bis Task-4-Evidence gegen aktuellen Stand rereaden
-  - prüfen, ob noch offene Drift-/Deploy-Reste bestehen
-  - Abschlussstand in `PROGRESS.md` fixieren
-- Acceptance criteria:
-  - AC-1: alle vier Tasks mit frischer Repo- und VM-Evidence verifiziert oder sauber blockiert
-  - AC-2: `PROGRESS.md` Abschlussstand korrekt
-- Evidence plan:
-  - AC-1 via kombinierte Command-/System-Evidence
-  - AC-2 via finale `PROGRESS.md`-Inspektion
-- Outcome:
-  - Alle vier Task-Fixpunkte sind im Repo und auf der VM auf dem aktuellen Stand gegengeprüft.
-  - Es blieb kein verbleibender Blocker zurück; nur die bereits vorhandenen untracked Dateien im Repo wurden bewusst unangetastet gelassen.
-- Evidence:
-  - AC-1 PASS:
-    - Task 1 Endstand: neue `hallway_encounter_detected`-Events zeigen weiter `room_id`, z. B. `8726303|37|50|flur-eg|`
-    - Task 2 Endstand: VM-`daemon.toml` und `/control/config` zeigen weiter `synthesis/sequencing/tick_sync/apicp = true`
-    - Task 3 Endstand: `/opt/sentinel/config/company-context.md` existiert, aktuelles Gateway-Journal zeigt `path:"config/company-context.md"`
-    - Task 4 Endstand: `/health` zeigt `{"circuit_breakers":{"claude-code":"closed"}}`
-    - Stabilität: `journalctl -u sentinel-daemon --since '10 min ago' | grep -Ei 'panic|drift'` => kein Treffer
-  - AC-2 PASS:
-    - `PROGRESS.md` auf Abschlussstand aktualisiert
-    - Repo-Worktree enthält nur die bekannten untracked Dateien `AGENTS.md`, `hooks/`, `test-288-verification.md`
-
-### Task 5 - Plan-Verifikation
-
-- Scope:
-  - alle vier Punkte gegen Repo und VM-Endstand prüfen
-- Checklist:
-  - Plan rereaden
-  - jede AC erneut gegen Evidence spiegeln
-  - Restbefunde dokumentieren
-- Acceptance criteria:
-  - AC-1: alle vier Tasks mit frischer Repo- und VM-Evidence verifiziert oder sauber blockiert
-  - AC-2: `PROGRESS.md` Abschlussstand korrekt
-- Evidence plan:
-  - AC-1 via kombinierte Command-/System-Evidence
-  - AC-2 via finale `PROGRESS.md`-Inspektion
-
-## Task 1 pre-task self-check
-
-- Was jetzt erledigt werden muss:
-  - `HallwayEncounterDetected` von inkonsistentem `location`-only Payload auf ein live auswertbares Raumfeld bringen
-  - Producer, Consumer und Tests in einem Zug synchron halten
-- Welche ACs jetzt bestehen müssen:
-  - AC-1: Encounter-Events haben auf der VM eine nicht-leere Raumangabe
-  - AC-2: Encounter-Perception bleibt für beteiligte Agents intakt
-  - AC-3: betroffene Tests/Clippy sind grün
-- Wie ich jede AC beweise:
-  - AC-1 mit frischer `sqlite3`-Abfrage auf `events.db`
-  - AC-2 mit Daemon-/Event-Evidence nach provozierter Begegnung
-  - AC-3 mit `cargo remote -c -- test` und `cargo remote -c -- clippy`
-- Erwartete Dateiänderungen:
-  - `crates/sentinel-common/src/events.rs`
-  - `crates/sentinel-ecs/src/systems.rs`
-  - `crates/sentinel-ecs/src/decision.rs`
-  - betroffene Tests in `crates/sentinel-ecs` und/oder `crates/sentinel-common`
-- Risiken / Abhängigkeiten:
-  - Event-Schemaänderung darf alte Reader nicht still brechen
-  - Live-Encounter muss sich auf der VM zeitnah provozieren lassen; sonst braucht die Task mehrere kurze Runtime-Anläufe
+  - Security-Issues, Commits, Tests, Deploys und VM-Evidence gegen den Endstand abgleichen
+  - verbleibende Blocker oder Restrisiken klar dokumentieren

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,15 +4,15 @@
 
 - Plan source: `User-Freigabe 2026-04-04: codex-security.md nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 2 - #291 rustls-webpki 0.102.8 / async-nats-Pfad beheben`
+- Current task: `Task 3 - #293 bincode 1.3.3 ablösen`
 - Current branch: `feat/security-291-292-293`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-04 11:01 UTC / Task 1 abgeschlossen`
+- Last refresh: `2026-04-04 11:10 UTC / Task 2 abgeschlossen`
 
 ## Current findings
 
 - `#292` ist auf aktuellem `main` re-verifiziert und geschlossen: `Cargo.lock` enthält kein `rustls-webpki 0.103.9`, `cargo remote -c -- tree -i rustls-webpki@0.103.9` findet keinen Paketpfad mehr, `status:verified` ist gesetzt.
-- `#291` bleibt nach Plan der echte offene `rustls-webpki`-Rest über `async-nats` im Daemon-Pfad.
+- `#291` ist technisch behoben: Workspace-Dependency `async-nats` wurde von `0.38` auf `0.47.0` angehoben; `cargo remote -c -- tree -i rustls-webpki@0.102.8` findet keinen Paketpfad mehr.
 - `#293` bleibt ein migrationskritischer `bincode`-Themenblock und ist nicht als bloßer Version-Bump zu behandeln.
 
 ## Blocked items
@@ -22,14 +22,15 @@
 ## Commit references
 
 - `TBD` `Task [1]: #292 re-verifizieren und formal schließen`
+- `TBD` `Task [2]: fix issue 291 async-nats webpki path`
 
 ## Task table
 
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | `#292` re-verifizieren und formal schließen | DONE | `rustls-webpki 0.103.9` auf aktuellem `main` gegen Lockfile, Dependency-Graph und Audit neu belegen; dann GitHub-Close-Workflow ausführen | inspect, command |
-| 2 | `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben | IN_PROGRESS | minimalen belastbaren Upgrade-Pfad implementieren, remote testen, auf VM deployen und NATS-/Daemon-Verhalten live verifizieren | inspect, command, system |
-| 3 | `#293` `bincode 1.3.3` ablösen | TODO | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
+| 2 | `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben | DONE | minimalen belastbaren Upgrade-Pfad implementieren, remote testen, auf VM deployen und NATS-/Daemon-Verhalten live verifizieren | inspect, command, system |
+| 3 | `#293` `bincode 1.3.3` ablösen | IN_PROGRESS | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
 | 4 | Plan-Verifikation | TODO | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
@@ -79,6 +80,26 @@
   - AC-1: `cargo remote -c -- tree -i rustls-webpki@0.102.8` zeigt keinen aktiven Produktivpfad mehr
   - AC-2: relevante Rust-Tests und Clippy sind gruen
   - AC-3: Daemon startet und der NATS-/Bridge-Pfad bleibt auf `10.0.0.240` intakt
+- Outcome:
+  - Der minimale sichere Upgrade-Korridor liegt bei `async-nats 0.47.0`; `0.45.0` und `0.46.0` hängen laut `cargo info --verbose` noch an `rustls-webpki@0.102`.
+  - Workspace-Dependency in `Cargo.toml` wurde auf `async-nats = "0.47"` angehoben; `Cargo.lock` wurde entsprechend aktualisiert.
+  - Der Daemon läuft nach Release-Build und VM-Deploy sauber weiter und verbindet sich wieder mit NATS/JetStream.
+- Evidence:
+  - AC-1 PASS:
+    - `cargo remote -c -- tree -i rustls-webpki@0.102.8` => `did not match any packages`
+    - `cargo update -p async-nats --precise 0.47.0` => `Removing rustls-webpki v0.102.8`
+  - AC-2 PASS:
+    - `cargo remote -c -- test -p sentinel-daemon -p sentinel-zenoh` => exit `0`
+    - `cargo remote -c -- clippy -p sentinel-daemon -p sentinel-zenoh --all-targets -- -D warnings` => exit `0`
+  - AC-3 PASS:
+    - `cargo remote -c -- build -p sentinel-daemon --release` => exit `0`
+    - VM-Deploy: `systemctl is-active sentinel-daemon nats-server sentinel-nats-bridge` => alle `active`
+    - VM-Journal:
+      - `NATS Connected url="nats://127.0.0.1:4222"`
+      - `eBPF NATS Bridge verbunden url="nats://127.0.0.1:4222"`
+      - `NATS Stream SENTINEL_JUDGE ready`
+      - `Subscribed to sentinel.judge.alert.>`
+    - keine neuen `tls`-, `panic`- oder NATS-Verbindungsfehler im geprüften Restart-Fenster
 
 ### Task 3 - `#293` `bincode 1.3.3` ablösen
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,16 +4,17 @@
 
 - Plan source: `User-Freigabe 2026-04-04: codex-security.md nach $start umsetzen`
 - Overall status: `IN_PROGRESS`
-- Current task: `Task 3 - #293 bincode 1.3.3 ablösen`
+- Current task: `Task 4 - Security-Plan-Verifikation`
 - Current branch: `feat/security-291-292-293`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-04 11:10 UTC / Task 2 abgeschlossen`
+- Last refresh: `2026-04-04 11:22 UTC / Task 3 abgeschlossen`
 
 ## Current findings
 
 - `#292` ist auf aktuellem `main` re-verifiziert und geschlossen: `Cargo.lock` enthält kein `rustls-webpki 0.103.9`, `cargo remote -c -- tree -i rustls-webpki@0.103.9` findet keinen Paketpfad mehr, `status:verified` ist gesetzt.
 - `#291` ist technisch behoben: Workspace-Dependency `async-nats` wurde von `0.38` auf `0.47.0` angehoben; `cargo remote -c -- tree -i rustls-webpki@0.102.8` findet keinen Paketpfad mehr.
-- `#293` bleibt ein migrationskritischer `bincode`-Themenblock und ist nicht als bloßer Version-Bump zu behandeln.
+- `#293` ist technisch abgeschlossen: `bincode 1.3.3` ist aus dem Graph entfernt, Snapshots laufen jetzt über einen expliziten `bincode 2`-Codec mit `legacy()`-Kompatibilitätskonfiguration.
+- Die Live-Verifikation auf `10.0.0.240` belegt Alt-Snapshot-Restore und Neu-Snapshot-Write auf dem neuen Daemon-Binary.
 
 ## Blocked items
 
@@ -21,8 +22,9 @@
 
 ## Commit references
 
-- `TBD` `Task [1]: #292 re-verifizieren und formal schließen`
-- `TBD` `Task [2]: fix issue 291 async-nats webpki path`
+- `4fe4e65` `Task [1]: re-verify and close issue 292`
+- `2b37f76` `Task [2]: fix issue 291 async-nats webpki path`
+- `TBD` `Task [3]: migrate issue 293 off bincode 1`
 
 ## Task table
 
@@ -30,8 +32,8 @@
 |---|------|--------|-------|----------|
 | 1 | `#292` re-verifizieren und formal schließen | DONE | `rustls-webpki 0.103.9` auf aktuellem `main` gegen Lockfile, Dependency-Graph und Audit neu belegen; dann GitHub-Close-Workflow ausführen | inspect, command |
 | 2 | `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben | DONE | minimalen belastbaren Upgrade-Pfad implementieren, remote testen, auf VM deployen und NATS-/Daemon-Verhalten live verifizieren | inspect, command, system |
-| 3 | `#293` `bincode 1.3.3` ablösen | IN_PROGRESS | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
-| 4 | Plan-Verifikation | TODO | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+| 3 | `#293` `bincode 1.3.3` ablösen | DONE | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
+| 4 | Plan-Verifikation | IN_PROGRESS | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
 
@@ -111,6 +113,28 @@
   - AC-1: `bincode 1.3.3` ist nicht mehr im aktiven Graph
   - AC-2: Snapshot-Erzeugung und -Restore funktionieren im Test
   - AC-3: der Daemon liest/schreibt Snapshots auf der VM ohne Regression
+- Outcome:
+  - Workspace-Dependency wurde auf `bincode 2.0.1` mit `serde`-Feature umgestellt; der Snapshot-Pfad nutzt jetzt einen expliziten `snapshot_codec`.
+  - Der Codec verwendet `bincode::config::legacy()` und hält damit bestehende Snapshot-Payloads lesbar, ohne den unmaintained `bincode 1.3.3`-Pfad beizubehalten.
+  - Auf `10.0.0.240` wurde ein vorhandener Alt-Snapshot erfolgreich restauriert und direkt danach ein neuer Snapshot mit dem neuen Daemon geschrieben.
+- Evidence:
+  - AC-1 PASS:
+    - `cargo remote -c -- tree -i bincode@1.3.3` => `did not match any packages`
+    - `Cargo.lock` enthält `bincode 2.0.1`, `bincode_derive 2.0.1`, `unty`, `virtue`; kein `bincode 1.3.3`
+  - AC-2 PASS:
+    - `cargo remote -c -- test -p sentinel-common -p sentinel-daemon` => exit `0`
+    - `crates/sentinel-common/tests/snapshot_roundtrip.rs` => `4 passed`, inklusive `world_snapshot_codec_rejects_trailing_bytes`
+    - `cargo remote -c -- clippy -p sentinel-common -p sentinel-daemon --all-targets -- -D warnings` => exit `0`
+  - AC-3 PASS:
+    - `cargo remote -c -- build -p sentinel-daemon --release` => exit `0`
+    - VM-Deploy auf `10.0.0.240` mit neuem `sentinel-daemon` erfolgreich
+    - `POST /operator/restore` fuer Alt-Snapshot `019d55b2-5079-7590-9789-e1cc79ce7c69` => `{"accepted":true,"message":"Restore gestartet"}`
+    - Journal: `Hot-Swap Restore abgeschlossen snapshot_id=019d55b2-5079-7590-9789-e1cc79ce7c69 tick=3600 ... agents=26`
+    - Event-Store: `snapshot_restored|019d55b2-5079-7590-9789-e1cc79ce7c69|...|3600`
+    - `POST /operator/snapshot` => `{"accepted":true,"message":"Snapshot-Erstellung gestartet"}`
+    - Journal: `Manueller World Snapshot erstellt snapshot_id=019d583a-ad54-7e81-94fb-39fd1f6452da`
+    - `sqlite3 world_snapshots ORDER BY created_at DESC LIMIT 5` zeigt neue Snapshot-IDs `019d583a-ad54...`, `019d583a-6ae8...`, `019d583a-6700...`
+    - kein `Snapshot-Deserialisierung fehlgeschlagen`, kein `panic`, kein `drift` im Prüffenster
 
 ### Task 4 - Plan-Verifikation
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,11 +3,11 @@
 ## Status
 
 - Plan source: `User-Freigabe 2026-04-04: codex-security.md nach $start umsetzen`
-- Overall status: `IN_PROGRESS`
-- Current task: `Task 4 - Security-Plan-Verifikation`
+- Overall status: `DONE`
+- Current task: `Security-Plan abgeschlossen`
 - Current branch: `feat/security-291-292-293`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-04 11:22 UTC / Task 3 abgeschlossen`
+- Last refresh: `2026-04-04 11:24 UTC / Plan abgeschlossen`
 
 ## Current findings
 
@@ -15,6 +15,7 @@
 - `#291` ist technisch behoben: Workspace-Dependency `async-nats` wurde von `0.38` auf `0.47.0` angehoben; `cargo remote -c -- tree -i rustls-webpki@0.102.8` findet keinen Paketpfad mehr.
 - `#293` ist technisch abgeschlossen: `bincode 1.3.3` ist aus dem Graph entfernt, Snapshots laufen jetzt über einen expliziten `bincode 2`-Codec mit `legacy()`-Kompatibilitätskonfiguration.
 - Die Live-Verifikation auf `10.0.0.240` belegt Alt-Snapshot-Restore und Neu-Snapshot-Write auf dem neuen Daemon-Binary.
+- Alle drei Security-Issues `#291`, `#292` und `#293` sind jetzt `CLOSED` und tragen `status:verified`.
 
 ## Blocked items
 
@@ -24,7 +25,8 @@
 
 - `4fe4e65` `Task [1]: re-verify and close issue 292`
 - `2b37f76` `Task [2]: fix issue 291 async-nats webpki path`
-- `TBD` `Task [3]: migrate issue 293 off bincode 1`
+- `9ada98b` `Task [3]: migrate issue 293 off bincode 1`
+- `TBD` `Task [4]: verify security plan completion`
 
 ## Task table
 
@@ -33,7 +35,7 @@
 | 1 | `#292` re-verifizieren und formal schließen | DONE | `rustls-webpki 0.103.9` auf aktuellem `main` gegen Lockfile, Dependency-Graph und Audit neu belegen; dann GitHub-Close-Workflow ausführen | inspect, command |
 | 2 | `#291` `rustls-webpki 0.102.8` / `async-nats`-Pfad beheben | DONE | minimalen belastbaren Upgrade-Pfad implementieren, remote testen, auf VM deployen und NATS-/Daemon-Verhalten live verifizieren | inspect, command, system |
 | 3 | `#293` `bincode 1.3.3` ablösen | DONE | Snapshot-/Persistenzpfade auf gepflegte Alternative migrieren, kompatibel testen und live Restore verifizieren | inspect, command, system |
-| 4 | Plan-Verifikation | IN_PROGRESS | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
+| 4 | Plan-Verifikation | DONE | alle drei Security-Issues gegen Repo-, GitHub- und VM-Endstand vollständig gegenprüfen | inspect, command, system |
 
 ## Task details
 
@@ -141,3 +143,11 @@
 - Scope:
   - Security-Issues, Commits, Tests, Deploys und VM-Evidence gegen den Endstand abgleichen
   - verbleibende Blocker oder Restrisiken klar dokumentieren
+- Outcome:
+  - `#291`, `#292` und `#293` sind jeweils mit `status:verified` geschlossen.
+  - Der Security-Branch enthält drei getrennte Task-Commits für Re-Verify, Dependency-Fix und Snapshot-Migration.
+  - Der aktive Worktree ist bis auf die bekannten untracked Workspace-Dateien sauber.
+- Evidence:
+  - `gh issue view 291/292/293 --json state,labels` => alle `CLOSED` mit `status:verified`
+  - `git status --short` => keine verbleibenden tracked Änderungen
+  - VM-Endstand aus Task 2 und Task 3 bleibt stabil: `sentinel-daemon active`, keine `panic`-/`drift`-Treffer im Prüffenster

--- a/crates/sentinel-common/src/lib.rs
+++ b/crates/sentinel-common/src/lib.rs
@@ -12,9 +12,11 @@ pub mod feature_flags;
 pub mod generated;
 pub mod psi;
 pub mod room;
+pub mod snapshot_codec;
 pub mod types;
 
 pub use events::{DomainEvent, DomainEventPayload};
+pub use snapshot_codec::{decode_world_snapshot, encode_world_snapshot};
 pub use types::*;
 
 #[cfg(test)]

--- a/crates/sentinel-common/src/snapshot_codec.rs
+++ b/crates/sentinel-common/src/snapshot_codec.rs
@@ -9,8 +9,7 @@ fn legacy_config() -> impl bincode::config::Config {
 }
 
 pub fn encode_world_snapshot(snapshot: &WorldSnapshot) -> anyhow::Result<Vec<u8>> {
-    bincode::serde::encode_to_vec(snapshot, legacy_config())
-        .context("World Snapshot serialisieren")
+    bincode::serde::encode_to_vec(snapshot, legacy_config()).context("World Snapshot serialisieren")
 }
 
 pub fn decode_world_snapshot(bytes: &[u8]) -> anyhow::Result<WorldSnapshot> {

--- a/crates/sentinel-common/src/snapshot_codec.rs
+++ b/crates/sentinel-common/src/snapshot_codec.rs
@@ -1,0 +1,26 @@
+use anyhow::{anyhow, Context};
+
+use crate::WorldSnapshot;
+
+/// Bincode 2 in legacy mode keeps wire compatibility with the historic
+/// `bincode::serialize` / `deserialize` snapshots from bincode 1.x.
+fn legacy_config() -> impl bincode::config::Config {
+    bincode::config::legacy()
+}
+
+pub fn encode_world_snapshot(snapshot: &WorldSnapshot) -> anyhow::Result<Vec<u8>> {
+    bincode::serde::encode_to_vec(snapshot, legacy_config())
+        .context("World Snapshot serialisieren")
+}
+
+pub fn decode_world_snapshot(bytes: &[u8]) -> anyhow::Result<WorldSnapshot> {
+    let (snapshot, consumed) = bincode::serde::decode_from_slice(bytes, legacy_config())
+        .context("World Snapshot deserialisieren")?;
+    if consumed != bytes.len() {
+        return Err(anyhow!(
+            "World Snapshot enthaelt {} ungenutzte Bytes",
+            bytes.len() - consumed
+        ));
+    }
+    Ok(snapshot)
+}

--- a/crates/sentinel-common/tests/snapshot_roundtrip.rs
+++ b/crates/sentinel-common/tests/snapshot_roundtrip.rs
@@ -1,10 +1,13 @@
-//! Bincode roundtrip test fuer WorldSnapshot.
+//! Snapshot-Codec roundtrip tests fuer WorldSnapshot.
 
 use sentinel_common::components::*;
-use sentinel_common::{EcsSnapshot, RedbDump, SnapshotTier, WorldSnapshot};
+use sentinel_common::{
+    decode_world_snapshot, encode_world_snapshot, EcsSnapshot, RedbDump, SnapshotTier,
+    WorldSnapshot,
+};
 
 #[test]
-fn world_snapshot_bincode_roundtrip() {
+fn world_snapshot_codec_roundtrip() {
     let snapshot = WorldSnapshot {
         snapshot_id: "test-snapshot-001".to_string(),
         schema_version: WorldSnapshot::SCHEMA_VERSION,
@@ -82,11 +85,12 @@ fn world_snapshot_bincode_roundtrip() {
     };
 
     // Serialize
-    let bytes = bincode::serialize(&snapshot).expect("bincode serialize failed");
+    let bytes = encode_world_snapshot(&snapshot).expect("snapshot encode failed");
     assert!(!bytes.is_empty(), "serialized snapshot must not be empty");
 
     // Deserialize
-    let restored: WorldSnapshot = bincode::deserialize(&bytes).expect("bincode deserialize failed");
+    let restored: WorldSnapshot =
+        decode_world_snapshot(&bytes).expect("snapshot decode failed");
 
     // Verify fields
     assert_eq!(restored.snapshot_id, snapshot.snapshot_id);
@@ -157,8 +161,60 @@ fn empty_world_snapshot_roundtrip() {
         projection_offsets: vec![],
     };
 
-    let bytes = bincode::serialize(&snapshot).unwrap();
-    let restored: WorldSnapshot = bincode::deserialize(&bytes).unwrap();
+    let bytes = encode_world_snapshot(&snapshot).unwrap();
+    let restored: WorldSnapshot = decode_world_snapshot(&bytes).unwrap();
     assert_eq!(restored.snapshot_id, "empty");
     assert_eq!(restored.ecs.positions.len(), 0);
+}
+
+#[test]
+fn world_snapshot_codec_rejects_trailing_bytes() {
+    let snapshot = WorldSnapshot {
+        snapshot_id: "trailing".to_string(),
+        schema_version: WorldSnapshot::SCHEMA_VERSION,
+        tick: 1,
+        sim_hour: 1.0,
+        timestamp_ms: 1,
+        tier: SnapshotTier::Hourly,
+        last_event_id: 1,
+        redb: RedbDump {
+            agent_states: vec![],
+            room_states: vec![],
+            personalities: vec![],
+            relationships: vec![],
+            voice_styles: vec![],
+            behavioral_notes: vec![],
+            narrative_summaries: vec![],
+            evolution_versions: vec![],
+            nmda_scores: vec![],
+            agent_facts: vec![],
+            sim_meta: vec![],
+            api_patterns: vec![],
+        },
+        ecs: EcsSnapshot {
+            positions: vec![],
+            bio_states: vec![],
+            personalities: vec![],
+            moods: vec![],
+            perception_states: vec![],
+            work_contexts: vec![],
+            agent_capabilities: vec![],
+            event_queues: vec![],
+            identities: vec![],
+            shift_infos: vec![],
+            relationships: vec![],
+            llm_configs: vec![],
+            active_chaos_json: vec![],
+            active_stimuli_json: vec![],
+            sim_tick: 1,
+            sim_hour: 1.0,
+            sim_delta_seconds: 1.0,
+        },
+        projection_offsets: vec![],
+    };
+
+    let mut bytes = encode_world_snapshot(&snapshot).unwrap();
+    bytes.push(0xAA);
+
+    assert!(decode_world_snapshot(&bytes).is_err());
 }

--- a/crates/sentinel-common/tests/snapshot_roundtrip.rs
+++ b/crates/sentinel-common/tests/snapshot_roundtrip.rs
@@ -89,8 +89,7 @@ fn world_snapshot_codec_roundtrip() {
     assert!(!bytes.is_empty(), "serialized snapshot must not be empty");
 
     // Deserialize
-    let restored: WorldSnapshot =
-        decode_world_snapshot(&bytes).expect("snapshot decode failed");
+    let restored: WorldSnapshot = decode_world_snapshot(&bytes).expect("snapshot decode failed");
 
     // Verify fields
     assert_eq!(restored.snapshot_id, snapshot.snapshot_id);

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1789,7 +1789,7 @@ fn ecs_tick_loop(
                 // 1. Snapshot laden
                 match es.load_world_snapshot(&restore_cmd.snapshot_id) {
                     Ok(Some(bytes)) => {
-                        match bincode::deserialize::<sentinel_common::WorldSnapshot>(&bytes) {
+                        match sentinel_common::decode_world_snapshot(&bytes) {
                             Ok(snapshot) => {
                                 // 2. redb restore (atomare Transaktion)
                                 if let Err(e) = ss.restore_all_tables(&snapshot.redb) {
@@ -2047,7 +2047,7 @@ fn ecs_tick_loop(
                                 );
                             }
                             Err(e) => {
-                                error!(error = %e, "Snapshot bincode-Deserialisierung fehlgeschlagen");
+                                error!(error = %e, "Snapshot-Deserialisierung fehlgeschlagen");
                             }
                         }
                     }

--- a/services/sentinel-daemon/src/snapshot.rs
+++ b/services/sentinel-daemon/src/snapshot.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use sentinel_common::{SnapshotMeta, SnapshotTier, WorldSnapshot};
+use sentinel_common::{encode_world_snapshot, SnapshotMeta, SnapshotTier, WorldSnapshot};
 use sentinel_limbo::EventStore;
 use sentinel_redb::StateStore;
 use tracing::{debug, info};
@@ -122,8 +122,8 @@ impl SnapshotManager {
             projection_offsets,
         };
 
-        // 6. bincode serialisieren + in Limbo speichern
-        let bytes = bincode::serialize(&snapshot)?;
+        // 6. Snapshot serialisieren + in Limbo speichern
+        let bytes = encode_world_snapshot(&snapshot)?;
         let size = bytes.len();
         event_store.save_world_snapshot(
             &snapshot_id,


### PR DESCRIPTION
## Summary
- re-verify and formally close `#292` after confirming `rustls-webpki 0.103.9` is absent from the current graph
- remove the remaining `rustls-webpki 0.102.8` path by upgrading `async-nats` for `#291`
- migrate world snapshot encode/decode off unmaintained `bincode 1` to an explicit `bincode 2` codec with legacy-compatible decoding for `#293`
- record the full remote-build and VM-evidence trail in `PROGRESS.md`

## Why
The remaining security backlog was down to three Rust advisory items. Two were dependency-graph cleanup issues, while `#293` also carried runtime risk because snapshot restore compatibility had to be preserved on the live VM.

## Impact
- the active dependency graph no longer contains `rustls-webpki 0.103.9`, `rustls-webpki 0.102.8`, or `bincode 1.3.3`
- `sentinel-daemon` snapshot write/restore now goes through a shared codec instead of direct `bincode` calls
- existing snapshots on `10.0.0.240` remain restorable and new snapshots still write successfully

## Validation
- `cargo remote -c -- tree -i rustls-webpki@0.103.9`
- `cargo remote -c -- tree -i rustls-webpki@0.102.8`
- `cargo remote -c -- tree -i bincode@1.3.3`
- `cargo remote -c -- test -p sentinel-daemon -p sentinel-zenoh`
- `cargo remote -c -- test -p sentinel-common -p sentinel-daemon`
- `cargo remote -c -- clippy -p sentinel-daemon -p sentinel-zenoh --all-targets -- -D warnings`
- `cargo remote -c -- clippy -p sentinel-common -p sentinel-daemon --all-targets -- -D warnings`
- `cargo remote -c -- build -p sentinel-daemon --release`
- VM verification on `10.0.0.240`:
  - `sentinel-daemon`, `nats-server`, `sentinel-nats-bridge` active after deploy
  - old snapshot `019d55b2-5079-7590-9789-e1cc79ce7c69` restored successfully via `/operator/restore`
  - new snapshot `019d583a-ad54-7e81-94fb-39fd1f6452da` created successfully via `/operator/snapshot`
  - no `Snapshot-Deserialisierung fehlgeschlagen`, `panic`, or `drift` in the verification window

## Issues
- addresses `#291`
- addresses `#292`
- addresses `#293`
