### PR TITLE
feat: harden daemon runtime reconciliation (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Daemon Hardening: Runtime-Truth, Reconcile und deterministischer Stall-Restart** (#279)
+  - neues Runtime-Read-Model `RuntimeHealthSnapshot` plus `GET /operator/runtime-health` fuer Drift-, Worker- und Agent-Truth
+  - neuer Runtime-Control-Pfad `POST /operator/runtime/reconcile` fuer stale cleanup, orphan-cgroup cleanup, kontrollierten Respawn und Projection-Rebuild-Request
+  - `PlatformSideEffect::RestartAgent` fuehrt jetzt einen Fast-Respawn im selben Tick aus statt auf den naechsten Shift-Check zu warten
+  - neuer loopback-/auth-faehiger Testhook `POST /operator/runtime/stall-restart-test` mit synchronem `pid_before`/`pid_after`-Nachweis
+
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block
   - Flurbegegnungen nur im selben Transit-Raum; Encounter pausieren Transit und lassen ihn spaeter wieder anlaufen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `service_health` laeuft jetzt unter in-process `catch_unwind`-Supervision; `POST /operator/runtime/panic-test` belegt Worker-Respawn ohne Daemon-PID-Wechsel
   - Platform-Controlplane-Analysepfade sind jetzt bounded: Trigger werden coalesced, alte Eintraege bei Ueberlauf gedropped und Queue-Stats ueber Runtime-Health sowie `POST /operator/runtime/analysis-flood-test` sichtbar
   - Projection/API-Konvergenz nutzt read-only Projection-Reads fuer Runtime-Health, erkennt Projection-Drift, fordert Full-Rebuilds per Request-Datei an und vermeidet Restart-Storms bei laufendem Projection-Service
+  - FUSE/Landlock Runtime-Konsistenz ist jetzt fail-closed: Sandboxes nutzen `fs_mount` nur nach aktivem `sentinel-fs`-Mount, fallen sonst auf `/ram/agents` zurueck und erlauben Execute nur fuer Agent-Binary, Breakout-Helper und notwendige ELF-Loader
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - neuer loopback-/auth-faehiger Testhook `POST /operator/runtime/stall-restart-test` mit synchronem `pid_before`/`pid_after`-Nachweis
   - `service_health` laeuft jetzt unter in-process `catch_unwind`-Supervision; `POST /operator/runtime/panic-test` belegt Worker-Respawn ohne Daemon-PID-Wechsel
   - Platform-Controlplane-Analysepfade sind jetzt bounded: Trigger werden coalesced, alte Eintraege bei Ueberlauf gedropped und Queue-Stats ueber Runtime-Health sowie `POST /operator/runtime/analysis-flood-test` sichtbar
+  - Projection/API-Konvergenz nutzt read-only Projection-Reads fuer Runtime-Health, erkennt Projection-Drift, fordert Full-Rebuilds per Request-Datei an und vermeidet Restart-Storms bei laufendem Projection-Service
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Platform-Controlplane-Analysepfade sind jetzt bounded: Trigger werden coalesced, alte Eintraege bei Ueberlauf gedropped und Queue-Stats ueber Runtime-Health sowie `POST /operator/runtime/analysis-flood-test` sichtbar
   - Projection/API-Konvergenz nutzt read-only Projection-Reads fuer Runtime-Health, erkennt Projection-Drift, fordert Full-Rebuilds per Request-Datei an und vermeidet Restart-Storms bei laufendem Projection-Service
   - FUSE/Landlock Runtime-Konsistenz ist jetzt fail-closed: Sandboxes nutzen `fs_mount` nur nach aktivem `sentinel-fs`-Mount, fallen sonst auf `/ram/agents` zurueck und erlauben Execute nur fuer Agent-Binary, Breakout-Helper und notwendige ELF-Loader
+  - Runtime-Reconcile entfernt jetzt auch gestoppte Prozesse in verwaisten Agent-Cgroups ueber `cgroup.kill`/SIGKILL-Fallback und schreibt Projection-only Ghost-Agents als `agent_despawned` in den append-only Truth-Stream
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PlatformSideEffect::RestartAgent` fuehrt jetzt einen Fast-Respawn im selben Tick aus statt auf den naechsten Shift-Check zu warten
   - neuer loopback-/auth-faehiger Testhook `POST /operator/runtime/stall-restart-test` mit synchronem `pid_before`/`pid_after`-Nachweis
   - `service_health` laeuft jetzt unter in-process `catch_unwind`-Supervision; `POST /operator/runtime/panic-test` belegt Worker-Respawn ohne Daemon-PID-Wechsel
+  - Platform-Controlplane-Analysepfade sind jetzt bounded: Trigger werden coalesced, alte Eintraege bei Ueberlauf gedropped und Queue-Stats ueber Runtime-Health sowie `POST /operator/runtime/analysis-flood-test` sichtbar
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Projection/API-Konvergenz nutzt read-only Projection-Reads fuer Runtime-Health, erkennt Projection-Drift, fordert Full-Rebuilds per Request-Datei an und vermeidet Restart-Storms bei laufendem Projection-Service
   - FUSE/Landlock Runtime-Konsistenz ist jetzt fail-closed: Sandboxes nutzen `fs_mount` nur nach aktivem `sentinel-fs`-Mount, fallen sonst auf `/ram/agents` zurueck und erlauben Execute nur fuer Agent-Binary, Breakout-Helper und notwendige ELF-Loader
   - Runtime-Reconcile entfernt jetzt auch gestoppte Prozesse in verwaisten Agent-Cgroups ueber `cgroup.kill`/SIGKILL-Fallback und schreibt Projection-only Ghost-Agents als `agent_despawned` in den append-only Truth-Stream
+  - Runtime-Health und Runtime-Control liefern serverseitige Timing-Felder; `scripts/vm-issue-279-bench.sh` belegt Reconcile, Projection-Drift-Detection, bounded Analysis-Flood und Stall-Bookkeeping mit VM-Sidecar-Metriken
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - neuer Runtime-Control-Pfad `POST /operator/runtime/reconcile` fuer stale cleanup, orphan-cgroup cleanup, kontrollierten Respawn und Projection-Rebuild-Request
   - `PlatformSideEffect::RestartAgent` fuehrt jetzt einen Fast-Respawn im selben Tick aus statt auf den naechsten Shift-Check zu warten
   - neuer loopback-/auth-faehiger Testhook `POST /operator/runtime/stall-restart-test` mit synchronem `pid_before`/`pid_after`-Nachweis
+  - `service_health` laeuft jetzt unter in-process `catch_unwind`-Supervision; `POST /operator/runtime/panic-test` belegt Worker-Respawn ohne Daemon-PID-Wechsel
 
 - **Room-Kommunikation Phase 2: Soft-Cap, Hallway Encounters, Transit-Realismus, adaptiver Heartbeat** (#289)
   - Raum-Kapazitaeten als Soft-Cap mit Perceptions `Es ist eng hier.` und `Der Raum ist komplett voll.` statt hartem Block

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,6 +4252,7 @@ dependencies = [
  "sentinel-fs",
  "sentinel-hippocampus",
  "sentinel-limbo",
+ "sentinel-projection",
  "sentinel-redb",
  "sentinel-runtime",
  "sentinel-sandbox",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -101,7 +101,7 @@
 - `92b3279` Task [8] Slice F - Projection/API-Konvergenz
 - `7eb95cb` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
 - `90792a5` Task [10] Out-of-scope Follow-up - Haiku-Policy
-- `TBD` Task [11] Phase 3 - Tests, Clippy, Builds
+- `441ff3c` Task [11] Phase 3 - Tests, Clippy, Builds
 - `TBD` Task [12] Phase 4 - Deploy auf die VM
 - `TBD` Task [13] Phase 5 - AC-Matrix
 - `TBD` Task [14] Benchmarks

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -43,7 +43,7 @@
 
 ## Commit references
 
-- `TBD` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
+- `dca25ac` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
 - `TBD` Task [2] Phase 1 - Donor-Audit und Clean Port
 - `TBD` Task [3] Slice A - Runtime-Health-Read-Model
 - `TBD` Task [4] Slice B - Runtime-Control / Reconcile
@@ -65,7 +65,7 @@
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | Phase 0 - Issue-Repair und Baseline-Reset | DONE | frische VM-Baseline, Issue-Body-Repair, canonical-main-Reset, Post-Reset-Baseline ohne runtime-health | command, system, inspect |
-| 2 | Phase 1 - Donor-Audit und Clean Port | PENDING | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
+| 2 | Phase 1 - Donor-Audit und Clean Port | IN_PROGRESS | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
 | 3 | Slice A - Runtime-Health-Read-Model | PENDING | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
 | 4 | Slice B - Runtime-Control / Reconcile | PENDING | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
 | 5 | Slice C - Fast Stall Recovery | PENDING | deterministischer Kandidat, SIGSTOP/SIGCONT, Respawn/Reconcile | command, system |
@@ -141,3 +141,51 @@
   - `2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883  /opt/sentinel/bin/sentinel-daemon`
   - `10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3  /opt/sentinel/bin/sentinel-projection`
 - AC-4 PASS: Post-reset baseline uses only main-compatible checks and confirms `runtime_health_http=404`.
+
+## Task 2 - Phase 1: Donor-Audit und Clean Port
+
+### Pre-task self-check
+
+- Was muss getan werden: alten Donor-Branch lesen, Commit-/Diff-Scope klassifizieren, Haiku- und #264-fremde Arbeit ausschliessen, eine saubere Port-Reihenfolge fuer die Code-Slices herstellen.
+- Welche ACs muessen hier passen:
+  - AC-1: Donor-Commits sind gegen `main` sichtbar und klassifiziert.
+  - AC-2: Out-of-scope Commits/Dateien sind explizit ausgeschlossen.
+  - AC-3: Clean-port Reihenfolge fuer Slice A-F und conditional Slice G ist dokumentiert.
+- Wie wird bewiesen: `git log`, `git diff --name-status`, gezielte Code-Inspection, Abgleich gegen `codex-plan279.md`.
+- Erwartete Dateien: `PROGRESS.md`, ggf. `test-279-verification.md`; noch kein Produktionscode, solange nur Audit laeuft.
+- Risiken:
+  - Der alte Donor-Branch ist auf #264 gestackt und darf nicht direkt gemergt werden.
+  - Haiku-Pinning ist bewusst out-of-scope fuer #279.
+
+### Outcome
+
+- Donor sources inspected:
+  - old donor: `/work/company/project-sentinel-issue279`, branch `feat/issue-279-daemon-hardening`
+  - safer stack donor: `/work/company/project-sentinel-issue279-stack`, branch `feat/issue-279-daemon-hardening-stack`
+- The old donor contains `dbb1b8e` which pins agent LLM requests to `haiku`; this is rejected for #279.
+- The stack donor removed the Haiku commit, but still spans a broad stacked diff and is not mergeable as a branch.
+- Clean-port source of truth:
+  - use stack donor commits as code references
+  - path-limit each slice
+  - do not port stale donor evidence or donor `PROGRESS.md`
+- Port order is fixed:
+  - Slice A from `29a0fb5`
+  - Slice B from `146ef43`
+  - Slice C from `fdc40c7`
+  - Slice D from `6919e66`
+  - Slice E from `389b5e6`
+  - Slice F from `14560c4` plus relevant stabilization from `b1e376b`
+  - Slice G from `6c31975` only if needed
+  - Benchmarks from `ffca58b` with fresh current evidence
+
+### Evidence
+
+- `test-279-verification.md` contains Phase-1 command/output evidence.
+- AC-1 PASS:
+  - `git log --oneline --decorate --reverse origin/main..HEAD` run on both donor worktrees.
+  - `git range-diff origin/main...feat/issue-279-daemon-hardening-stack` shows the old #264 lineage and the #279 commit sequence.
+- AC-2 PASS:
+  - old donor `dbb1b8e` / `services/sentinel-daemon/src/llm_bridge.rs` is explicitly rejected.
+  - stale donor `PROGRESS.md`, old evidence and branch-wide #264 paths are excluded.
+- AC-3 PASS:
+  - clean port order and path-limited rules are documented in `test-279-verification.md`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -127,7 +127,7 @@
 - `441ff3c` Task [11] Phase 3 - Tests, Clippy, Builds
 - `aa4ee20` Task [12] Phase 4 - Deploy auf die VM
 - `e53cb5c` Task [13] Phase 5 - AC-Matrix
-- `TBD` Task [14] Benchmarks
+- `f752ffc` Task [14] Benchmarks
 - `TBD` Task [15] PR- und Close-Sequenz
 - `TBD` Task [16] Plan-Verifikation
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_13_DONE_TASK_14_PENDING`
-- Current task: `Task 14 - Benchmarks`
+- Overall status: `TASK_14_DONE_TASK_15_PENDING`
+- Current task: `Task 15 - PR- und Close-Sequenz`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -97,6 +97,13 @@
   - AC-5 `service_health` Panic-Test blieb im selben Daemon-PID `1485419`, Worker `running=true`, `restart_count=1`
   - AC-6 Flood-Test mit `10000` Triggern blieb bounded: `queue_depth=1`, `dropped=9983`, `coalesced=9999`, `rss_delta_kb=-80`
   - AC-7 30-Minuten-Soak endete PASS; Artefakte liegen auf der VM unter `/tmp/issue279-soak-20260423T123633Z`
+- Task 14 ist erledigt:
+  - Benchmark-Instrumentierung fuer `elapsed_us`, `snapshot_build_elapsed_us`, `enqueue_per_request_ns` und `bookkeeping_elapsed_ns` wurde implementiert
+  - Remote-Qualitaetsmatrix nach Instrumentierung ist gruen: `fmt`, Daemon-Tests `194 passed`, Clippy Daemon mit `--features fuse`, Release-Build Daemon
+  - finaler Daemon-Hash wurde auf die VM deployed: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`
+  - Benchmark-Harness `/opt/sentinel/scripts/vm-issue-279-bench.sh` lief auf `10.0.0.240` mit Sidecars fuer RAM, CPU, IOPS und Prozesszustand
+  - Benchmark-Artefakte liegen auf der VM unter `/tmp/issue279-bench-20260423T132030Z`
+  - alle vier Pflicht-Benchmarks sind PASS: Reconcile `2134us < 5000us`, Projection-Drift-Detection `817us < 5000us`, Analysis-Flood `148ns/request < 250000ns/request`, Stall-Bookkeeping `700ns < 50000ns`
 
 ## Blocked items
 
@@ -141,7 +148,7 @@
 | 11 | Phase 3 - Tests, Clippy, Builds | DONE | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
 | 12 | Phase 4 - Deploy auf die VM | DONE | ExecStart pruefen, scp/install, restart, post-restart smoke, Projection-/Cgroup-Drift reparieren | command, system |
 | 13 | Phase 5 - AC-Matrix | DONE | alle ACs mit Command, Output, PASS auf VM | command, system |
-| 14 | Benchmarks | PENDING | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
+| 14 | Benchmarks | DONE | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
 | 15 | PR- und Close-Sequenz | PENDING | PR mit Pflichtsektionen, labels, merge, branch delete, issue close erst nach verified | command |
 | 16 | Plan-Verifikation | PENDING | Plan Zeile fuer Zeile gegen Ergebnis pruefen, Abweichungen fixen | inspect, command |
 
@@ -759,3 +766,74 @@
   - `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`
   - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
   - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`
+
+## Task 14 - Benchmarks
+
+### Pre-task self-check
+
+- Was muss getan werden: issue-spezifische Benchmarks fuer Runtime-Reconcile, Projection-Drift-Detection, bounded Analysis-Flood und Stall-Recovery-Bookkeeping auf der Deploy-VM messen.
+- Welche ACs muessen hier passen:
+  - AC-1: Benchmarks messen serverseitige Runtime-Pfade, nicht HTTP-Wallclock mit 1-Hz-Tick-Wartezeit.
+  - AC-2: Sidecar-Monitoring fuer RAM, CPU, IOPS und Prozesszustand liegt pro Lauf vor.
+  - AC-3: finaler VM-Zustand bleibt healthy: `expected/runtime/projection/cgroups = 26/26/26/26`, keine stale/orphan/zombie/drift-Treffer.
+  - AC-4: `journalctl` seit Benchmark-Start zeigt keine Panic-/Drift-Regressionsmarker.
+- Wie wird bewiesen: `cargo remote -c --`, Deploy-Hash, `/opt/sentinel/scripts/vm-issue-279-bench.sh`, Sidecar-Artefakte unter `/tmp/issue279-bench-20260423T132030Z`.
+- Erwartete Dateien: `scripts/vm-issue-279-bench.sh`, `PROGRESS.md`, `test-279-verification.md`, `CHANGELOG.md`.
+- Risiken:
+  - HTTP-End-to-End-Zeit ist fuer diese Benchmarks nicht geeignet, weil Runtime-Control-Befehle im ECS-Tick abgearbeitet werden; deshalb wurden serverseitige Timing-Felder ergaenzt.
+
+### Outcome
+
+- Runtime-Control und Runtime-Health liefern benchmarkfaehige serverseitige Timing-Felder:
+  - `RuntimeReconcileResponse.elapsed_us`
+  - `RuntimeHealthSnapshot.snapshot_build_elapsed_us`
+  - `RuntimeAnalysisFloodTestResponse.enqueue_per_request_ns`
+  - `RuntimeStallRestartTestResponse.bookkeeping_elapsed_ns`
+- Remote-Qualitaetsmatrix nach Instrumentierung ist gruen:
+  - `cargo remote -c -- fmt --all`
+  - `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`: `194 passed`
+  - `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
+- VM-Deploy erfolgte am systemd-`ExecStart`-Pfad `/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`.
+- VM-Binary-Hash: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`.
+- Benchmark PASS:
+  - `runtime_reconcile_26_agents`: `2134us < 5000us`
+  - `projection_divergence_detection`: `817us < 5000us`
+  - `analysis_flood_cap`: `148ns/request < 250000ns/request`
+  - `stall_recovery_bookkeeping`: `700ns < 50000ns`
+- Finaler VM-Gate blieb healthy: `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`.
+
+### Evidence
+
+- `cargo remote -c -- fmt --all`
+  - PASS: exit `0`.
+- `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`
+  - PASS: `194 passed; 0 failed`.
+- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
+  - PASS: exit `0`.
+- `sha256sum target/release/sentinel-daemon`
+  - PASS: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d  target/release/sentinel-daemon`.
+- Deploy:
+  - `ssh ubuntu@10.0.0.240 "grep ExecStart /etc/systemd/system/sentinel-daemon.service"`
+  - PASS: `ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`.
+  - `scp target/release/sentinel-daemon ubuntu@10.0.0.240:/tmp/sentinel-daemon.issue279-bench`
+  - `ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/sentinel-daemon.issue279-bench /opt/sentinel/bin/sentinel-daemon && sudo systemctl restart sentinel-daemon"`
+  - PASS: service active, VM hash matches `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`.
+- Benchmark:
+  - `scp scripts/vm-issue-279-bench.sh ubuntu@10.0.0.240:/tmp/vm-issue-279-bench.sh`
+  - `ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/vm-issue-279-bench.sh /opt/sentinel/scripts/vm-issue-279-bench.sh && /opt/sentinel/scripts/vm-issue-279-bench.sh"`
+  - PASS: `BENCH_PASS out_dir=/tmp/issue279-bench-20260423T132030Z`.
+- Sidecars:
+  - `/tmp/issue279-bench-20260423T132030Z/free-before.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/free-after.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/vmstat-before.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/vmstat-after.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/iostat-before.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/iostat-after.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/ps-before.txt`
+  - `/tmp/issue279-bench-20260423T132030Z/ps-after.txt`
+- Final service gate:
+  - `sentinel-daemon`, `sentinel-projection`, `sentinel-gateway`, `sentinel-nats-bridge`: all `active`.
+  - `journalctl -u sentinel-daemon --since <benchmark-start>` panic/drift marker scan: empty.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_4_DONE_TASK_5_PENDING`
-- Current task: `Task 5 - Slice C: Fast Stall Recovery`
+- Overall status: `TASK_5_DONE_TASK_6_PENDING`
+- Current task: `Task 6 - Slice D: Worker-Supervision`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -44,6 +44,11 @@
   - Expected active Agents koennen mit Backoff N=3 respawned werden
   - Projection-Rebuild wird ueber `.projection-rebuild-request` entkoppelt angefordert
   - aktuelle #264-SIGSTOP-Semantik wurde bei Konfliktauflösung beibehalten
+- Slice C ist erledigt:
+  - `POST /operator/runtime/stall-restart-test` ist als synchroner Operator-Testhook verdrahtet
+  - `PlatformSideEffect::RestartAgent` nutzt jetzt einen same-tick Fast-Respawn statt verzögertem Despawn
+  - der Fast-Restart entfernt alte Runtime-, Security- und Sandbox-Fragmente und respawned danach denselben Agent
+  - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
 
 ## Blocked items
 
@@ -57,7 +62,7 @@
 - `dca25ac` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
 - `e2e7523` Task [2] Phase 1 - Donor-Audit und Clean Port
 - `f5be73b` Task [3] Slice A - Runtime-Health-Read-Model
-- `TBD` Task [4] Slice B - Runtime-Control / Reconcile
+- `ca44759` Task [4] Slice B - Runtime-Control / Reconcile
 - `TBD` Task [5] Slice C - Fast Stall Recovery
 - `TBD` Task [6] Slice D - Worker-Supervision
 - `TBD` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
@@ -79,7 +84,7 @@
 | 2 | Phase 1 - Donor-Audit und Clean Port | DONE | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
 | 3 | Slice A - Runtime-Health-Read-Model | DONE | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
 | 4 | Slice B - Runtime-Control / Reconcile | DONE | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
-| 5 | Slice C - Fast Stall Recovery | PENDING | deterministischer Kandidat, SIGSTOP/SIGCONT, Respawn/Reconcile | command, system |
+| 5 | Slice C - Fast Stall Recovery | DONE | deterministischer Stall-Testhook, same-tick Fast-Respawn, Runtime/Security/Sandbox-Recreate | inspect, command, system |
 | 6 | Slice D - Worker-Supervision | PENDING | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
 | 8 | Slice F - Projection/API-Konvergenz | PENDING | read-only Projection-Reads, Rebuild-Request, drift-heal | inspect, command, system |
@@ -297,3 +302,60 @@
 - `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
   - PASS: `Finished release profile [optimized] target(s) in 1m 00s`
   - artifact hash: `19ce8b228b5588142399a4f712afd4cd89b1caca2be43c1273355a3ad30fe724  target/release/sentinel-daemon`
+
+## Task 5 - Slice C: Fast Stall Recovery
+
+### Pre-task self-check
+
+- Was muss getan werden: Fast-Stall-Recovery aus dem Donor path-limited portieren, einen deterministischen Operator-Testhook bereitstellen und `PlatformSideEffect::RestartAgent` vom verzögerten Despawn auf same-tick Fast-Respawn umstellen.
+- Welche ACs muessen hier passen:
+  - AC-1: Operator-Testhook nimmt `agent_id`, `mode` und `stall_secs` an, validiert Eingaben und dispatcht in den ECS-Thread.
+  - AC-2: Fast-Restart entfernt alte Runtime-, Sandbox-, eBPF- und Security-Fragmente und erzeugt danach Runtime- und Security-State neu.
+  - AC-3: `PlatformSideEffect::RestartAgent` nutzt den Fast-Restart-Pfad statt nur zu despawnen.
+  - AC-4: relevante Remote-Tests, FUSE-Release-Build und `git diff --check` sind gruen.
+- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- fmt/test/build`, `sha256sum`, `git diff --check`.
+- Erwartete Dateien: `services/sentinel-daemon/src/runtime_control.rs`, `operator_api.rs`, `orchestrator.rs`, `runtime_health.rs`, `CHANGELOG.md`.
+- Risiken:
+  - Testhook darf kein Auth-Bypass sein; er laeuft ueber die bestehende Operator-API-Schutzschicht.
+  - Stall-Test darf den ECS-Thread nicht kuenstlich schlafen lassen.
+  - Fast-Restart darf keine alten cgroups oder Security-Snapshots zuruecklassen.
+
+### Outcome
+
+- Path-limited donor Slice C was applied from stack donor `fdc40c7`.
+- Added `RuntimeControlCommand::StallRestartTest` plus typed request/response structs.
+- Added `POST /operator/runtime/stall-restart-test`:
+  - rejects `agent_id=0`
+  - allows only `mode=sigstop` or `mode=direct`
+  - rejects `stall_secs=0`
+  - dispatches to the ECS owner thread and waits with `recv_timeout(10s)`
+- Added `restart_agent_fast_path()` in the orchestrator:
+  - captures `pid_before`
+  - tears down sandbox handle and unregisters eBPF cgroup id
+  - removes and terminates the old tracked process
+  - removes stale security runtime state
+  - despawns ECS/runtime state
+  - respawns the same configured agent immediately
+  - captures `pid_after` and runtime/security presence
+- Replaced `PlatformSideEffect::RestartAgent` with the same fast-path restart.
+- No Haiku/model-policy changes were introduced.
+
+### Evidence
+
+- `cargo remote -c -- fmt --check`
+  - PASS after applying remote rustfmt diffs locally.
+- `cargo remote -c -- test -p sentinel-daemon runtime_stall_restart -- --nocapture`
+  - PASS: `2 passed; 0 failed; 180 filtered out; finished in 1.49s`
+  - Covered tests:
+    - `operator_api::tests::runtime_stall_restart_test_is_forwarded_and_returns_response`
+    - `operator_api::tests::runtime_stall_restart_test_rejects_invalid_mode`
+- `cargo remote -c -- test -p sentinel-daemon restart_agent_fast_path -- --nocapture`
+  - PASS: `1 passed; 0 failed; 181 filtered out; finished in 0.14s`
+  - Covered test:
+    - `orchestrator::tests::test_restart_agent_fast_path_recreates_runtime_and_security_state`
+  - Note: build-server test sandbox logged `bwrap: Can't find source path /work/company`; this did not fail the test and is limited to the remote test fixture path.
+- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
+  - PASS: `Finished release profile [optimized] target(s) in 56.20s`
+  - artifact hash: `3470152e8b897217e2d2e547549b8f6759b3e733ec53d8a3ea8e00745da8d2bd  target/release/sentinel-daemon`
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_12_DONE_TASK_13_PENDING`
-- Current task: `Task 13 - Phase 5: AC-Matrix`
+- Overall status: `TASK_13_DONE_TASK_14_PENDING`
+- Current task: `Task 14 - Benchmarks`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -88,6 +88,15 @@
   - zweiter VM-Deploy mit Daemon-Hash `d6c30a324d85cbb3ec9d919a14e5f5744482cda75e59984e6133944289129d86`
   - Live-Reconcile meldete `orphan_cgroups_before=3`, `orphan_cgroups_after=0`, `orphan_cgroups_removed=3`
   - finaler Runtime-Health-Gate ist gruen: `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`, Dashboard-API `26`
+- Task 13 ist erledigt:
+  - `/tmp/opcurl` ist auf der VM installiert und operator-auth-aware
+  - AC-1 bis AC-7 wurden auf `10.0.0.240` mit echten Commands/Outputs belegt
+  - AC-2 Stall-Restart wechselte `Thomas Mueller` von PID `1487965` auf `1488241` und blieb healthy
+  - AC-3 Restore stellte den Original-Hash wieder her; Reconcile brachte die VM danach zurueck auf `26/26/26/26`
+  - AC-4 Projection-Drift wurde per SQLite-Delete erzeugt und durch Reconcile/Rebuild wieder auf `26/26/26/26` gebracht
+  - AC-5 `service_health` Panic-Test blieb im selben Daemon-PID `1485419`, Worker `running=true`, `restart_count=1`
+  - AC-6 Flood-Test mit `10000` Triggern blieb bounded: `queue_depth=1`, `dropped=9983`, `coalesced=9999`, `rss_delta_kb=-80`
+  - AC-7 30-Minuten-Soak endete PASS; Artefakte liegen auf der VM unter `/tmp/issue279-soak-20260423T123633Z`
 
 ## Blocked items
 
@@ -131,7 +140,7 @@
 | 10 | Out-of-scope Follow-up - Haiku-Policy | DONE | separates Gateway-/Policy-Issue #314 erstellt und in #279 verlinkt, nicht #279-Close-Bedingung | command, inspect |
 | 11 | Phase 3 - Tests, Clippy, Builds | DONE | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
 | 12 | Phase 4 - Deploy auf die VM | DONE | ExecStart pruefen, scp/install, restart, post-restart smoke, Projection-/Cgroup-Drift reparieren | command, system |
-| 13 | Phase 5 - AC-Matrix | PENDING | alle ACs mit Command, Output, PASS auf VM | command, system |
+| 13 | Phase 5 - AC-Matrix | DONE | alle ACs mit Command, Output, PASS auf VM | command, system |
 | 14 | Benchmarks | PENDING | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
 | 15 | PR- und Close-Sequenz | PENDING | PR mit Pflichtsektionen, labels, merge, branch delete, issue close erst nach verified | command |
 | 16 | Plan-Verifikation | PENDING | Plan Zeile fuer Zeile gegen Ergebnis pruefen, Abweichungen fixen | inspect, command |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -109,7 +109,7 @@
 - `7eb95cb` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
 - `90792a5` Task [10] Out-of-scope Follow-up - Haiku-Policy
 - `441ff3c` Task [11] Phase 3 - Tests, Clippy, Builds
-- `TBD` Task [12] Phase 4 - Deploy auf die VM
+- `aa4ee20` Task [12] Phase 4 - Deploy auf die VM
 - `TBD` Task [13] Phase 5 - AC-Matrix
 - `TBD` Task [14] Benchmarks
 - `TBD` Task [15] PR- und Close-Sequenz

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,379 +2,142 @@
 
 ## Status
 
-- Plan source: `/work/company/codex-plan264.md`
-- Overall status: `TASK_1_DONE_TASK_2_DONE_TASK_3_PENDING`
-- Current task: `Task 3 - Write-Anomaly Enforcement, SIGSTOP und Platform-Intervention-Audit (Phase B)`
-- Current branch: `feat/issue-264-security-hardening-closure`
+- Plan source: `/work/company/codex-plan279.md`
+- Overall status: `TASK_1_DONE_TASK_2_PENDING`
+- Current task: `Task 2 - Phase 1: Donor-Audit und Clean Port`
+- Current branch: `feat/issue-279-daemon-hardening-v2`
+- Worktree: `/work/company/project-sentinel-279-review`
+- Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-11 Europe/Vienna`
+- Last refresh: `2026-04-23 Europe/Vienna`
 
 ## Current findings
 
-- Ausgangsstand vor dem Branch-Schnitt: `main = origin/main = 0395905`.
-- Arbeitsbranch `feat/issue-264-security-hardening-closure` wurde frisch von diesem Stand angelegt.
-- Im Worktree existiert bereits eine fremde tracked Aenderung an `.gitignore`; sie bleibt unangetastet.
-- Projektregeln, globale Regeln, Workspace-Handover, repo-lokales `.claude/AGENTS.md` und der komplette `#264`-Plan wurden in dieser Session frisch gelesen.
-- Die Start-Hooks sind lokal in `.claude/settings.json` registriert:
-  - `~/bin/pretooluse-task-checklist-gate.sh`
-  - `~/bin/pretooluse-start-progress-gate.sh`
-  - `~/bin/posttooluse-start-enforcer.sh`
-- `mainrag search "issue 264 security hardening" --source claude-conversations --limit 5` ist aktuell nicht nutzbar, weil `http://localhost:3001/api/v1/sources` `Connection refused` liefert.
-- `gh issue view 264` bestaetigt die Truth-Repair-Ausgangslage:
-  - Ausgangsstand war `CLOSED` mit `status:verified`
-  - nach Truth-Repair ist `#264` jetzt `OPEN` mit `status:ready`
-  - Body ist auf den neuen Stand gezogen: AC-3 bleibt in scope, FUSE-Gate ist explizit, Kette ist korrigiert
-- Harte Ausfuehrungsregel aus dem Plan:
-  - Ohne klare AC-3-Scope-Entscheidung startet kein Feature-Task jenseits von Task 1.
-- Die Scope-Entscheidung fuer diese Ausfuehrung ist jetzt fest:
-  - **AC-3 bleibt in `#264` in scope**
-  - Wenn FUSE oder Artifact-Restore live nicht tragfaehig sind, ist das ein dokumentierter Blocker fuer `#264`, kein Re-Scope im Vorbeigehen
-- Frische Start-Baseline fuer `#264` ist belegt:
-  - `services/sentinel-daemon/Cargo.toml` enthaelt `default = [..., "fuse"]` und eigenes `fuse` Feature
-  - Live auf `10.0.0.240` ist aktuell **kein** `fs_mount` in `daemon.toml` gesetzt
-  - Live auf `10.0.0.240` existiert der Trigger `protect_recent_snapshots`
-  - `sentinel-daemon`, `sentinel-gateway` und `sentinel-projection` sind `active`
-  - `landlock.rs` nutzt aktuell `all_access` fuer `write_paths`
-  - `cockpit.ts` mappt sowohl `platform_analysis` als auch `platform_intervention`
-- Task-2-Readiness und Live-Evidence stehen jetzt:
-  - `operator_api.rs` exponiert die geplanten loopback-only `/operator/security/*` Hooks fuer Trash, Runtime-State, Write-Anomaly und Landlock
-  - `orchestrator.rs` tracked dafuer live `bwrap_pid`, Agent-Home und optionales `fs_mount` in einem shared Runtime-State
-  - `ArtifactPlane::open()` initialisiert jetzt auch `fs_trash_queue`; ohne diesen Fix waeren die neuen Trash-Inspect-/GC-Pfade auf leeren Tabellen gelandet
-  - `breakout-helper` deckt jetzt die Landlock-Szenarien `exec-from-home`, `exec-bin-sh` und `exec-python3` ab; vorher war nur `exec-from-tmp` implementiert
-  - Der Live-Befund auf `10.0.0.240` war erst rot im Detail:
-    - `landlock-test` lieferte korrekt `exit_code=1` plus `Permission denied`, aber der Response markierte faelschlich `blocked:false`
-  - Der Fix ist jetzt deployed und live bestaetigt:
-    - dieselben Exec-Szenarien liefern `blocked:true`
-  - Der tatsaechliche API-Contract der Task-2-Hooks ist dokumentiert:
-    - `fs-trash-fixture` braucht `agent_name`, `relative_path`, `content`
-    - `write-anomaly-test` braucht `agent_name`, `mode`, `bytes_per_sec`
+- `$start` wurde fuer diese Ausfuehrung aktiviert.
+- Projektregeln, globale Regeln, Workspace-Handover und der komplette `#279`-Plan wurden in dieser Session frisch gelesen.
+- Der neue Worktree ist sauber von `origin/main` geschnitten; alte #264/#279-Stack-Worktrees bleiben unangetastet.
+- `gh issue view 279` ist erreichbar; GitHub ist aktuell die SSOT.
+- `#279` ist `OPEN` und steht aktuell auf `status:in-progress`.
+- Der GitHub-Issue-Body ist stale: er enthaelt noch `Blocked by #278`, alte Runtime-Zahlen und muss vor Codearbeit truth-repaired werden.
+- `mainrag search "issue 279 daemon hardening runtime" --source claude-conversations --limit 5` ist aktuell nicht nutzbar, weil `localhost:3001` `Connection refused` liefert. Das ist kein Task-Blocker, aber ein dokumentierter Kontextverlust.
+- Phase 0 ist erledigt:
+  - frische Pre-Reset-VM-Baseline ist in `test-279-verification.md` dokumentiert
+  - GitHub-Issue `#279` wurde auf frische 2026-04-23-Wahrheit repariert
+  - canonical `main` wurde remote gebaut und auf `10.0.0.240` deployed
+  - Post-Reset-Baseline zeigt erwartetes `runtime_health_http=404`
+  - Drift bleibt auf `main` reproduzierbar: API/Projection `57`, live cgroups `29`
+- Review-Entscheidungen aus dem Plan:
+  - Haiku-/Model-Policy ist out-of-scope fuer `#279`.
+  - Der Branch darf keine #264-Stack-Commits enthalten.
+  - Frische VM-Zahlen muessen dynamisch gemessen werden, nicht aus alten Reviews kopiert werden.
+  - Canonical-main-Reset muss ohne `/operator/runtime-health` messbar sein, weil `main` diesen Endpoint noch nicht hat.
+  - Operator-Auth wird spaeter ueber einen gemeinsamen `/tmp/opcurl` Helper operationalisiert.
+  - FUSE/Landlock bekommt nur bei aktivem Slice G eigene Build-/Deploy-Gates.
 
 ## Blocked items
 
 - Kein harter technischer Blocker beim Setup.
-- Bedingter Blocker:
-  - Wenn Task 1 die AC-3-Scope-Entscheidung nicht sauber im Issue-/Execution-Stand verankert, bleiben Task 8 bis Task 10 gesperrt.
-- Nebenfund:
-  - `mainrag` lokal nicht verfuegbar; fuer `#264` aktuell kein technischer Blocker, aber dokumentierter Kontextverlust-Risikoindikator.
+- `mainrag` ist lokal nicht verfuegbar; fuer `#279` nicht blockierend.
+- Kein Phase-0-Blocker mehr.
+- Der Main-Reset bestaetigt, dass der volle #279-Recovery-Scope notwendig bleibt.
 
 ## Commit references
 
-- `f089875` Task [1]
-- `TBD` Task [2]
-- `TBD` Task [3]
-- `TBD` Task [4]
-- `TBD` Task [5]
-- `TBD` Task [6]
-- `TBD` Task [7]
-- `TBD` Task [8]
-- `TBD` Task [9]
-- `TBD` Task [10]
-- `TBD` Task [11]
+- `TBD` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
+- `TBD` Task [2] Phase 1 - Donor-Audit und Clean Port
+- `TBD` Task [3] Slice A - Runtime-Health-Read-Model
+- `TBD` Task [4] Slice B - Runtime-Control / Reconcile
+- `TBD` Task [5] Slice C - Fast Stall Recovery
+- `TBD` Task [6] Slice D - Worker-Supervision
+- `TBD` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
+- `TBD` Task [8] Slice F - Projection/API-Konvergenz
+- `TBD` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
+- `TBD` Task [10] Out-of-scope Follow-up - Haiku-Policy
+- `TBD` Task [11] Phase 3 - Tests, Clippy, Builds
+- `TBD` Task [12] Phase 4 - Deploy auf die VM
+- `TBD` Task [13] Phase 5 - AC-Matrix
+- `TBD` Task [14] Benchmarks
+- `TBD` Task [15] PR- und Close-Sequenz
+- `TBD` Task [16] Plan-Verifikation
 
 ## Task table
 
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
-| 1 | Issue-Truth-Repair, Branch-/Execution-Setup und AC-3-Scope-Gate | DONE | GitHub-Truth-Repair, Branch-/SSOT-Setup, AC-3-Entscheidung, frische Baseline fuer `#264` | command, system, inspect |
-| 2 | Operator-/Admin-Security-Read- und Testpfade (Phase E Foundations) | DONE | `/operator/security/*` Read-/Test-Hooks, Auth/Loopback, deterministische Evidence-Pfade | inspect, command, system |
-| 3 | Write-Anomaly Enforcement, SIGSTOP und Platform-Intervention-Audit (Phase B) | PENDING | Rolling Baseline, deterministischer Suspend, `platform_intervention` Audit-Trail | inspect, command, system |
-| 4 | Landlock-Minimal-Exec und `sandbox_exec_blocked` Events (Phase C) | PENDING | `write_paths` ohne Execute, minimale Exec-Allowlist, Security-Eventpfad | inspect, command, system |
-| 5 | Immutable Snapshot Hardening und Retention-Sicherheit (Phase D) | PENDING | SQLite-Trigger, Retention-/Prune-Vertraeglichkeit, Delete-Pfade | inspect, command, system |
-| 6 | Dashboard/Cockpit/Projection/UI-Surfaces und lokale UI-Tests (AC-5) | PENDING | Cockpit-/Dashboard-Surfaces, lokale Bun-/Projection-Tests, deploybare UI-Pfade | inspect, command, browser |
-| 7 | Phase-1 Deploy, VM-Verifikation und Benchmarks fuer AC-4 bis AC-8 | PENDING | Release-Build, Deploy, Restarts, AC-4..AC-8, Phase-1-Benchmarks, no panic/no drift | command, system, browser |
-| 8 | FUSE-Runtime-Gate und CAS Trash-Queue Implementation fuer AC-1/AC-2 | PENDING | `fuse` Feature-Gate, `fs_mount`, Trash-Queue Runtime-/Inspect-Pfade | inspect, command, system |
-| 9 | Artifact-Restore-Integration fuer AC-3 oder formaler Blocker-Pfad nach Scope-Entscheid | PENDING | Restore-Pfad fuer Artifact-Plane oder offizieller Re-Scope-/Blocker-Pfad | inspect, command, system |
-| 10 | Phase-2 Deploy, VM-Verifikation und Benchmarks fuer AC-1 bis AC-3 | PENDING | FUSE-/Artifact-Runtime live verifizieren, AC-1..AC-3, Phase-2-Benchmarks | command, system, browser |
-| 11 | Plan-Verifikation | PENDING | Plan Zeile fuer Zeile gegen Ergebnis pruefen, Mismatches fixen, Abschlussstatus setzen | inspect, command, system, browser |
+| 1 | Phase 0 - Issue-Repair und Baseline-Reset | DONE | frische VM-Baseline, Issue-Body-Repair, canonical-main-Reset, Post-Reset-Baseline ohne runtime-health | command, system, inspect |
+| 2 | Phase 1 - Donor-Audit und Clean Port | PENDING | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
+| 3 | Slice A - Runtime-Health-Read-Model | PENDING | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
+| 4 | Slice B - Runtime-Control / Reconcile | PENDING | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
+| 5 | Slice C - Fast Stall Recovery | PENDING | deterministischer Kandidat, SIGSTOP/SIGCONT, Respawn/Reconcile | command, system |
+| 6 | Slice D - Worker-Supervision | PENDING | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
+| 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
+| 8 | Slice F - Projection/API-Konvergenz | PENDING | read-only Projection-Reads, Rebuild-Request, drift-heal | inspect, command, system |
+| 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | PENDING | nur falls Main-Repro es braucht: FUSE/Landlock Runtime Restore, eigene Build-/Deploy-Gates | inspect, command, system |
+| 10 | Out-of-scope Follow-up - Haiku-Policy | PENDING | separates Gateway-/Policy-Issue oder Kommentar, nicht #279-Close-Bedingung | command, inspect |
+| 11 | Phase 3 - Tests, Clippy, Builds | PENDING | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
+| 12 | Phase 4 - Deploy auf die VM | PENDING | ExecStart pruefen, scp/install, restart, post-restart smoke | command, system |
+| 13 | Phase 5 - AC-Matrix | PENDING | alle ACs mit Command, Output, PASS auf VM | command, system |
+| 14 | Benchmarks | PENDING | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
+| 15 | PR- und Close-Sequenz | PENDING | PR mit Pflichtsektionen, labels, merge, branch delete, issue close erst nach verified | command |
+| 16 | Plan-Verifikation | PENDING | Plan Zeile fuer Zeile gegen Ergebnis pruefen, Abweichungen fixen | inspect, command |
 
-## Task details
+## Task 1 - Phase 0: Issue-Repair und Baseline-Reset
 
-### Task 1 - Issue-Truth-Repair, Branch-/Execution-Setup und AC-3-Scope-Gate
+### Pre-task self-check
 
-- Scope:
-  - `#264`-Ist-Zustand gegen GitHub, Repo und VM neu erfassen
-  - GitHub-Truth-Repair vorbereiten/anwenden
-  - Branch-/Execution-SSOT auf `#264` ziehen
-  - AC-3-Scope-Entscheidung sauber im Ausfuehrungsstand verankern
-- Checklist:
-  - `gh issue view 264` gegen [codex-plan264.md](/work/company/codex-plan264.md) abgleichen
-  - Branch-/Worktree-Baseline dokumentieren
-  - Truth-Repair-Kommandos fuer Reopen/Labels/Body vorbereiten oder anwenden
-  - AC-3-Scope-Pfad festhalten: in-scope oder offizieller Re-Scope-/Blocker-Pfad
-  - frische Baseline-Facts fuer `fuse`, Landlock, Snapshot-Trigger und Cockpit-Mergepfad dokumentieren
-- Acceptance criteria:
-  - AC-1: Branch und `PROGRESS.md` sind sauber auf `#264` umgestellt, ohne fremde Worktree-Aenderungen zu verlieren
-  - AC-2: GitHub-Truth-Repair fuer `#264` ist vorbereitet oder live angewendet; veraltete Verify-/Kettenannahmen sind explizit adressiert
-  - AC-3: AC-3-Scope-Entscheidung ist fuer diese Ausfuehrung festgehalten; downstream FUSE-/Restore-Tasks laufen nicht auf stillen Annahmen
-  - AC-4: frische Start-Baseline fuer `#264` liegt mit Repo-/VM-Evidence vor
-- Required evidence:
-  - AC-1: `command`, `system`
-  - AC-2: `command`, `inspect`
-  - AC-3: `command`, `inspect`
-  - AC-4: `command`, `inspect`, `system`
-- Pre-task self-check:
-  - Was muss getan werden: die historische Falsch-Schliessung und der echte Startzustand muessen vor jeder Feature-Arbeit neu eingehaengt werden
-  - Welche ACs muessen hier passen: AC-1 bis AC-4 dieses Tasks
-  - Wie wird bewiesen: Git/GitHub/VM-Kommandos, gezielte Code-Lesepfade, Issue-State
-  - Erwartete Dateien: `PROGRESS.md`, ggf. GitHub-Issue-Body, evtl. keine Produktionscode-Files
-  - Risiken: AC-3-Scope kann echten Stop verursachen; `mainrag` ist lokal nicht verfuegbar
-- Outcome:
-  - Arbeitsbranch `feat/issue-264-security-hardening-closure` ist frisch von `main = origin/main = 0395905` angelegt.
-  - `#264` wurde von `CLOSED + status:verified` auf `OPEN + status:ready` truth-repaired.
-  - Der Issue-Body ist jetzt auf dem ehrlichen Ausfuehrungsstand:
-    - aktuelle Luecken benannt
-    - FUSE-Compile-Gate explizit
-    - AC-3 bleibt in scope
-    - Kette `#263 -> #264 -> #265 -> #266` korrigiert
-  - Die Scope-Entscheidung fuer diese Session ist festgehalten:
-    - AC-3 bleibt in `#264`
-    - FUSE-/Artifact-Restore-Probleme gelten als Blocker, nicht als stiller Re-Scope
-  - Die frische Start-Baseline fuer FUSE, Landlock, Snapshot-Trigger und Cockpit-Mergepfad ist mit Repo-/VM-Evidence dokumentiert.
-- Evidence:
-  - AC-1 PASS:
-    - `git fetch origin main && git rev-parse main && git rev-parse origin/main && git rev-list --left-right --count main...origin/main` => `main = origin/main = 0395905`, Divergenz `0 0`
-    - `git switch -c feat/issue-264-security-hardening-closure` => neuer Arbeitsbranch aktiv
-    - `git status --short --branch` => fremde `.gitignore`-Aenderung blieb erhalten; keine fremde Datei verworfen
-  - AC-2 PASS:
-    - `gh issue reopen 264`
-    - `gh issue edit 264 --remove-label "status:verified" --add-label "status:triage" --add-label "quality:needs-spec"`
-    - `gh issue edit 264 --body-file - ...`
-    - `gh issue edit 264 --remove-label "quality:needs-spec" --remove-label "status:triage" --add-label "status:ready"`
-    - `gh issue view 264 --json state,labels,body ...` => `OPEN`, `status:ready`, Body enthaelt AC-3-in-scope, FUSE-Gate und neue Kette
-  - AC-3 PASS:
-    - User-Entscheidung in dieser Session: `AC-3 bleibt in #264`
-    - Issue-Body enthaelt explizit `AC-3 bleibt in diesem Issue in scope`
-    - Blocker-Semantik ist damit klar: FUSE-/Artifact-Restore-Probleme blockieren `#264`, sie schneiden AC-3 nicht still aus
-  - AC-4 PASS:
-    - `rg -n '^default = .*fuse|^fuse =' services/sentinel-daemon/Cargo.toml` => `default = [..., "fuse"]`, eigenes `fuse` Feature vorhanden
-    - `ssh ubuntu@10.0.0.240 "grep -n '^fs_mount' /opt/sentinel/config/daemon.toml || true"` => aktuell kein `fs_mount` gesetzt
-    - `ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/events.db \"SELECT name FROM sqlite_master WHERE type='trigger' AND name='protect_recent_snapshots';\""` => `protect_recent_snapshots`
-    - `ssh ubuntu@10.0.0.240 "systemctl is-active sentinel-daemon sentinel-gateway sentinel-projection"` => alle `active`
-    - `rg -n 'all_access|write_paths|exec_paths|/tmp|/home/\\{name\\}' crates/sentinel-sandbox/src/landlock.rs` => `write_paths` nutzen `all_access`
-    - `rg -n 'platform_analysis|platform_intervention' dashboard/src/routes/cockpit.ts` => beide Eventtypen werden im Cockpit gemappt
+- Was muss getan werden: frische Runtime-Wahrheit erfassen, GitHub-Issue korrigieren, canonical `main` auf der VM deployen, danach Baseline ohne `/operator/runtime-health` belegen.
+- Welche ACs muessen hier passen:
+  - AC-1: frische experimentelle VM-Baseline ist dokumentiert.
+  - AC-2: `#279` Issue-Body ist truth-repaired und enthaelt keine stale Blocked-by-/Zahlen-Behauptung.
+  - AC-3: canonical `main` Binaries fuer Daemon und Projection sind remote gebaut, Deploy-Pfad inklusive ExecStart ist belegt.
+  - AC-4: Post-Reset-Baseline ohne `/operator/runtime-health` ist belegt.
+- Wie wird bewiesen: `gh`, `ssh ubuntu@10.0.0.240`, `cargo remote -c --`, `scp`, `systemctl`, `curl`, `sqlite3`, `journalctl`.
+- Erwartete Dateien: `PROGRESS.md`, `docs/issue-279-phase0-baseline.md`, optional temporaere Issue-Body-Datei.
+- Risiken:
+  - VM laeuft aktuell moeglicherweise mit experimentellen #279-Binaries; Phase 0 ersetzt diese bewusst durch canonical `main`.
+  - Nach Main-Reset ist `/operator/runtime-health` erwartbar nicht vorhanden.
+  - Deployment darf nicht gegen falsche systemd `ExecStart`-Pfade kopieren.
 
-### Task 2 - Operator-/Admin-Security-Read- und Testpfade (Phase E Foundations)
+### Outcome
 
-- Scope:
-  - loopback-only `/operator/security/*` Read- und Test-Hooks fuer deterministische AC-Evidence
-- Checklist:
-  - `GET /operator/security/fs-trash`
-  - `POST /operator/security/fs-trash-fixture`
-  - `POST /operator/security/fs-trash-age`
-  - `POST /operator/security/fs-trash-gc`
-  - `POST /operator/security/fs-ransomware-test`
-  - `GET /operator/security/agent-runtime-state`
-  - `POST /operator/security/write-anomaly-test`
-  - `POST /operator/security/landlock-test`
-  - Auth/Loopback-Regeln absichern
-- Acceptance criteria:
-  - AC-1: alle noetigen Security-Read-/Testpfade existieren und sind nur lokal/admin nutzbar
-  - AC-2: Operator-Secret wird korrekt erzwungen, falls gesetzt
-  - AC-3: lokale Tests und Remote-Rust-Checks fuer die neuen Pfade sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`
-  - AC-2: `inspect`, `system`
-  - AC-3: `command`
-- Outcome:
-  - `services/sentinel-daemon/src/operator_api.rs` exponiert jetzt die geplanten Security-Hooks:
-    - `GET /operator/security/fs-trash`
-    - `POST /operator/security/fs-trash-fixture`
-    - `POST /operator/security/fs-trash-age`
-    - `POST /operator/security/fs-trash-gc`
-    - `POST /operator/security/fs-ransomware-test`
-    - `GET /operator/security/agent-runtime-state`
-    - `POST /operator/security/write-anomaly-test`
-    - `POST /operator/security/landlock-test`
-  - Query-Parsing, loopback-read paths, Auth-Check fuer gesetztes Operator-Secret und body-size routing sind zentral im Operator-API-Pfad verankert.
-  - `services/sentinel-daemon/src/orchestrator.rs` fuehrt jetzt einen shared `security_runtime_state` mit `agent_id`, `aggregate_id`, `agent_name`, `bwrap_pid`, Home-Pfad und optionalem `fs_mount`; der State wird beim Spawn, Fallback, Restart und Shutdown mitgefuehrt.
-  - `crates/sentinel-fs/src/artifact.rs` initialisiert `fs_trash_queue` beim Open und expose't Test-/Inspect-Helfer fuer Trash-Timestamps.
-  - `crates/sentinel-sandbox/src/bin/breakout_helper.rs` deckt jetzt die deterministischen Exec-Szenarien `exec-from-home`, `exec-bin-sh` und `exec-python3` ab.
-  - Ein realer Runtime-Bug im neuen Landlock-Testpfad wurde behoben:
-    - Landlock blockierte Exec bereits korrekt im Wrapper
-    - der API-Response markierte das aber nur bei `exit_code == 0` als `blocked`
-    - jetzt wird auch der reale Wrapper-Fehlerpfad `exec failed: Permission denied` bzw. `Operation not permitted` als `blocked:true` gemappt
-- Evidence:
-  - AC-1 PASS:
-    - `rg -n "fs-trash|write-anomaly-test|landlock-test|agent-runtime-state" services/sentinel-daemon/src/operator_api.rs` => alle geplanten `/operator/security/*` Endpunkte sind im Handler verdrahtet
-    - `cargo remote -c -- build -p sentinel-daemon --release` => `Finished release profile [optimized] target(s)` fuer den Deploy-Stand
-    - `scp target/release/sentinel-daemon ubuntu@10.0.0.240:/tmp/sentinel-daemon` und `ssh ubuntu@10.0.0.240 "sudo systemctl stop sentinel-daemon && sudo install -m 0755 /tmp/sentinel-daemon /opt/sentinel/bin/sentinel-daemon && sudo systemctl start sentinel-daemon && sudo systemctl is-active sentinel-daemon"` => Redeploy erfolgreich, Dienst `active`
-    - `curl --max-time 2 http://10.0.0.240:8084/operator/security/agent-runtime-state?agent_id=49` => Timeout von ausserhalb der VM, also kein versehentlich exponierter Remote-Pfad
-    - `ssh ubuntu@10.0.0.240 "curl -s http://127.0.0.1:8084/operator/security/agent-runtime-state?agent_id=49"` => `found:true`, `agent_name:"Carla Friedmann"`, `bwrap_pid:...`, `home_host_path:"/ram/agents/Carla Friedmann"`
-    - `ssh ubuntu@10.0.0.240 'python3 - <<'"'"'PY'"'"' ... fs-trash-fixture ... PY'` => `accepted:true`, `chunk_hashes:["e926e21be7c88cc5152a7d37fff800fb"]`, `trashed_chunks:1`
-    - `ssh ubuntu@10.0.0.240 'python3 - <<'"'"'PY'"'"' ... write-anomaly-test ... PY'` => `accepted:true`, `mode:"burst"`, `bwrap_pid:1161446`, `host_path:"/ram/agents/Carla Friedmann/.issue264-write-anomaly.bin"`
-    - `ssh ubuntu@10.0.0.240 "curl -s -X POST http://127.0.0.1:8084/operator/security/landlock-test -H 'Content-Type: application/json' -d '{\"agent_name\":\"Carla Friedmann\",\"scenario\":\"exec-python3\"}'"` => `accepted:true`, `blocked:true`, Wrapper meldet `Permission denied`
-    - `ssh ubuntu@10.0.0.240 "curl -s -X POST http://127.0.0.1:8084/operator/security/landlock-test -H 'Content-Type: application/json' -d '{\"agent_name\":\"Carla Friedmann\",\"scenario\":\"exec-bin-sh\"}'"` => ebenfalls `blocked:true`
-  - AC-2 PASS:
-    - `cargo remote -c -- test -p sentinel-daemon operator_api::tests -- --nocapture` => Test `security_get_requires_auth_when_configured` gruen
-    - `rg -n "is_security_path|is_authorized|shared_secret" services/sentinel-daemon/src/operator_api.rs` => GET-Security-Pfade und POSTs haengen am zentralen Secret-Check
-    - Live auf `10.0.0.240` liefert nur Loopback Antworten; der Host `10.0.0.240:8084` bleibt von aussen nicht erreichbar
-  - AC-3 PASS:
-    - `cargo remote -c -- test -p sentinel-daemon operator_api::tests -- --nocapture` => `21 passed`
-    - `cargo remote -c -- test -p sentinel-daemon orchestrator::tests -- --nocapture` => Exit `0`
-    - `cargo remote -c -- test -p sentinel-fs artifact::tests -- --nocapture` => `5 passed`
-    - `cargo remote -c -- clippy -p sentinel-daemon -p sentinel-fs --all-targets -- -D warnings` => Exit `0`
-    - `cargo remote -c -- clippy -p sentinel-sandbox --all-targets -- -D warnings` => Exit `0`
+- Fresh pre-reset VM baseline captured:
+  - services active
+  - API agents `57`
+  - Projection agents `57`
+  - experimental runtime-health expected active agents `26`
+  - experimental runtime-health runtime agents `26`
+  - experimental runtime-health orphan cgroups `33`
+  - experimental runtime-health projection drift `true`
+- GitHub issue `#279` body repaired at `2026-04-23T09:47:19Z`:
+  - removed stale `Blocked by #278`
+  - removed old 2026-04-21 numbers as current truth
+  - removed #264-stacked branch assumption
+  - kept Haiku/model policy out-of-scope
+  - kept strict `status:verified` close rule
+- Canonical `main` artifacts built through `cargo remote -c --`:
+  - `sentinel-daemon --features fuse`: `Finished release profile [optimized] target(s) in 12m 04s`
+  - `sentinel-projection-service`: `Finished release profile [optimized] target(s) in 1m 37s`
+- Main artifacts deployed to exact VM `ExecStart` paths:
+  - `/opt/sentinel/bin/sentinel-daemon`
+  - `/opt/sentinel/bin/sentinel-projection`
+  - timestamp backup created with `20260423T100300Z`
+- Post-reset baseline without runtime-health captured:
+  - services active
+  - API agents `57`
+  - Projection agents `57`
+  - cgroup dirs `59`
+  - live cgroup process dirs `29`
+  - `/operator/runtime-health` returns `404`, expected on current `main`
+- Conclusion:
+  - canonical `main` does not self-heal the runtime/projection/cgroup drift
+  - full #279 recovery scope remains required
 
-### Task 3 - Write-Anomaly Enforcement, SIGSTOP und Platform-Intervention-Audit (Phase B)
+### Evidence
 
-- Scope:
-  - Rolling-Baseline, Write-Anomaly-Trigger, echter `SIGSTOP`, Audit-Trail ueber `platform_intervention`
-- Checklist:
-  - Baseline-Berechnung erweitern
-  - Triggerlogik `>10x` oder absoluter Schwellwert
-  - deterministischen SIGSTOP-Sideeffect bauen
-  - `platform_intervention` fuer `write_anomaly` sauber persistieren
-  - Tests fuer Baseline, Trigger, SIGSTOP, Audit schreiben
-- Acceptance criteria:
-  - AC-1: Write-Anomaly feuert nicht mehr nur `alert`, sondern echten Suspend-Sideeffect
-  - AC-2: Audit-Trail laeuft ueber eindeutigen Eventtyp und korreliert mit Ziel-Agent/Action
-  - AC-3: lokale Tests und Remote-Rust-Checks sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`
-
-### Task 4 - Landlock-Minimal-Exec und `sandbox_exec_blocked` Events (Phase C)
-
-- Scope:
-  - `write_paths` ohne Execute, minimale Exec-Allowlist, strukturierter Security-Eventpfad
-- Checklist:
-  - `landlock.rs` fuer non-exec write paths umbauen
-  - minimale Exec-Allowlist definieren
-  - `/tmp`, `/home/{agent}`, `/bin/sh`, `/usr/bin/python3` explizit abdecken
-  - neues `sandbox_exec_blocked` Eventmodell + Persistenz bauen
-  - Wrapper-/Breakout-/Daemon-Pfade zusammenfuehren
-- Acceptance criteria:
-  - AC-1: Execute ist weder ueber zu breite `exec_paths` noch ueber `write_paths/all_access` moeglich
-  - AC-2: blockierte Exec-Versuche landen strukturiert im Event Store
-  - AC-3: lokale Tests und Remote-Rust-Checks sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`
-
-### Task 5 - Immutable Snapshot Hardening und Retention-Sicherheit (Phase D)
-
-- Scope:
-  - Snapshot-DELETE-Trigger, Retention-/Promotion-/Prune-Kompatibilitaet
-- Checklist:
-  - Trigger-/Delete-Pfade lesen und haerten
-  - Tests fuer `<7 Tage` blockiert, `>7 Tage` erlaubt, Promotion ohne Delete
-  - Retention-/Prune-Nebenpfade pruefen
-- Acceptance criteria:
-  - AC-1: Snapshots juenger als 7 Tage bleiben undeletable
-  - AC-2: erlaubte Delete-/Retention-Pfade bleiben funktionsfaehig
-  - AC-3: lokale Tests und Remote-Rust-Checks sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`
-
-### Task 6 - Dashboard/Cockpit/Projection/UI-Surfaces und lokale UI-Tests (AC-5)
-
-- Scope:
-  - Cockpit-/Dashboard-Surfaces fuer Write-Anomaly-/Intervention-Incidents, lokale Bun-/Projection-Tests, stabile Playwright-Ziele
-- Checklist:
-  - Cockpit-Route und Summary-/Severity-Mapping pruefen/erweitern
-  - stabile DOM-Selektoren fuer Incident-Readout sichern
-  - `bun test` + `bun run typecheck`
-  - falls noetig Projection-Read-Model-Tests
-- Acceptance criteria:
-  - AC-1: UI kann Write-Anomaly-/Suspend-Fall ueber `platform_analysis` oder `platform_intervention` sichtbar machen
-  - AC-2: lokale Dashboard-/Projection-Tests sind gruen
-  - AC-3: Deploy-Pfad fuer Dashboard/Projection ist bei Bedarf klar und getestet
-- Required evidence:
-  - AC-1: `inspect`, `browser`
-  - AC-2: `command`
-  - AC-3: `command`, `system`
-
-### Task 7 - Phase-1 Deploy, VM-Verifikation und Benchmarks fuer AC-4 bis AC-8
-
-- Scope:
-  - Release-Build, Deploy, Restarts, AC-4..AC-8 auf `10.0.0.240`, Benchmarks, no panic/no drift
-- Checklist:
-  - Remote Builds fuer geaenderte Artefakte
-  - Deploy `sentinel-daemon`, `landlock-wrapper`, ggf. Dashboard/Projection
-  - AC-4..AC-8 live verifizieren
-  - Playwright-Screenshot fuer AC-5
-  - Benchmarks + Sidecar-Metriken fahren
-  - `panic`-/`drift`-Check fahren
-- Acceptance criteria:
-  - AC-1: AC-4 bis AC-8 sind live mit frischer VM-Evidence belegt
-  - AC-2: Phase-1-Benchmarks liegen gegen Zielwert vor
-  - AC-3: keine `panic`- und keine `drift`-Regression im Verifikationsfenster
-- Required evidence:
-  - AC-1: `command`, `system`, `browser`
-  - AC-2: `command`, `system`
-  - AC-3: `command`, `system`
-
-### Task 8 - FUSE-Runtime-Gate und CAS Trash-Queue Implementation fuer AC-1/AC-2
-
-- Scope:
-  - `fuse` Feature-Gate, `fs_mount`, Runtime-Pfade fuer CAS Trash-Queue, deterministische Inspect-Pfade
-- Checklist:
-  - `fuse` Build-/Config-Gate final absichern
-  - Trash-Queue Runtime-/Inspect-Pfade an aktive FUSE-/Artifact-Plane anbinden
-  - Tests fuer Grace-Period und Freigabe nachziehen
-- Acceptance criteria:
-  - AC-1: FUSE-Runtime-Gate ist echt, nicht nur Config-Schein
-  - AC-2: Trash-Queue laeuft im aktiven Runtime-Pfad und nicht nur im isolierten Testpfad
-  - AC-3: lokale Tests und Remote-Rust-Checks sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`
-
-### Task 9 - Artifact-Restore-Integration fuer AC-3 oder formaler Blocker-Pfad nach Scope-Entscheid
-
-- Scope:
-  - Restore-Pfad fuer Artifact-Plane integrieren oder den formal erlaubten Re-Scope-/Blocker-Pfad sauber umsetzen
-- Checklist:
-  - Snapshot-/Restore-Pfade fuer Artifact-Plane lesen/anpassen
-  - `restore_from_trash()` korrekt in den Runtime-Restore einhaengen
-  - Falls Scope anders entschieden: offiziellen Re-Scope-/Blocker-Pfad auf Issue-Ebene ziehen
-- Acceptance criteria:
-  - AC-1: AC-3 ist technisch geliefert oder formal sauber aus `#264` herausgeschnitten
-  - AC-2: kein stiller Architekturbruch zwischen Snapshot, ECS und Artifact-Plane
-  - AC-3: lokale Tests und Remote-Rust-Checks sind gruen
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`
-
-### Task 10 - Phase-2 Deploy, VM-Verifikation und Benchmarks fuer AC-1 bis AC-3
-
-- Scope:
-  - FUSE-/Artifact-Runtime deployen und AC-1..AC-3 live verifizieren
-- Checklist:
-  - `sentinel-daemon --features fuse` remote bauen und deployen
-  - `fs_mount` live setzen und verifizieren
-  - AC-1..AC-3 auf der VM fahren
-  - Phase-2-Benchmarks und Sidecar-Metriken dokumentieren
-- Acceptance criteria:
-  - AC-1: AC-1 und AC-2 sind live ueber echten FUSE-/Artifact-Runtime-Pfad belegt
-  - AC-2: AC-3 ist live bytegenau verifiziert oder der formale Re-Scope-/Blocker-Pfad ist durch Task 9 hergestellt
-  - AC-3: Benchmarks, `panic`- und `drift`-Checks sind gruen
-- Required evidence:
-  - AC-1: `command`, `system`
-  - AC-2: `command`, `system`
-  - AC-3: `command`, `system`, `browser`
-
-### Task 11 - Plan-Verifikation
-
-- Scope:
-  - [codex-plan264.md](/work/company/codex-plan264.md) vollstaendig gegen das Ergebnis pruefen und letzte Mismatches sofort schliessen
-- Checklist:
-  - Plan komplett rereaden
-  - Ergebnis Zeile fuer Zeile gegen Plan vergleichen
-  - finale Live-/E2E-Verifikation fahren
-  - Restabweichungen sofort fixen oder als echten Blocker dokumentieren
-  - `PROGRESS.md` final auf `COMPLETE` oder `BLOCKED` setzen
-- Acceptance criteria:
-  - AC-1: kein ungepruefter Plan-/Implementierungs-Mismatch bleibt offen
-  - AC-2: Abschlussstatus ist ehrlich (`COMPLETE` oder `BLOCKED`)
-  - AC-3: Issue-Close-Vorbereitung folgt erst nach finaler Evidence
-- Required evidence:
-  - AC-1: `inspect`, `command`, `system`, `browser`
-  - AC-2: `inspect`, `command`
-  - AC-3: `command`, `system`
+- `test-279-verification.md` contains Phase-0 command/output evidence.
+- AC-1 PASS: Pre-reset VM baseline captured on `10.0.0.240`.
+- AC-2 PASS: `gh issue edit 279 --repo silentspike/project-sentinel --body-file docs/issue-279-body.md`; follow-up `gh issue view` confirmed repaired body.
+- AC-3 PASS: remote release builds succeeded and deployed SHA256 values match installed VM binaries:
+  - `2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883  /opt/sentinel/bin/sentinel-daemon`
+  - `10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3  /opt/sentinel/bin/sentinel-projection`
+- AC-4 PASS: Post-reset baseline uses only main-compatible checks and confirms `runtime_health_http=404`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_9_DONE_TASK_10_PENDING`
-- Current task: `Task 10 - Out-of-scope Follow-up: Haiku-Policy`
+- Overall status: `TASK_10_DONE_TASK_11_PENDING`
+- Current task: `Task 11 - Phase 3: Tests, Clippy, Builds`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -71,6 +71,10 @@
   - bei fehlendem FUSE-Mount faellt die Runtime explizit auf `/ram/agents` zurueck statt bwrap auf einen toten Mountpoint zu richten
   - Landlock-Exec-Allowlist bleibt schmal und enthaelt zusaetzlich die notwendigen dynamischen ELF-Loader
   - Remote-Tests, Clippy, FUSE-Release-Builds, Sandbox-Binary-Build, Scope-Guard und Artifact-Hashes sind dokumentiert
+- Task 10 ist erledigt:
+  - Es gab kein separates offenes Haiku-/Agent-Model-Policy-Issue
+  - neues Follow-up `#314` wurde fuer Gateway-/Inference-Agent-Model-Defaults erstellt
+  - `#279` wurde mit der Scope-Entscheidung kommentiert: keine Modellentscheidung im Daemon, Gateway waehlt Default
 
 ## Blocked items
 
@@ -111,7 +115,7 @@
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | DONE | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
 | 8 | Slice F - Projection/API-Konvergenz | DONE | read-only Projection-Reads, Rebuild-Request, drift-heal, no restart storm | inspect, command, system |
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | DONE | FUSE-Aktivierungs-Gate, `/ram/agents` Fallback, Landlock-ELF-Loader-Allowlist, eigene Build-/Deploy-Gates | inspect, command, system |
-| 10 | Out-of-scope Follow-up - Haiku-Policy | PENDING | separates Gateway-/Policy-Issue oder Kommentar, nicht #279-Close-Bedingung | command, inspect |
+| 10 | Out-of-scope Follow-up - Haiku-Policy | DONE | separates Gateway-/Policy-Issue #314 erstellt und in #279 verlinkt, nicht #279-Close-Bedingung | command, inspect |
 | 11 | Phase 3 - Tests, Clippy, Builds | PENDING | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
 | 12 | Phase 4 - Deploy auf die VM | PENDING | ExecStart pruefen, scp/install, restart, post-restart smoke | command, system |
 | 13 | Phase 5 - AC-Matrix | PENDING | alle ACs mit Command, Output, PASS auf VM | command, system |
@@ -617,3 +621,40 @@
   - `517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon`
   - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
   - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`
+
+## Task 10 - Out-of-scope Follow-up: Haiku-Policy
+
+### Pre-task self-check
+
+- Was muss getan werden: Haiku-/Agent-Model-Policy nicht in #279 implementieren, sondern als separates Gateway-/Inference-Follow-up sichern.
+- Welche ACs muessen hier passen:
+  - AC-1: Es gibt keine Haiku-/Model-Pinning-Aenderung im #279-Branch.
+  - AC-2: Bestehende Issues wurden geprueft, damit kein Duplikat erzeugt wird.
+  - AC-3: Wenn kein passendes Issue existiert, wird ein eigenes Follow-up erstellt.
+  - AC-4: #279 dokumentiert die Scope-Entscheidung.
+- Wie wird bewiesen: GitHub-Issue-Suche, neues Issue, Kommentar auf #279, Scope-Guard aus Task 9.
+- Erwartete Dateien: `PROGRESS.md`.
+- Risiken:
+  - Die fachliche Entscheidung "Agents sollen Haiku nutzen" darf nicht durch Daemon-Hardcoding umgesetzt werden.
+  - #279 darf dadurch keine neue Close-Bedingung bekommen.
+
+### Outcome
+
+- GitHub-Suche nach Haiku-/Model-Policy-Themen fand kein passendes offenes Follow-up.
+- Neues Issue erstellt: `#314 Policy: Agent LLM model defaults via Gateway/Inference layer`.
+- `#314` definiert Haiku als Agent-Runtime-Default in Gateway/Inference, nicht im Daemon.
+- #279 kommentiert mit Scope-Entscheidung und Link auf #314.
+- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
+
+### Evidence
+
+- `gh issue list --repo silentspike/project-sentinel --state all --search "Haiku in:title" --limit 20 --json number,title,state,labels,url`
+  - PASS: no matching existing Haiku policy issue.
+- `gh issue list --repo silentspike/project-sentinel --state all --search "model in:title" --limit 20 --json number,title,state,labels,url`
+  - PASS: only unrelated/closed historical model issues found.
+- `gh issue create ...`
+  - PASS: created `https://github.com/silentspike/project-sentinel/issues/314`.
+- `gh issue comment 279 ...`
+  - PASS: created `https://github.com/silentspike/project-sentinel/issues/279#issuecomment-4304109979`.
+- Scope guard inherited from Task 9:
+  - `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -89,7 +89,7 @@
 - `b3b7786` Task [6] Slice D - Worker-Supervision
 - `bc57b4c` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
 - `92b3279` Task [8] Slice F - Projection/API-Konvergenz
-- `TBD` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
+- `7eb95cb` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
 - `TBD` Task [10] Out-of-scope Follow-up - Haiku-Policy
 - `TBD` Task [11] Phase 3 - Tests, Clippy, Builds
 - `TBD` Task [12] Phase 4 - Deploy auf die VM

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_1_DONE_TASK_2_PENDING`
-- Current task: `Task 2 - Phase 1: Donor-Audit und Clean Port`
+- Overall status: `TASK_3_DONE_TASK_4_PENDING`
+- Current task: `Task 4 - Slice B: Runtime-Control / Reconcile`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -32,7 +32,12 @@
   - Frische VM-Zahlen muessen dynamisch gemessen werden, nicht aus alten Reviews kopiert werden.
   - Canonical-main-Reset muss ohne `/operator/runtime-health` messbar sein, weil `main` diesen Endpoint noch nicht hat.
   - Operator-Auth wird spaeter ueber einen gemeinsamen `/tmp/opcurl` Helper operationalisiert.
-  - FUSE/Landlock bekommt nur bei aktivem Slice G eigene Build-/Deploy-Gates.
+- FUSE/Landlock bekommt nur bei aktivem Slice G eigene Build-/Deploy-Gates.
+- Slice A ist erledigt:
+  - `GET /operator/runtime-health` ist als read-only Operator-Pfad verdrahtet
+  - Snapshot deckt Runtime, Projection, Cgroups, Security-Runtime und Worker-State ab
+  - Operator-Auth-Schutz fuer den Endpoint ist im Unit-Test belegt
+  - initialer Warnungsfund `unused import RuntimeHealthSnapshot` wurde vor Commit bereinigt
 
 ## Blocked items
 
@@ -44,7 +49,7 @@
 ## Commit references
 
 - `dca25ac` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
-- `TBD` Task [2] Phase 1 - Donor-Audit und Clean Port
+- `e2e7523` Task [2] Phase 1 - Donor-Audit und Clean Port
 - `TBD` Task [3] Slice A - Runtime-Health-Read-Model
 - `TBD` Task [4] Slice B - Runtime-Control / Reconcile
 - `TBD` Task [5] Slice C - Fast Stall Recovery
@@ -65,9 +70,9 @@
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | Phase 0 - Issue-Repair und Baseline-Reset | DONE | frische VM-Baseline, Issue-Body-Repair, canonical-main-Reset, Post-Reset-Baseline ohne runtime-health | command, system, inspect |
-| 2 | Phase 1 - Donor-Audit und Clean Port | IN_PROGRESS | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
-| 3 | Slice A - Runtime-Health-Read-Model | PENDING | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
-| 4 | Slice B - Runtime-Control / Reconcile | PENDING | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
+| 2 | Phase 1 - Donor-Audit und Clean Port | DONE | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
+| 3 | Slice A - Runtime-Health-Read-Model | DONE | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
+| 4 | Slice B - Runtime-Control / Reconcile | IN_PROGRESS | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
 | 5 | Slice C - Fast Stall Recovery | PENDING | deterministischer Kandidat, SIGSTOP/SIGCONT, Respawn/Reconcile | command, system |
 | 6 | Slice D - Worker-Supervision | PENDING | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
@@ -189,3 +194,43 @@
   - stale donor `PROGRESS.md`, old evidence and branch-wide #264 paths are excluded.
 - AC-3 PASS:
   - clean port order and path-limited rules are documented in `test-279-verification.md`.
+
+## Task 3 - Slice A: Runtime-Health-Read-Model
+
+### Pre-task self-check
+
+- Was muss getan werden: Runtime-Health-Snapshot aus dem Donor path-limited portieren und `GET /operator/runtime-health` als loopback/auth-konformen Read-Pfad verfuegbar machen.
+- Welche ACs muessen hier passen:
+  - AC-1: `runtime_health.rs` existiert und berechnet runtime/cgroup/projection/worker truth ohne Seiteneffekte.
+  - AC-2: Operator-Endpoint ist verdrahtet und nutzt die bestehende Operator-Auth-/Loopback-Struktur.
+  - AC-3: relevante Remote-Rust-Tests oder mindestens package build fuer Slice A sind gruen.
+- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- test/build`.
+- Erwartete Dateien: `services/sentinel-daemon/src/runtime_health.rs`, `lib.rs`, `operator_api.rs`, `orchestrator.rs`, `service_health.rs`, ggf. `Cargo.toml/Cargo.lock`.
+- Risiken:
+  - Donor-Patch darf keine Reconcile-/Stall-/Queue-Semantik vorziehen.
+  - `runtime-health` muss read-only bleiben.
+
+### Outcome
+
+- Path-limited donor Slice A was applied from stack donor `29a0fb5`.
+- Merge conflict in `services/sentinel-daemon/src/operator_api.rs` was resolved by keeping current `main`'s `open_fs_layer` security/FUSE helper and adding only the new `is_protected_read_path()` read-auth helper.
+- Added `services/sentinel-daemon/src/runtime_health.rs`.
+- Added `sentinel-projection` as `sentinel-daemon` dependency so the daemon can read Projection truth without mutating Projection state.
+- Wired `SharedRuntimeHealthState` through `orchestrator.rs` into the ECS tick loop and Operator API.
+- Added `GET /operator/runtime-health` as a protected read path; it returns the current snapshot and respects the existing operator shared-secret auth rule.
+- Extended `ServiceHealthChecker` with a read-only worker snapshot for runtime-health reporting.
+- Fixed the initial `unused import RuntimeHealthSnapshot` warning by moving the import into the test module.
+
+### Evidence
+
+- `cargo remote -c -- test -p sentinel-daemon runtime_health -- --nocapture`
+  - PASS: `3 passed; 0 failed; 173 filtered out; finished in 10.28s`
+  - Covered tests:
+    - `runtime_health::tests::build_snapshot_marks_missing_projection_and_security_as_stale`
+    - `operator_api::tests::runtime_health_endpoint_returns_snapshot`
+    - `operator_api::tests::runtime_health_endpoint_requires_auth_when_secret_is_set`
+- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
+  - PASS: `Finished release profile [optimized] target(s) in 1m 07s`
+  - artifact hash: `7b5145a77da0a55a3e9e9da00b2d9036ce943df748d327b4095f87955b0034d2  target/release/sentinel-daemon`
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_3_DONE_TASK_4_PENDING`
-- Current task: `Task 4 - Slice B: Runtime-Control / Reconcile`
+- Overall status: `TASK_4_DONE_TASK_5_PENDING`
+- Current task: `Task 5 - Slice C: Fast Stall Recovery`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -38,6 +38,12 @@
   - Snapshot deckt Runtime, Projection, Cgroups, Security-Runtime und Worker-State ab
   - Operator-Auth-Schutz fuer den Endpoint ist im Unit-Test belegt
   - initialer Warnungsfund `unused import RuntimeHealthSnapshot` wurde vor Commit bereinigt
+- Slice B ist erledigt:
+  - `POST /operator/runtime/reconcile` ist als Runtime-Control-Pfad verdrahtet
+  - Reconcile entfernt unerwartete Runtime-Fragmente, orphan Cgroups und stale Security-Snapshots
+  - Expected active Agents koennen mit Backoff N=3 respawned werden
+  - Projection-Rebuild wird ueber `.projection-rebuild-request` entkoppelt angefordert
+  - aktuelle #264-SIGSTOP-Semantik wurde bei Konfliktauflösung beibehalten
 
 ## Blocked items
 
@@ -50,7 +56,7 @@
 
 - `dca25ac` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
 - `e2e7523` Task [2] Phase 1 - Donor-Audit und Clean Port
-- `TBD` Task [3] Slice A - Runtime-Health-Read-Model
+- `f5be73b` Task [3] Slice A - Runtime-Health-Read-Model
 - `TBD` Task [4] Slice B - Runtime-Control / Reconcile
 - `TBD` Task [5] Slice C - Fast Stall Recovery
 - `TBD` Task [6] Slice D - Worker-Supervision
@@ -72,7 +78,7 @@
 | 1 | Phase 0 - Issue-Repair und Baseline-Reset | DONE | frische VM-Baseline, Issue-Body-Repair, canonical-main-Reset, Post-Reset-Baseline ohne runtime-health | command, system, inspect |
 | 2 | Phase 1 - Donor-Audit und Clean Port | DONE | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
 | 3 | Slice A - Runtime-Health-Read-Model | DONE | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
-| 4 | Slice B - Runtime-Control / Reconcile | IN_PROGRESS | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
+| 4 | Slice B - Runtime-Control / Reconcile | DONE | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
 | 5 | Slice C - Fast Stall Recovery | PENDING | deterministischer Kandidat, SIGSTOP/SIGCONT, Respawn/Reconcile | command, system |
 | 6 | Slice D - Worker-Supervision | PENDING | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
@@ -234,3 +240,60 @@
   - artifact hash: `7b5145a77da0a55a3e9e9da00b2d9036ce943df748d327b4095f87955b0034d2  target/release/sentinel-daemon`
 - `git diff --check`
   - PASS: no whitespace/conflict errors.
+
+## Task 4 - Slice B: Runtime-Control / Reconcile
+
+### Pre-task self-check
+
+- Was muss getan werden: Runtime-Control aus dem Donor path-limited portieren und `POST /operator/runtime/reconcile` als kontrollierten Reparaturpfad in den ECS-Thread verdrahten.
+- Welche ACs muessen hier passen:
+  - AC-1: `runtime_control.rs` definiert Request/Response, Command und bounded Respawn-Backoff.
+  - AC-2: Operator-Endpoint dispatcht in den ECS-Thread und wartet bounded auf Response.
+  - AC-3: Orchestrator kann stale Runtime-Fragmente, Security-Snapshots und orphan Cgroups bereinigen.
+  - AC-4: Missing expected Agents koennen mit Backoff respawned oder als `repair_blocked` dokumentiert werden.
+  - AC-5: Projection-Rebuild wird entkoppelt per Request-Datei angefordert.
+  - AC-6: relevante Remote-Rust-Tests und Release-Build sind gruen.
+- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- test/build`.
+- Erwartete Dateien: `services/sentinel-daemon/src/runtime_control.rs`, `lib.rs`, `operator_api.rs`, `orchestrator.rs`.
+- Risiken:
+  - Donor-Patch darf keine alte #264-SIGSTOP-Abschwaechung einschleppen.
+  - Reconcile darf nicht inline Projection mutieren.
+  - Respawn-Fehler muessen bounded bleiben und duerfen keinen Endlos-Loop erzeugen.
+
+### Outcome
+
+- Path-limited donor Slice B was applied from stack donor `146ef43`.
+- Added `services/sentinel-daemon/src/runtime_control.rs` with:
+  - `RuntimeReconcileRequest`
+  - `RuntimeReconcileResponse`
+  - `RuntimeControlCommand`
+  - `RespawnBackoffTracker::new(3)` semantics
+  - `write_projection_rebuild_request()`
+- Added `POST /operator/runtime/reconcile` and a bounded `recv_timeout(10s)` response path.
+- Wired `runtime_tx/runtime_rx` through Operator API and ECS loop.
+- Added `run_runtime_reconcile()` in the orchestrator:
+  - removes unexpected active runtime fragments
+  - removes stale security runtime snapshots
+  - tears down orphan cgroups without live PIDs
+  - restores missing security runtime snapshots when core runtime is healthy
+  - respawns expected active Agents when requested
+  - records `repair_blocked` via `PlatformIntervention`
+  - updates `SharedRuntimeHealthState` with counters and per-agent repair status
+- Conflict resolution:
+  - kept current `suspend_pids()` implementation with 2s multi-PID verification from #264/main lineage
+  - rejected donor's narrower 250ms tracked-PID-only check
+
+### Evidence
+
+- `cargo remote -c -- test -p sentinel-daemon runtime_control -- --nocapture`
+  - PASS: `2 passed; 0 failed; 177 filtered out`
+  - Covered tests:
+    - `runtime_control::tests::respawn_backoff_tracker_applies_exponential_backoff_until_blocked`
+    - `runtime_control::tests::write_projection_rebuild_request_persists_request_file`
+- `cargo remote -c -- test -p sentinel-daemon runtime_reconcile -- --nocapture`
+  - PASS: `1 passed; 0 failed; 178 filtered out; finished in 0.61s`
+  - Covered test:
+    - `operator_api::tests::runtime_reconcile_is_forwarded_and_returns_response`
+- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
+  - PASS: `Finished release profile [optimized] target(s) in 1m 00s`
+  - artifact hash: `19ce8b228b5588142399a4f712afd4cd89b1caca2be43c1273355a3ad30fe724  target/release/sentinel-daemon`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_8_DONE_TASK_9_PENDING`
-- Current task: `Task 9 - Slice G: Conditional FUSE/Landlock Runtime Restore`
+- Overall status: `TASK_9_DONE_TASK_10_PENDING`
+- Current task: `Task 10 - Out-of-scope Follow-up: Haiku-Policy`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -66,6 +66,11 @@
   - Runtime-Health erkennt Projection-Drift und zaehlt driftende Projection-Agenten
   - Runtime-Reconcile fordert Projection-Rebuilds per Request-Datei an und vermeidet Restart-Storms, wenn `sentinel-projection` bereits aktiv ist
   - Remote-Tests, Clippy, Release-Builds und Artifact-Hashes fuer Daemon und Projection sind dokumentiert
+- Slice G ist erledigt:
+  - Daemon aktiviert `fs_mount` fuer Sandbox, Operator-API und ECS nur noch, wenn `sentinel-fs` wirklich als FUSE-Mount aktiv ist
+  - bei fehlendem FUSE-Mount faellt die Runtime explizit auf `/ram/agents` zurueck statt bwrap auf einen toten Mountpoint zu richten
+  - Landlock-Exec-Allowlist bleibt schmal und enthaelt zusaetzlich die notwendigen dynamischen ELF-Loader
+  - Remote-Tests, Clippy, FUSE-Release-Builds, Sandbox-Binary-Build, Scope-Guard und Artifact-Hashes sind dokumentiert
 
 ## Blocked items
 
@@ -83,7 +88,7 @@
 - `f5e3dd9` Task [5] Slice C - Fast Stall Recovery
 - `b3b7786` Task [6] Slice D - Worker-Supervision
 - `bc57b4c` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
-- `TBD` Task [8] Slice F - Projection/API-Konvergenz
+- `92b3279` Task [8] Slice F - Projection/API-Konvergenz
 - `TBD` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
 - `TBD` Task [10] Out-of-scope Follow-up - Haiku-Policy
 - `TBD` Task [11] Phase 3 - Tests, Clippy, Builds
@@ -105,7 +110,7 @@
 | 6 | Slice D - Worker-Supervision | DONE | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | DONE | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
 | 8 | Slice F - Projection/API-Konvergenz | DONE | read-only Projection-Reads, Rebuild-Request, drift-heal, no restart storm | inspect, command, system |
-| 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | PENDING | nur falls Main-Repro es braucht: FUSE/Landlock Runtime Restore, eigene Build-/Deploy-Gates | inspect, command, system |
+| 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | DONE | FUSE-Aktivierungs-Gate, `/ram/agents` Fallback, Landlock-ELF-Loader-Allowlist, eigene Build-/Deploy-Gates | inspect, command, system |
 | 10 | Out-of-scope Follow-up - Haiku-Policy | PENDING | separates Gateway-/Policy-Issue oder Kommentar, nicht #279-Close-Bedingung | command, inspect |
 | 11 | Phase 3 - Tests, Clippy, Builds | PENDING | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
 | 12 | Phase 4 - Deploy auf die VM | PENDING | ExecStart pruefen, scp/install, restart, post-restart smoke | command, system |
@@ -548,3 +553,67 @@
 - `cargo remote -c -- build -q -p sentinel-projection-service --release`
   - PASS: exit `0`
   - artifact hash: `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`
+
+## Task 9 - Slice G: Conditional FUSE/Landlock Runtime Restore
+
+### Pre-task self-check
+
+- Was muss getan werden: Slice G nur soweit umsetzen, wie der canonical-main-Reset es fuer Runtime-Konsistenz rechtfertigt: kein #264-Port, kein Gateway-/Model-Scope, sondern FUSE-Aktivierung fail-closed und Landlock-Exec-Pfade runtime-faehig halten.
+- Welche ACs muessen hier passen:
+  - AC-1: `fs_mount` wird nur an Sandbox, Operator-API und ECS weitergegeben, wenn `sentinel-fs` wirklich als FUSE-Mount aktiv ist.
+  - AC-2: Wenn der FUSE-Mount nicht aktiv wird, laeuft die Runtime explizit ueber `/ram/agents` weiter statt auf einen leeren Mountpoint zu zeigen.
+  - AC-3: Landlock bleibt eng und erlaubt Execute nicht wieder pauschal fuer `/usr` oder `/lib`.
+  - AC-4: Dynamische ELF-Binaries koennen weiter starten, weil die notwendigen Loader explizit erlaubt sind.
+  - AC-5: Remote-Tests, Clippy, FUSE-Builds, Sandbox-Binary-Build, Scope-Guard und `git diff --check` sind gruen.
+- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
+- Erwartete Dateien: `services/sentinel-daemon/src/orchestrator.rs`, `crates/sentinel-sandbox/src/landlock.rs`, `CHANGELOG.md`.
+- Risiken:
+  - FUSE darf nicht blind als aktiv gelten, nur weil `fs_mount` konfiguriert ist.
+  - Landlock darf nicht durch breite `/usr`-/`/lib`-Exec-Allowlists verwässert werden.
+  - Slice G darf keine #264-Security-ACs oder Haiku-/Gateway-Policy einschleppen.
+
+### Outcome
+
+- `mountinfo_contains_mountpoint()` prueft jetzt exakt auf Mountpoint, FUSE-Filesystem und `sentinel-fs` als Mount-Source.
+- `wait_for_fuse_mount()` wartet bounded bis zu 2s auf den FUSE-Mount und prueft danach final erneut.
+- Der Daemon berechnet `active_fs_mount` und gibt nur diesen aktiven Mount an Sandbox, Operator-API und ECS weiter.
+- Wenn `config.fs_mount` gesetzt ist, aber kein tragfaehiger FUSE-Mount aktiv wird, loggt der Daemon eine Warnung und nutzt weiter `/ram/agents`.
+- Landlock `default_exec_paths()` bleibt eng:
+  - `/usr/bin/agent-runtime`
+  - `/breakout-helper`
+  - `/lib64/ld-linux-x86-64.so.2`
+  - `/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2`
+- Tests sichern ab, dass `/usr` nicht als pauschaler Exec-Pfad zurueckkommt.
+- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
+
+### Evidence
+
+- `cargo remote -c -- test -q -p sentinel-daemon mountinfo_contains_mountpoint_matches_exact_sentinel_fuse_mount --features fuse -- --nocapture`
+  - PASS: targeted FUSE-mountinfo test passed.
+- `cargo remote -c -- test -q -p sentinel-sandbox ruleset_for_agent_paths -- --nocapture`
+  - PASS: Landlock-Agent-Ruleset-Test passed and confirms no `/usr` exec path.
+- `cargo remote -c -- fmt --check`
+  - PASS: no remaining rustfmt diff.
+- `cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture`
+  - PASS: `44 tests: 41 passed, 3 ignored`; `16 tests: 14 passed, 2 ignored`; `12 tests: 3 passed, 9 ignored`.
+- `cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-sandbox --release --bins`
+  - PASS: exit `0`.
+- `cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture`
+  - PASS: `93 passed`; `19 passed`; `2 ignored`.
+- `cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings`
+  - PASS: exit `0`.
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.
+- Scope guard:
+  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates`
+  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`.
+- Artifact hashes:
+  - `517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon`
+  - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
+  - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_7_DONE_TASK_8_PENDING`
-- Current task: `Task 8 - Slice F: Projection/API-Konvergenz`
+- Overall status: `TASK_8_DONE_TASK_9_PENDING`
+- Current task: `Task 9 - Slice G: Conditional FUSE/Landlock Runtime Restore`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -60,6 +60,12 @@
   - Runtime-Health publiziert Queue-Depth, Dropped- und Coalesced-Counter
   - `POST /operator/runtime/analysis-flood-test` erzeugt deterministische Queue-Pressure fuer VM-/AC-Evidence
   - Remote-Tests, FUSE-Release-Build, Clippy, Scope-Guard und Artifact-Hash sind dokumentiert
+- Slice F ist erledigt:
+  - Projection-Worker konsumiert `.projection-rebuild-request` und fuehrt Full-Rebuild in-place aus
+  - Projection-Store bietet read-only Open fuer Runtime-Health ohne Migration/Startup-Cleanup
+  - Runtime-Health erkennt Projection-Drift und zaehlt driftende Projection-Agenten
+  - Runtime-Reconcile fordert Projection-Rebuilds per Request-Datei an und vermeidet Restart-Storms, wenn `sentinel-projection` bereits aktiv ist
+  - Remote-Tests, Clippy, Release-Builds und Artifact-Hashes fuer Daemon und Projection sind dokumentiert
 
 ## Blocked items
 
@@ -76,7 +82,7 @@
 - `ca44759` Task [4] Slice B - Runtime-Control / Reconcile
 - `f5e3dd9` Task [5] Slice C - Fast Stall Recovery
 - `b3b7786` Task [6] Slice D - Worker-Supervision
-- `TBD` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
+- `bc57b4c` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
 - `TBD` Task [8] Slice F - Projection/API-Konvergenz
 - `TBD` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
 - `TBD` Task [10] Out-of-scope Follow-up - Haiku-Policy
@@ -98,7 +104,7 @@
 | 5 | Slice C - Fast Stall Recovery | DONE | deterministischer Stall-Testhook, same-tick Fast-Respawn, Runtime/Security/Sandbox-Recreate | inspect, command, system |
 | 6 | Slice D - Worker-Supervision | DONE | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | DONE | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
-| 8 | Slice F - Projection/API-Konvergenz | PENDING | read-only Projection-Reads, Rebuild-Request, drift-heal | inspect, command, system |
+| 8 | Slice F - Projection/API-Konvergenz | DONE | read-only Projection-Reads, Rebuild-Request, drift-heal, no restart storm | inspect, command, system |
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | PENDING | nur falls Main-Repro es braucht: FUSE/Landlock Runtime Restore, eigene Build-/Deploy-Gates | inspect, command, system |
 | 10 | Out-of-scope Follow-up - Haiku-Policy | PENDING | separates Gateway-/Policy-Issue oder Kommentar, nicht #279-Close-Bedingung | command, inspect |
 | 11 | Phase 3 - Tests, Clippy, Builds | PENDING | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
@@ -477,3 +483,68 @@
 - Scope guard:
   - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates || true`
   - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`
+
+## Task 8 - Slice F: Projection/API-Konvergenz
+
+### Pre-task self-check
+
+- Was muss getan werden: Slice F aus Donor `14560c4` plus relevante Stabilisierung aus `b1e376b` path-limited portieren, Projection-Drift erkennbar machen, Projection-Rebuilds per Request-Datei ausloesen und Restart-Storms vermeiden.
+- Welche ACs muessen hier passen:
+  - AC-1: Projection-Worker konsumiert eine Rebuild-Request-Datei und entfernt sie nach erfolgreichem Full-Rebuild.
+  - AC-2: Projection-Read-Model kann read-only geoeffnet werden, ohne Migrations-/Cleanup-Writes auf Runtime-Health-Reads auszufuehren.
+  - AC-3: Handlerfehler rollen Projection-Batches zurueck statt teilweise fortzuschreiben.
+  - AC-4: Runtime-Health erkennt Projection-Drift gegen Runtime-/Security-/Cgroup-Truth.
+  - AC-5: Runtime-Reconcile fordert bei Drift einen Rebuild an und startet `sentinel-projection` nicht neu, solange der Service aktiv ist und in-place rebuilden kann.
+  - AC-6: Remote-Tests, Clippy, Release-Builds, Artefakt-Hashes und Scope-Guard sind gruen.
+- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
+- Erwartete Dateien: `crates/sentinel-projection/*`, `services/sentinel-projection/src/main.rs`, `services/sentinel-daemon/src/runtime_health.rs`, `runtime_control.rs`, `orchestrator.rs`, `service_health.rs`, `operator_api.rs`, `CHANGELOG.md`.
+- Risiken:
+  - Projection-Recovery darf keine Restart-Schleife erzeugen.
+  - Runtime-Health darf keine Projection-Migrationen oder Startup-Cleanup nebenbei ausfuehren.
+  - Slice F darf keine FUSE/Landlock- oder Gateway-/Model-Policy-Arbeit einschleppen.
+
+### Outcome
+
+- Path-limited Slice F was applied from stack donor `14560c4` plus relevant stabilization from `b1e376b`.
+- `ProjectionConfig` now carries `rebuild_request_path` and a `1s` poll interval.
+- `ProjectionWorker` now polls `.projection-rebuild-request`, runs a full rebuild in-place, and removes the request file after success.
+- Projection batch handler failures now rollback the transaction and return an error instead of silently skipping failed events.
+- `ReadModelStore::open_readonly()` opens Projection DB read-only with a busy timeout and does not run migrations or startup cleanup.
+- Runtime-Health uses read-only Projection access and reports:
+  - `projection_drift_detected`
+  - `projection_drift_agents`
+- Runtime-Reconcile writes rebuild request payloads with a reason and reports:
+  - `projection_drift_before`
+  - `projection_drift_after`
+  - `projection_restart_attempted`
+  - `projection_restart_succeeded`
+- Runtime-Reconcile deliberately skips `systemctl restart sentinel-projection` when Projection is already active and a request-file rebuild can run in-place.
+- `service_health::restart_service()` now calls `systemctl reset-failed` before restart when a restart is actually required.
+- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
+
+### Evidence
+
+- `cargo remote -c -- fmt --check`
+  - PASS: no remaining rustfmt diff.
+- `cargo remote -c -- test -p sentinel-projection rebuild_request -- --nocapture`
+  - PASS: `1 passed; 0 failed`
+- `cargo remote -c -- test -q -p sentinel-projection -- --nocapture`
+  - PASS: `7 unit + 6 acceptance tests passed`
+- `cargo remote -c -- test -q -p sentinel-daemon runtime_control -- --nocapture`
+  - PASS: `2 passed`
+- `cargo remote -c -- test -q -p sentinel-daemon runtime_health -- --nocapture`
+  - PASS: `4 passed`
+- `cargo remote -c -- test -q -p sentinel-daemon test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place -- --nocapture`
+  - PASS: `1 passed`
+- `cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings`
+  - PASS: exit `0`
+- `cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings`
+  - PASS: exit `0`
+- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - PASS: exit `0`
+- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
+  - PASS: exit `0`
+  - artifact hash: `3a05fc872c061ae973e3d820e0a1aaa2d0a909b201d61e9b0c8c84b080c08425  target/release/sentinel-daemon`
+- `cargo remote -c -- build -q -p sentinel-projection-service --release`
+  - PASS: exit `0`
+  - artifact hash: `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_10_DONE_TASK_11_PENDING`
-- Current task: `Task 11 - Phase 3: Tests, Clippy, Builds`
+- Overall status: `TASK_11_DONE_TASK_12_PENDING`
+- Current task: `Task 12 - Phase 4: Deploy auf die VM`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -75,6 +75,12 @@
   - Es gab kein separates offenes Haiku-/Agent-Model-Policy-Issue
   - neues Follow-up `#314` wurde fuer Gateway-/Inference-Agent-Model-Defaults erstellt
   - `#279` wurde mit der Scope-Entscheidung kommentiert: keine Modellentscheidung im Daemon, Gateway waehlt Default
+- Task 11 ist erledigt:
+  - komplette Remote-Testmatrix fuer Daemon, Projection und Projection-Service ist gruen
+  - Clippy ist fuer Daemon, Projection, Projection-Service, `sentinel-fs` und `sentinel-sandbox` gruen
+  - Release-Artefakte fuer Daemon, Projection und Sandbox-Helper wurden remote gebaut
+  - conditional FUSE/Landlock-Gates wurden erneut auf demselben Branch wiederholt
+  - `git diff --check`, Haiku-Scope-Guard und Artifact-Hashes sind dokumentiert
 
 ## Blocked items
 
@@ -116,7 +122,7 @@
 | 8 | Slice F - Projection/API-Konvergenz | DONE | read-only Projection-Reads, Rebuild-Request, drift-heal, no restart storm | inspect, command, system |
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | DONE | FUSE-Aktivierungs-Gate, `/ram/agents` Fallback, Landlock-ELF-Loader-Allowlist, eigene Build-/Deploy-Gates | inspect, command, system |
 | 10 | Out-of-scope Follow-up - Haiku-Policy | DONE | separates Gateway-/Policy-Issue #314 erstellt und in #279 verlinkt, nicht #279-Close-Bedingung | command, inspect |
-| 11 | Phase 3 - Tests, Clippy, Builds | PENDING | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
+| 11 | Phase 3 - Tests, Clippy, Builds | DONE | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
 | 12 | Phase 4 - Deploy auf die VM | PENDING | ExecStart pruefen, scp/install, restart, post-restart smoke | command, system |
 | 13 | Phase 5 - AC-Matrix | PENDING | alle ACs mit Command, Output, PASS auf VM | command, system |
 | 14 | Benchmarks | PENDING | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
@@ -658,3 +664,82 @@
   - PASS: created `https://github.com/silentspike/project-sentinel/issues/279#issuecomment-4304109979`.
 - Scope guard inherited from Task 9:
   - `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`
+
+## Task 11 - Phase 3: Tests, Clippy, Builds
+
+### Pre-task self-check
+
+- Was muss getan werden: die komplette Remote-Qualitaetsmatrix fuer #279 ausfuehren, inklusive conditional FUSE/Landlock-Gates, Release-Artefakte erzeugen und Scope-/Whitespace-Guards belegen.
+- Welche ACs muessen hier passen:
+  - AC-1: Daemon-, Projection- und Projection-Service-Tests laufen auf dem Remote-Builder gruen.
+  - AC-2: Clippy ist fuer alle beruehrten Rust-Crates gruen.
+  - AC-3: Release-Artefakte fuer Daemon, Projection und Sandbox-Helper existieren lokal nach Remote-Build.
+  - AC-4: conditional FUSE/Landlock-Gates bleiben nach allen Slices gruen.
+  - AC-5: `git diff --check` und Haiku-/Model-Scope-Guard sind gruen.
+- Wie wird bewiesen: ausschliesslich `cargo remote -c --` fuer Rust, danach lokale `git diff --check`, `rg` Scope-Guard und `sha256sum`.
+- Erwartete Dateien: `PROGRESS.md`, `test-279-verification.md`; keine Code-Aenderungen.
+- Risiken:
+  - Der Daemon-Test enthaelt einen erwarteten kontrollierten Panic-Test; PASS ist nur gueltig, wenn `catch_unwind` den Test abfaengt und der Testprozess erfolgreich endet.
+  - Release-Hashes muessen die finalen Artefakte fuer Task 12 sein.
+
+### Outcome
+
+- Full daemon test suite passed on the remote builder:
+  - `193 passed; 0 failed; 0 ignored; finished in 10.29s`
+  - expected controlled `panic-test requested for service_health` output was caught by the worker-supervision test.
+- Projection tests passed on the remote builder:
+  - `sentinel-projection`: `7 passed` and `6 passed`
+  - `sentinel-projection-service`: `0 tests`, exit `0`
+- Clippy passed for:
+  - `sentinel-daemon --all-targets --features fuse`
+  - `sentinel-projection --all-targets`
+  - `sentinel-projection-service --all-targets`
+  - `sentinel-fs --all-targets --features fuse-tests`
+  - `sentinel-sandbox --all-targets`
+- Release builds passed for:
+  - `sentinel-daemon --release --features fuse`
+  - `sentinel-projection-service --release`
+  - `sentinel-sandbox --release --bins`
+- Conditional FUSE/Landlock tests were repeated and remained green:
+  - `sentinel-fs --features fuse-tests`: `93 passed`, `19 passed`, `2 ignored`
+  - `sentinel-sandbox`: `41 passed, 3 ignored`; `14 passed, 2 ignored`; `3 passed, 9 ignored`
+- No Haiku/model-policy change was introduced; runtime still leaves model selection to the Gateway default.
+
+### Evidence
+
+- `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`
+  - PASS: `193 passed; 0 failed; 0 ignored; finished in 10.29s`.
+- `cargo remote -c -- test -q -p sentinel-projection -- --nocapture`
+  - PASS: `7 passed`; `6 passed`; no failures.
+- `cargo remote -c -- test -q -p sentinel-projection-service -- --nocapture`
+  - PASS: `0 tests`, exit `0`.
+- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-projection-service --release`
+  - PASS: exit `0`.
+- `cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture`
+  - PASS: `93 passed; 19 passed; 2 ignored`.
+- `cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture`
+  - PASS: `44 tests: 41 passed, 3 ignored`; `16 tests: 14 passed, 2 ignored`; `12 tests: 3 passed, 9 ignored`.
+- `cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings`
+  - PASS: exit `0`.
+- `cargo remote -c -- build -q -p sentinel-sandbox --release --bins`
+  - PASS: exit `0`.
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.
+- Scope guard:
+  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates`
+  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`.
+- Artifact hashes:
+  - `517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon`
+  - `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`
+  - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
+  - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_5_DONE_TASK_6_PENDING`
-- Current task: `Task 6 - Slice D: Worker-Supervision`
+- Overall status: `TASK_6_DONE_TASK_7_PENDING`
+- Current task: `Task 7 - Slice E: bounded Analysis-/Recovery-Pfade`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -49,6 +49,11 @@
   - `PlatformSideEffect::RestartAgent` nutzt jetzt einen same-tick Fast-Respawn statt verzögertem Despawn
   - der Fast-Restart entfernt alte Runtime-, Security- und Sandbox-Fragmente und respawned danach denselben Agent
   - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
+- Slice D ist erledigt:
+  - `service_health` ist per `catch_unwind` in-process supervised
+  - `POST /operator/runtime/panic-test` triggert kontrolliert den Service-Health-Panic-Test ueber den ECS-Thread
+  - Runtime-Health-Worker-State zeigt `running`, `restart_count`, `last_error` und `thread_name`
+  - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
 
 ## Blocked items
 
@@ -63,7 +68,7 @@
 - `e2e7523` Task [2] Phase 1 - Donor-Audit und Clean Port
 - `f5be73b` Task [3] Slice A - Runtime-Health-Read-Model
 - `ca44759` Task [4] Slice B - Runtime-Control / Reconcile
-- `TBD` Task [5] Slice C - Fast Stall Recovery
+- `f5e3dd9` Task [5] Slice C - Fast Stall Recovery
 - `TBD` Task [6] Slice D - Worker-Supervision
 - `TBD` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
 - `TBD` Task [8] Slice F - Projection/API-Konvergenz
@@ -85,7 +90,7 @@
 | 3 | Slice A - Runtime-Health-Read-Model | DONE | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
 | 4 | Slice B - Runtime-Control / Reconcile | DONE | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
 | 5 | Slice C - Fast Stall Recovery | DONE | deterministischer Stall-Testhook, same-tick Fast-Respawn, Runtime/Security/Sandbox-Recreate | inspect, command, system |
-| 6 | Slice D - Worker-Supervision | PENDING | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
+| 6 | Slice D - Worker-Supervision | DONE | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
 | 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
 | 8 | Slice F - Projection/API-Konvergenz | PENDING | read-only Projection-Reads, Rebuild-Request, drift-heal | inspect, command, system |
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | PENDING | nur falls Main-Repro es braucht: FUSE/Landlock Runtime Restore, eigene Build-/Deploy-Gates | inspect, command, system |
@@ -357,5 +362,53 @@
 - `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
   - PASS: `Finished release profile [optimized] target(s) in 56.20s`
   - artifact hash: `3470152e8b897217e2d2e547549b8f6759b3e733ec53d8a3ea8e00745da8d2bd  target/release/sentinel-daemon`
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.
+
+## Task 6 - Slice D: Worker-Supervision
+
+### Pre-task self-check
+
+- Was muss getan werden: Worker-Supervision aus Donor `6919e66` path-limited portieren, `service_health` per `catch_unwind` im selben Daemon-Prozess neu starten und einen deterministischen Panic-Testhook bereitstellen.
+- Welche ACs muessen hier passen:
+  - AC-1: `service_health`-Worker-Panics werden gefangen und erhoehen `restart_count`, ohne den Daemon-Prozess zu beenden.
+  - AC-2: `POST /operator/runtime/panic-test` akzeptiert nur den erlaubten Worker `service_health`, dispatcht in den ECS-Thread und liefert eine bounded Response.
+  - AC-3: Runtime-Health-Worker-State bleibt beobachtbar: `running`, `restart_count`, `last_error`, `thread_name`.
+  - AC-4: Remote-Tests, FUSE-Release-Build, Artefakt-Hash und `git diff --check` sind gruen.
+- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/build`, `sha256sum`, `git diff --check`.
+- Erwartete Dateien: `services/sentinel-daemon/src/service_health.rs`, `runtime_control.rs`, `operator_api.rs`, `orchestrator.rs`, `CHANGELOG.md`.
+- Risiken:
+  - Der Panic-Test muss ein kontrollierter Testpfad bleiben und darf keinen Daemon-Crash als PASS werten.
+  - Die bestehende Operator-Auth-/Loopback-Schutzschicht darf nicht umgangen werden.
+
+### Outcome
+
+- Path-limited donor Slice D was applied from stack donor `6919e66`.
+- `ServiceHealthChecker::spawn()` supervisiert den Worker jetzt in einer Schleife mit `panic::catch_unwind(AssertUnwindSafe(...))`.
+- Ein kontrollierter Panic erhoeht `restart_count`, schreibt `last_error` und startet `service-health-checker` im selben Daemon-Prozess erneut.
+- `ServiceHealthControl::{PanicTest, Shutdown}` steuert Test und sauberen Drop des Workers.
+- `POST /operator/runtime/panic-test` ist verdrahtet:
+  - rejects empty worker
+  - allows only `worker=service_health`
+  - dispatches via `RuntimeControlCommand::PanicTest`
+  - waits with `recv_timeout(10s)`
+- Der Orchestrator behandelt den Panic-Test im ECS-Owner-Thread und ruft `service_health_checker.trigger_panic_test()`.
+- No Haiku/model-policy changes were introduced.
+
+### Evidence
+
+- `cargo remote -c -- fmt --check`
+  - PASS: no remaining rustfmt diff.
+- `cargo remote -c -- test -p sentinel-daemon runtime_panic_test -- --nocapture`
+  - PASS: `2 passed; 0 failed; 183 filtered out; finished in 0.07s`
+  - Covered tests:
+    - `operator_api::tests::runtime_panic_test_is_forwarded_and_returns_response`
+    - `operator_api::tests::runtime_panic_test_rejects_invalid_worker`
+- `cargo remote -c -- test -p sentinel-daemon panic_test_restarts_worker_in_process -- --nocapture`
+  - PASS: `1 passed; 0 failed; 184 filtered out; finished in 0.25s`
+  - Note: the printed panic/backtrace is expected evidence from the intentional panic-test path; `catch_unwind` catches it and the test passes.
+- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
+  - PASS: `Finished release profile [optimized] target(s) in 57.79s`
+  - artifact hash: `4400fcb9162fe242f3cbebda550f25175976abc8f444475ab201d0570e43c3d2  target/release/sentinel-daemon`
 - `git diff --check`
   - PASS: no whitespace/conflict errors.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -119,7 +119,7 @@
 - `90792a5` Task [10] Out-of-scope Follow-up - Haiku-Policy
 - `441ff3c` Task [11] Phase 3 - Tests, Clippy, Builds
 - `aa4ee20` Task [12] Phase 4 - Deploy auf die VM
-- `TBD` Task [13] Phase 5 - AC-Matrix
+- `e53cb5c` Task [13] Phase 5 - AC-Matrix
 - `TBD` Task [14] Benchmarks
 - `TBD` Task [15] PR- und Close-Sequenz
 - `TBD` Task [16] Plan-Verifikation

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -94,7 +94,7 @@
 - `bc57b4c` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
 - `92b3279` Task [8] Slice F - Projection/API-Konvergenz
 - `7eb95cb` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
-- `TBD` Task [10] Out-of-scope Follow-up - Haiku-Policy
+- `90792a5` Task [10] Out-of-scope Follow-up - Haiku-Policy
 - `TBD` Task [11] Phase 3 - Tests, Clippy, Builds
 - `TBD` Task [12] Phase 4 - Deploy auf die VM
 - `TBD` Task [13] Phase 5 - AC-Matrix

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_6_DONE_TASK_7_PENDING`
-- Current task: `Task 7 - Slice E: bounded Analysis-/Recovery-Pfade`
+- Overall status: `TASK_7_DONE_TASK_8_PENDING`
+- Current task: `Task 8 - Slice F: Projection/API-Konvergenz`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -18,7 +18,7 @@
 - Der neue Worktree ist sauber von `origin/main` geschnitten; alte #264/#279-Stack-Worktrees bleiben unangetastet.
 - `gh issue view 279` ist erreichbar; GitHub ist aktuell die SSOT.
 - `#279` ist `OPEN` und steht aktuell auf `status:in-progress`.
-- Der GitHub-Issue-Body ist stale: er enthaelt noch `Blocked by #278`, alte Runtime-Zahlen und muss vor Codearbeit truth-repaired werden.
+- Der GitHub-Issue-Body war stale und wurde in Phase 0 truth-repaired; aktuelle SSOT ist `#279` mit `status:in-progress`.
 - `mainrag search "issue 279 daemon hardening runtime" --source claude-conversations --limit 5` ist aktuell nicht nutzbar, weil `localhost:3001` `Connection refused` liefert. Das ist kein Task-Blocker, aber ein dokumentierter Kontextverlust.
 - Phase 0 ist erledigt:
   - frische Pre-Reset-VM-Baseline ist in `test-279-verification.md` dokumentiert
@@ -54,6 +54,12 @@
   - `POST /operator/runtime/panic-test` triggert kontrolliert den Service-Health-Panic-Test ueber den ECS-Thread
   - Runtime-Health-Worker-State zeigt `running`, `restart_count`, `last_error` und `thread_name`
   - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
+- Slice E ist erledigt:
+  - Platform-Controlplane-Triggerqueue ist bounded und coalesced doppelte Trigger
+  - LLM-Analyzer-Channel ist bounded und zaehlt Dropped-Requests
+  - Runtime-Health publiziert Queue-Depth, Dropped- und Coalesced-Counter
+  - `POST /operator/runtime/analysis-flood-test` erzeugt deterministische Queue-Pressure fuer VM-/AC-Evidence
+  - Remote-Tests, FUSE-Release-Build, Clippy, Scope-Guard und Artifact-Hash sind dokumentiert
 
 ## Blocked items
 
@@ -69,7 +75,7 @@
 - `f5be73b` Task [3] Slice A - Runtime-Health-Read-Model
 - `ca44759` Task [4] Slice B - Runtime-Control / Reconcile
 - `f5e3dd9` Task [5] Slice C - Fast Stall Recovery
-- `TBD` Task [6] Slice D - Worker-Supervision
+- `b3b7786` Task [6] Slice D - Worker-Supervision
 - `TBD` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
 - `TBD` Task [8] Slice F - Projection/API-Konvergenz
 - `TBD` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
@@ -91,7 +97,7 @@
 | 4 | Slice B - Runtime-Control / Reconcile | DONE | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
 | 5 | Slice C - Fast Stall Recovery | DONE | deterministischer Stall-Testhook, same-tick Fast-Respawn, Runtime/Security/Sandbox-Recreate | inspect, command, system |
 | 6 | Slice D - Worker-Supervision | DONE | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
-| 7 | Slice E - bounded Analysis-/Recovery-Pfade | PENDING | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
+| 7 | Slice E - bounded Analysis-/Recovery-Pfade | DONE | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
 | 8 | Slice F - Projection/API-Konvergenz | PENDING | read-only Projection-Reads, Rebuild-Request, drift-heal | inspect, command, system |
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | PENDING | nur falls Main-Repro es braucht: FUSE/Landlock Runtime Restore, eigene Build-/Deploy-Gates | inspect, command, system |
 | 10 | Out-of-scope Follow-up - Haiku-Policy | PENDING | separates Gateway-/Policy-Issue oder Kommentar, nicht #279-Close-Bedingung | command, inspect |
@@ -412,3 +418,62 @@
   - artifact hash: `4400fcb9162fe242f3cbebda550f25175976abc8f444475ab201d0570e43c3d2  target/release/sentinel-daemon`
 - `git diff --check`
   - PASS: no whitespace/conflict errors.
+
+## Task 7 - Slice E: bounded Analysis-/Recovery-Pfade
+
+### Pre-task self-check
+
+- Was muss getan werden: Slice E aus Donor `389b5e6` path-limited portieren, unbounded Analyse-Vorstufen begrenzen, Coalescing-/Drop-Counter sichtbar machen und einen deterministischen Flood-Testhook bereitstellen.
+- Welche ACs muessen hier passen:
+  - AC-1: Platform-Controlplane-Triggerqueue ist bounded, coalesced Duplikate und droppt aelteste Eintraege bei Ueberlauf.
+  - AC-2: LLM-Analyzer-Channel ist bounded und zaehlt Dropped-Requests statt unbounded Memory-Wachstum zuzulassen.
+  - AC-3: Runtime-Health enthaelt `analysis_queue_depth`, `analysis_queue_dropped_total` und `analysis_queue_coalesced_total`.
+  - AC-4: `POST /operator/runtime/analysis-flood-test` erzeugt kontrollierte Queue-Pressure fuer Live-Verifikation.
+  - AC-5: Remote-Tests, FUSE-Release-Build, Clippy, Artefakt-Hash, Scope-Guard und `git diff --check` sind gruen.
+- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
+- Erwartete Dateien: `config/daemon.toml`, `services/sentinel-daemon/src/config.rs`, `operator_api.rs`, `orchestrator.rs`, `platform_controlplane/*`, `runtime_control.rs`, `runtime_health.rs`, `CHANGELOG.md`.
+- Risiken:
+  - Nur den #279-Queue-Scope portieren, keine Gateway-/Model-Policy.
+  - Analyzer- und Controlplane-Stats muessen zusammengefuehrt werden, damit Runtime-Health nicht nur eine Queue sieht.
+  - Flood-Test muss ueber Operator-API/Runtime-Control laufen und darf kein ungeschuetzter Produktionspfad werden.
+
+### Outcome
+
+- Path-limited donor Slice E was applied from stack donor `389b5e6`.
+- Added `[daemon.platform_controlplane]` settings:
+  - `llm_trigger_queue_capacity = 16`
+  - `llm_analysis_channel_capacity = 16`
+- `PlatformControlplane` now uses a bounded `VecDeque` trigger queue.
+- Duplicate queued triggers are coalesced and counted via `analysis_queue_coalesced_total`.
+- Overflow drops the oldest trigger and increments `analysis_queue_dropped_total`.
+- `PlatformLlmAnalyzerHandle` now uses a bounded channel sized from config and tracks depth/drop counters.
+- Runtime-Health now publishes merged controlplane/analyzer queue stats.
+- Added `POST /operator/runtime/analysis-flood-test`:
+  - rejects `count=0`
+  - dispatches through `RuntimeControlCommand::AnalysisFloodTest`
+  - injects bounded/coalesced queue pressure in the ECS owner thread
+  - returns `requested`, `queue_depth`, `dropped_total` and `coalesced_total`
+- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
+
+### Evidence
+
+- `cargo remote -c -- fmt --check`
+  - PASS: no remaining rustfmt diff.
+- `cargo remote -c -- test -p sentinel-daemon test_parse_config -- --nocapture`
+  - PASS: `2 passed; 0 failed; 188 filtered out`
+- `cargo remote -c -- test -p sentinel-daemon trigger_queue -- --nocapture`
+  - PASS: `2 passed; 0 failed; 188 filtered out`
+- `cargo remote -c -- test -p sentinel-daemon enqueue_drops_when_bounded_queue_is_full -- --nocapture`
+  - PASS: `1 passed; 0 failed; 189 filtered out`
+- `cargo remote -c -- test -p sentinel-daemon runtime_analysis_flood_test -- --nocapture`
+  - PASS: `2 passed; 0 failed; 188 filtered out; finished in 0.06s`
+- `cargo remote -c -- clippy -p sentinel-daemon --all-targets --features fuse -- -D warnings`
+  - PASS: `Finished dev profile [unoptimized + debuginfo] target(s) in 2m 59s`
+- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
+  - PASS: `Finished release profile [optimized] target(s) in 56.44s`
+  - artifact hash: `39bf79442190541ec03f11a66c4e8be437f6a8bd1f2e2366611a0d9ad0366cb2  target/release/sentinel-daemon`
+- `git diff --check`
+  - PASS: no whitespace/conflict errors.
+- Scope guard:
+  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates || true`
+  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_11_DONE_TASK_12_PENDING`
-- Current task: `Task 12 - Phase 4: Deploy auf die VM`
+- Overall status: `TASK_12_DONE_TASK_13_PENDING`
+- Current task: `Task 13 - Phase 5: AC-Matrix`
 - Current branch: `feat/issue-279-daemon-hardening-v2`
 - Worktree: `/work/company/project-sentinel-279-review`
 - Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
@@ -81,6 +81,13 @@
   - Release-Artefakte fuer Daemon, Projection und Sandbox-Helper wurden remote gebaut
   - conditional FUSE/Landlock-Gates wurden erneut auf demselben Branch wiederholt
   - `git diff --check`, Haiku-Scope-Guard und Artifact-Hashes sind dokumentiert
+- Task 12 ist erledigt:
+  - Release-Artefakte wurden an den systemd `ExecStart`-Pfaden auf `10.0.0.240` installiert
+  - erste Runtime-Reconcile-Runde reparierte Projection-only Drift von `57` auf `26`, deckte aber drei verwaiste gestoppte #264-Write-Anomaly-Cgroups auf
+  - Cgroup-Reconcile wurde gehärtet: verwaiste Live-Cgroups werden ueber `cgroup.kill`/SIGKILL-Fallback geleert und danach entfernt
+  - zweiter VM-Deploy mit Daemon-Hash `d6c30a324d85cbb3ec9d919a14e5f5744482cda75e59984e6133944289129d86`
+  - Live-Reconcile meldete `orphan_cgroups_before=3`, `orphan_cgroups_after=0`, `orphan_cgroups_removed=3`
+  - finaler Runtime-Health-Gate ist gruen: `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`, Dashboard-API `26`
 
 ## Blocked items
 
@@ -123,7 +130,7 @@
 | 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | DONE | FUSE-Aktivierungs-Gate, `/ram/agents` Fallback, Landlock-ELF-Loader-Allowlist, eigene Build-/Deploy-Gates | inspect, command, system |
 | 10 | Out-of-scope Follow-up - Haiku-Policy | DONE | separates Gateway-/Policy-Issue #314 erstellt und in #279 verlinkt, nicht #279-Close-Bedingung | command, inspect |
 | 11 | Phase 3 - Tests, Clippy, Builds | DONE | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
-| 12 | Phase 4 - Deploy auf die VM | PENDING | ExecStart pruefen, scp/install, restart, post-restart smoke | command, system |
+| 12 | Phase 4 - Deploy auf die VM | DONE | ExecStart pruefen, scp/install, restart, post-restart smoke, Projection-/Cgroup-Drift reparieren | command, system |
 | 13 | Phase 5 - AC-Matrix | PENDING | alle ACs mit Command, Output, PASS auf VM | command, system |
 | 14 | Benchmarks | PENDING | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
 | 15 | PR- und Close-Sequenz | PENDING | PR mit Pflichtsektionen, labels, merge, branch delete, issue close erst nach verified | command |

--- a/config/daemon.toml
+++ b/config/daemon.toml
@@ -83,3 +83,5 @@ llm_gateway_timeout_ms = 30000
 llm_prompt_template = "platform-controlplane-default"
 llm_max_context_events = 10
 llm_max_failed_interventions = 3
+llm_trigger_queue_capacity = 16
+llm_analysis_channel_capacity = 16

--- a/crates/sentinel-projection/benches/projection_bench.rs
+++ b/crates/sentinel-projection/benches/projection_bench.rs
@@ -89,6 +89,13 @@ fn make_worker(event_store: Arc<EventStore>, db_path: &str) -> ProjectionWorker 
         poll_interval: Duration::from_millis(1),
         batch_size: 100,
         db_path: db_path.to_string(),
+        rebuild_request_path: std::path::Path::new(db_path)
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join(".projection-rebuild-request")
+            .to_string_lossy()
+            .to_string(),
+        rebuild_request_poll_interval: Duration::from_secs(1),
     };
     ProjectionWorker::new(event_store, config).unwrap()
 }

--- a/crates/sentinel-projection/src/config.rs
+++ b/crates/sentinel-projection/src/config.rs
@@ -1,5 +1,6 @@
 //! Konfiguration fuer den Projection Worker.
 
+use std::path::Path;
 use std::time::Duration;
 
 /// Konfiguration fuer den ProjectionWorker.
@@ -10,14 +11,27 @@ pub struct ProjectionConfig {
     pub batch_size: usize,
     /// Pfad zur Read-Model SQLite-Datenbank. Default: "data/projection.db".
     pub db_path: String,
+    /// Dateipfad fuer Full-Rebuild-Requests aus daemon-seitigen Repair-Pfaden.
+    pub rebuild_request_path: String,
+    /// Intervall fuer das Polling der Rebuild-Request-Datei.
+    pub rebuild_request_poll_interval: Duration,
 }
 
 impl Default for ProjectionConfig {
     fn default() -> Self {
+        let db_path = "data/projection.db".to_string();
+        let rebuild_request_path = Path::new(&db_path)
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(".projection-rebuild-request")
+            .to_string_lossy()
+            .to_string();
         Self {
             poll_interval: Duration::from_millis(50),
             batch_size: 100,
-            db_path: "data/projection.db".to_string(),
+            db_path,
+            rebuild_request_path,
+            rebuild_request_poll_interval: Duration::from_secs(1),
         }
     }
 }

--- a/crates/sentinel-projection/src/store.rs
+++ b/crates/sentinel-projection/src/store.rs
@@ -366,6 +366,55 @@ impl ReadModelStore {
         )?;
         Ok(count)
     }
+
+    /// Listet aktive Agents in der Live-View.
+    ///
+    /// Dieser Read-Pfad wird vom Daemon fuer Runtime-Health genutzt. Er bleibt
+    /// read-only und macht Projection-only Ghost-Agents explizit sichtbar.
+    pub fn active_agents(&self) -> anyhow::Result<Vec<AgentView>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let mut stmt = conn.prepare(
+            "SELECT agent_id, name, role, shift_set, status, current_room, in_transit,
+                    transit_target, last_action, last_action_tick, hunger, energy,
+                    stress, bladder, social_need, caffeine_mg, mood, last_event_id,
+                    updated_at
+             FROM agent_live_view
+             WHERE status = 'active'
+             ORDER BY agent_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(AgentView {
+                agent_id: row.get(0)?,
+                name: row.get(1)?,
+                role: row.get(2)?,
+                shift_set: row.get(3)?,
+                status: row.get(4)?,
+                current_room: row.get(5)?,
+                in_transit: row.get::<_, i32>(6)? != 0,
+                transit_target: row.get(7)?,
+                last_action: row.get(8)?,
+                last_action_tick: row.get(9)?,
+                hunger: row.get(10)?,
+                energy: row.get(11)?,
+                stress: row.get(12)?,
+                bladder: row.get(13)?,
+                social_need: row.get(14)?,
+                caffeine_mg: row.get(15)?,
+                mood: row.get(16)?,
+                last_event_id: row.get(17)?,
+                updated_at: row.get(18)?,
+            })
+        })?;
+
+        let mut agents = Vec::new();
+        for row in rows {
+            agents.push(row?);
+        }
+        Ok(agents)
+    }
 }
 
 // ── View-Structs ─────────────────────────────────

--- a/crates/sentinel-projection/src/store.rs
+++ b/crates/sentinel-projection/src/store.rs
@@ -8,9 +8,10 @@
 //! tolerieren Re-Processing bei Restart.
 
 use anyhow::Context;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OpenFlags};
 use std::sync::{Arc, Mutex};
-use tracing::info;
+use std::time::Duration;
+use tracing::{debug, info};
 
 // ── SQL Schemas ──────────────────────────────────
 
@@ -94,6 +95,7 @@ impl ReadModelStore {
     pub fn open(path: &str) -> anyhow::Result<Self> {
         let conn = Connection::open(path)
             .with_context(|| format!("Failed to open projection DB: {path}"))?;
+        conn.busy_timeout(Duration::from_secs(5))?;
 
         // WAL-Modus + Performance-Pragmas (wie EventStore)
         conn.pragma_update(None, "journal_mode", "WAL")?;
@@ -149,6 +151,21 @@ impl ReadModelStore {
         }
 
         info!(path, "ReadModelStore opened");
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Oeffnet eine existierende Read-Model-Datenbank schreibgeschuetzt.
+    ///
+    /// Verwendet keinen Startup-Cleanup und keine Schema-Migrationen. Dieser
+    /// Pfad ist fuer daemon-seitige Runtime-Health-Diagnostik bestimmt, damit
+    /// kein zweiter Writer auf `projection.db` entsteht.
+    pub fn open_readonly(path: &str) -> anyhow::Result<Self> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("Failed to open projection DB readonly: {path}"))?;
+        conn.busy_timeout(Duration::from_secs(5))?;
+        debug!(path, readonly = true, "ReadModelStore opened");
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })
@@ -413,6 +430,12 @@ impl<'a> ReadModelTransaction<'a> {
     /// Committed die SQLite-Transaktion.
     pub fn commit(&self) -> anyhow::Result<()> {
         self.guard.execute_batch("COMMIT")?;
+        Ok(())
+    }
+
+    /// Rollback fuer fail-closed Batch-Fehler.
+    pub fn rollback(&self) -> anyhow::Result<()> {
+        self.guard.execute_batch("ROLLBACK")?;
         Ok(())
     }
 
@@ -798,6 +821,28 @@ mod tests {
             .query_row("SELECT count(*) FROM kpi_1m", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_open_readonly_reads_existing_projection_without_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-readonly.db");
+        let store = ReadModelStore::open(path.to_str().unwrap()).unwrap();
+
+        {
+            let txn = store.begin_transaction().unwrap();
+            txn.begin().unwrap();
+            txn.upsert_agent(7, "Readonly Agent", "QA", 1, "active", 10)
+                .unwrap();
+            txn.update_agent_room(7, "empfang", 11).unwrap();
+            txn.commit().unwrap();
+        }
+        drop(store);
+
+        let readonly = ReadModelStore::open_readonly(path.to_str().unwrap()).unwrap();
+        let agent = readonly.get_agent(7).unwrap().unwrap();
+        assert_eq!(agent.name, "Readonly Agent");
+        assert_eq!(agent.current_room.as_deref(), Some("empfang"));
     }
 
     #[test]

--- a/crates/sentinel-projection/src/worker.rs
+++ b/crates/sentinel-projection/src/worker.rs
@@ -3,8 +3,11 @@
 //! Sync API (kein async) — passt zum EventStore Pattern.
 //! Poll-Loop mit `std::thread::sleep` bei leeren Batches.
 
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use std::thread;
+use std::time::Instant;
 
 use anyhow::Context;
 use sentinel_common::DomainEventPayload;
@@ -92,14 +95,21 @@ impl ProjectionWorker {
     pub fn run(&self) -> anyhow::Result<()> {
         // Rooms initialisieren (idempotent)
         self.read_store.initialize_rooms(ROOM_IDS)?;
+        let mut next_rebuild_poll = Instant::now();
 
         info!(
             poll_interval_ms = self.config.poll_interval.as_millis() as u64,
             batch_size = self.config.batch_size,
+            rebuild_request_path = %self.config.rebuild_request_path,
             "Projection worker starting live mode"
         );
 
         loop {
+            if Instant::now() >= next_rebuild_poll {
+                self.handle_rebuild_request_if_present()?;
+                next_rebuild_poll = Instant::now() + self.config.rebuild_request_poll_interval;
+            }
+
             let offset = self.event_store.get_offset(PROJECTION_NAME)?.unwrap_or(0);
 
             let batch = self
@@ -185,6 +195,41 @@ impl ProjectionWorker {
         Ok(total_processed)
     }
 
+    fn handle_rebuild_request_if_present(&self) -> anyhow::Result<bool> {
+        let request_path = Path::new(&self.config.rebuild_request_path);
+        if !request_path.exists() {
+            return Ok(false);
+        }
+
+        let payload = fs::read_to_string(request_path).with_context(|| {
+            format!(
+                "Projection-Rebuild-Request konnte nicht gelesen werden: {}",
+                request_path.display()
+            )
+        })?;
+        info!(
+            path = %request_path.display(),
+            request = %payload,
+            "Projection-Rebuild-Request erkannt"
+        );
+
+        let rebuilt = self
+            .rebuild()
+            .context("Projection-Rebuild aus Request-Datei fehlgeschlagen")?;
+        fs::remove_file(request_path).with_context(|| {
+            format!(
+                "Projection-Rebuild-Request konnte nicht entfernt werden: {}",
+                request_path.display()
+            )
+        })?;
+        info!(
+            path = %request_path.display(),
+            events = rebuilt,
+            "Projection-Rebuild-Request abgearbeitet"
+        );
+        Ok(true)
+    }
+
     /// Verarbeitet einen Batch von Events innerhalb einer Transaktion.
     ///
     /// Gibt Anzahl erfolgreich verarbeiteter Events zurueck.
@@ -223,13 +268,22 @@ impl ProjectionWorker {
             // Alle Handler aufrufen (Reihenfolge: agent -> room -> kpi)
             for handler in &self.handlers {
                 if let Err(e) = handler.handle(*row_id, event, &payload, &txn) {
+                    txn.rollback().with_context(|| {
+                        format!(
+                            "Rollback nach Projection-Handlerfehler fehlgeschlagen row_id={row_id} event_type={}",
+                            event.event_type
+                        )
+                    })?;
                     error!(
                         row_id,
                         event_type = event.event_type,
                         error = %e,
-                        "Handler error, skipping event"
+                        "Handler error, aborting batch"
                     );
-                    break;
+                    return Err(e).context(format!(
+                        "Projection-Handlerfehler row_id={row_id} event_type={}",
+                        event.event_type
+                    ));
                 }
             }
 
@@ -295,4 +349,121 @@ fn deserialize_legacy_payload(event_type: &str, payload: &str) -> Option<DomainE
     }
 
     serde_json::from_value(value).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::bail;
+    use sentinel_common::{AgentId, DomainEvent, DomainEventPayload};
+    use tempfile::tempdir;
+
+    struct FailingHandler;
+
+    impl crate::handlers::ProjectionHandler for FailingHandler {
+        fn handle(
+            &self,
+            _row_id: i64,
+            _event: &DomainEvent,
+            _payload: &DomainEventPayload,
+            _txn: &crate::store::ReadModelTransaction<'_>,
+        ) -> anyhow::Result<()> {
+            bail!("synthetic handler failure");
+        }
+    }
+
+    fn append_event(store: &EventStore, tick: u64, payload: &DomainEventPayload) {
+        let mut event = DomainEvent::new(
+            payload.event_type_str(),
+            "test-aggregate",
+            &payload.to_json(),
+            &format!("corr-{tick}"),
+            tick,
+        );
+        event.timestamp_ms = tick * 1000;
+        store.append_event(&event).unwrap();
+    }
+
+    #[test]
+    fn rebuild_request_file_triggers_full_rebuild_and_is_removed() {
+        let dir = tempdir().unwrap();
+        let event_store =
+            Arc::new(EventStore::open(dir.path().join("events.db").to_str().unwrap()).unwrap());
+        append_event(
+            &event_store,
+            1,
+            &DomainEventPayload::AgentSpawned {
+                agent_id: AgentId(1),
+                name: "Test Agent".to_string(),
+                role: "QA".to_string(),
+                shift_set: 1,
+                room_id: "empfang".to_string(),
+            },
+        );
+
+        let request_path = dir.path().join(".projection-rebuild-request");
+        let config = ProjectionConfig {
+            poll_interval: std::time::Duration::from_millis(1),
+            batch_size: 16,
+            db_path: dir
+                .path()
+                .join("projection.db")
+                .to_string_lossy()
+                .to_string(),
+            rebuild_request_path: request_path.to_string_lossy().to_string(),
+            rebuild_request_poll_interval: std::time::Duration::from_secs(1),
+        };
+        let worker = ProjectionWorker::new(Arc::clone(&event_store), config).unwrap();
+
+        fs::write(
+            &request_path,
+            r#"{"requested_by":"runtime_reconcile","reason":"projection_drift","tick":42}"#,
+        )
+        .unwrap();
+
+        assert!(worker.handle_rebuild_request_if_present().unwrap());
+        assert!(!request_path.exists());
+        assert_eq!(worker.read_store().active_agent_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn handler_error_rolls_back_batch_and_returns_err() {
+        let dir = tempdir().unwrap();
+        let event_store =
+            Arc::new(EventStore::open(dir.path().join("events.db").to_str().unwrap()).unwrap());
+        append_event(
+            &event_store,
+            1,
+            &DomainEventPayload::AgentSpawned {
+                agent_id: AgentId(1),
+                name: "Test Agent".to_string(),
+                role: "QA".to_string(),
+                shift_set: 1,
+                room_id: "empfang".to_string(),
+            },
+        );
+
+        let config = ProjectionConfig {
+            poll_interval: std::time::Duration::from_millis(1),
+            batch_size: 16,
+            db_path: dir
+                .path()
+                .join("projection.db")
+                .to_string_lossy()
+                .to_string(),
+            rebuild_request_path: dir
+                .path()
+                .join(".projection-rebuild-request")
+                .to_string_lossy()
+                .to_string(),
+            rebuild_request_poll_interval: std::time::Duration::from_secs(1),
+        };
+        let mut worker = ProjectionWorker::new(Arc::clone(&event_store), config).unwrap();
+        worker.handlers = vec![Box::new(FailingHandler)];
+
+        let batch = event_store.get_events_since_with_id(0, 16).unwrap();
+        let err = worker.process_batch(&batch).unwrap_err();
+        assert!(format!("{err:#}").contains("synthetic handler failure"));
+        assert_eq!(worker.read_store().active_agent_count().unwrap(), 0);
+    }
 }

--- a/crates/sentinel-projection/tests/acceptance.rs
+++ b/crates/sentinel-projection/tests/acceptance.rs
@@ -18,6 +18,13 @@ fn make_config(db_path: &str) -> ProjectionConfig {
         poll_interval: Duration::from_millis(1),
         batch_size: 100,
         db_path: db_path.to_string(),
+        rebuild_request_path: std::path::Path::new(db_path)
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join(".projection-rebuild-request")
+            .to_string_lossy()
+            .to_string(),
+        rebuild_request_poll_interval: Duration::from_secs(1),
     }
 }
 

--- a/crates/sentinel-sandbox/src/cgroups.rs
+++ b/crates/sentinel-sandbox/src/cgroups.rs
@@ -322,6 +322,55 @@ pub fn remove_cgroup(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Force-kills all processes that are still attached to an agent cgroup.
+///
+/// Runtime reconciliation uses this for stale cgroups whose tracked runtime
+/// handle is already gone. `cgroup.kill` handles stopped processes reliably;
+/// the PID fallback keeps older cgroup-v2 hosts functional.
+pub fn kill_cgroup_processes(name: &str) -> Result<usize> {
+    let path = cgroup_path(name);
+    if !std::path::Path::new(&path).exists() {
+        return Ok(0);
+    }
+
+    let initial_pids = list_pids_in_cgroup(name)?;
+    if initial_pids.is_empty() {
+        return Ok(0);
+    }
+
+    let kill_path = format!("{path}/cgroup.kill");
+    if std::path::Path::new(&kill_path).exists() {
+        std::fs::write(&kill_path, "1")
+            .with_context(|| format!("Failed to write cgroup.kill for {name}"))?;
+    } else {
+        for pid in &initial_pids {
+            let status = std::process::Command::new("kill")
+                .args(["-KILL", &pid.to_string()])
+                .status()
+                .with_context(|| format!("Failed to SIGKILL PID {pid} in cgroup {name}"))?;
+            if !status.success() && std::path::Path::new(&format!("/proc/{pid}")).exists() {
+                warn!(pid = *pid, cgroup = %name, "SIGKILL for cgroup member returned non-zero");
+            }
+        }
+    }
+
+    for _ in 0..20 {
+        if list_pids_in_cgroup(name)?.is_empty() {
+            return Ok(initial_pids.len());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let remaining = list_pids_in_cgroup(name)?;
+    if remaining.is_empty() {
+        Ok(initial_pids.len())
+    } else {
+        Err(anyhow::anyhow!(
+            "cgroup {name} still contains PIDs after kill: {remaining:?}"
+        ))
+    }
+}
+
 /// Adds a process to an agent's cgroup.
 pub fn add_pid_to_cgroup(name: &str, pid: u32) -> Result<()> {
     let path = format!("{}/cgroup.procs", cgroup_path(name));
@@ -436,6 +485,11 @@ mod tests {
     fn remove_nonexistent_ok() {
         // Removing a non-existent cgroup should succeed silently
         assert!(remove_cgroup("does-not-exist-xyz").is_ok());
+    }
+
+    #[test]
+    fn kill_nonexistent_cgroup_is_noop() {
+        assert_eq!(kill_cgroup_processes("does-not-exist-xyz").unwrap(), 0);
     }
 
     #[test]

--- a/crates/sentinel-sandbox/src/landlock.rs
+++ b/crates/sentinel-sandbox/src/landlock.rs
@@ -25,6 +25,16 @@ pub struct LandlockRuleset {
 }
 
 impl LandlockRuleset {
+    fn default_exec_paths() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/usr/bin/agent-runtime"),
+            PathBuf::from("/breakout-helper"),
+            // Dynamically linked ELF binaries also need their loader executable.
+            PathBuf::from("/lib64/ld-linux-x86-64.so.2"),
+            PathBuf::from("/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"),
+        ]
+    }
+
     /// Creates a Masterplan-compliant ruleset for an agent.
     ///
     /// Paths are relative to the bwrap mount namespace:
@@ -46,10 +56,7 @@ impl LandlockRuleset {
                 PathBuf::from(format!("/home/{name}")),
                 PathBuf::from("/tmp"),
             ],
-            exec_paths: vec![
-                PathBuf::from("/usr/bin/agent-runtime"),
-                PathBuf::from("/breakout-helper"),
-            ],
+            exec_paths: Self::default_exec_paths(),
         }
     }
 
@@ -163,6 +170,9 @@ mod tests {
             .exec_paths
             .contains(&PathBuf::from("/usr/bin/agent-runtime")));
         assert!(rs.exec_paths.contains(&PathBuf::from("/breakout-helper")));
+        assert!(rs
+            .exec_paths
+            .contains(&PathBuf::from("/lib64/ld-linux-x86-64.so.2")));
         assert!(!rs.exec_paths.contains(&PathBuf::from("/usr")));
     }
 

--- a/scripts/vm-issue-279-bench.sh
+++ b/scripts/vm-issue-279-bench.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8084}"
+OUT_DIR="${OUT_DIR:-/tmp/issue279-bench-$(date -u +%Y%m%dT%H%M%SZ)}"
+START_TIME="$(date -u '+%Y-%m-%d %H:%M:%S')"
+
+mkdir -p "$OUT_DIR"
+
+secret="$(python3 - <<'PY'
+import pathlib, tomllib
+cfg = tomllib.loads(pathlib.Path('/opt/sentinel/config/daemon.toml').read_text())
+print(cfg.get('daemon', {}).get('operator_api', {}).get('shared_secret') or '')
+PY
+)"
+
+CURL_AUTH=()
+if [ -n "$secret" ]; then
+  CURL_AUTH=(-H "x-sentinel-operator-key: $secret")
+fi
+
+op_get() {
+  curl -fsS "${CURL_AUTH[@]}" "$BASE_URL$1"
+}
+
+op_post() {
+  local path="$1"
+  local body="$2"
+  curl -fsS "${CURL_AUTH[@]}" -H 'Content-Type: application/json' -d "$body" "$BASE_URL$path"
+}
+
+json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+value = payload.get(sys.argv[2])
+if value is None:
+    raise SystemExit(f"missing field: {sys.argv[2]}")
+print(value)
+PY
+}
+
+record_result() {
+  local name="$1"
+  local actual="$2"
+  local target="$3"
+  local unit="$4"
+  local source="$5"
+  local pass="PASS"
+  if [ "$actual" -ge "$target" ]; then
+    pass="FAIL"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$actual" "$target" "$unit" "$pass" "$source" >> "$OUT_DIR/bench-results.tsv"
+  if [ "$pass" = "FAIL" ]; then
+    echo "BENCH_FAIL $name actual=$actual target=$target unit=$unit source=$source" >&2
+    exit 1
+  fi
+}
+
+assert_healthy() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    h = json.load(handle)
+expected = h["expected_active_agents"]
+checks = {
+    "runtime_agents": h["runtime_agents"] == expected,
+    "projection_agents": h["projection_agents"] == expected,
+    "live_cgroup_dirs": h["live_cgroup_dirs"] == expected,
+    "stale_runtime_entries": h["stale_runtime_entries"] == 0,
+    "orphan_cgroups": h["orphan_cgroups"] == 0,
+    "zombie_tracked_pids": h["zombie_tracked_pids"] == 0,
+    "projection_drift_detected": not h["projection_drift_detected"],
+}
+failed = [key for key, ok in checks.items() if not ok]
+if failed:
+    raise SystemExit("unhealthy: " + ",".join(failed))
+print(
+    f"healthy expected={expected} runtime={h['runtime_agents']} projection={h['projection_agents']} "
+    f"cgroups={h['live_cgroup_dirs']} stale={h['stale_runtime_entries']} "
+    f"orphans={h['orphan_cgroups']} zombies={h['zombie_tracked_pids']} "
+    f"snapshot_us={h.get('snapshot_build_elapsed_us')}"
+)
+PY
+}
+
+wait_healthy() {
+  local label="$1"
+  local file="$OUT_DIR/health-${label}.json"
+  for attempt in $(seq 1 90); do
+    op_get /operator/runtime-health > "$file"
+    if assert_healthy "$file" > "$OUT_DIR/health-${label}.txt" 2>/dev/null; then
+      cat "$OUT_DIR/health-${label}.txt"
+      return 0
+    fi
+    sleep 2
+  done
+  assert_healthy "$file"
+}
+
+process_snapshot() {
+  local label="$1"
+  local daemon_pid
+  local projection_pid
+  daemon_pid="$(pgrep -x sentinel-daemon | head -n1 || true)"
+  projection_pid="$(pgrep -f '/opt/sentinel/bin/sentinel-projection' | head -n1 || true)"
+  {
+    echo "label=$label"
+    echo "daemon_pid=$daemon_pid"
+    echo "projection_pid=$projection_pid"
+    if [ -n "$daemon_pid$projection_pid" ]; then
+      ps -o pid,ppid,stat,%cpu,%mem,rss,comm -p "$daemon_pid" "$projection_pid" 2>/dev/null || true
+    fi
+  } > "$OUT_DIR/ps-${label}.txt"
+}
+
+capture_sidecars() {
+  local label="$1"
+  free -m > "$OUT_DIR/free-${label}.txt"
+  vmstat 1 5 > "$OUT_DIR/vmstat-${label}.txt"
+  if ! command -v iostat >/dev/null 2>&1; then
+    echo "iostat missing; install sysstat before benchmark acceptance" >&2
+    exit 1
+  fi
+  iostat -x 1 5 > "$OUT_DIR/iostat-${label}.txt"
+  process_snapshot "$label"
+}
+
+printf '%s\t%s\t%s\t%s\t%s\t%s\n' "name" "actual" "target_exclusive" "unit" "pass" "source" > "$OUT_DIR/bench-results.tsv"
+
+capture_sidecars before
+wait_healthy pre
+
+max_reconcile_us=0
+for idx in $(seq 1 5); do
+  file="$OUT_DIR/runtime-reconcile-${idx}.json"
+  op_post /operator/runtime/reconcile '{"dry_run":true,"respawn_missing":true,"projection_rebuild":false}' > "$file"
+  elapsed="$(json_field "$file" elapsed_us)"
+  printf '%s\t%s\n' "$idx" "$elapsed" >> "$OUT_DIR/runtime-reconcile-runs.tsv"
+  if [ "$elapsed" -gt "$max_reconcile_us" ]; then
+    max_reconcile_us="$elapsed"
+  fi
+done
+record_result runtime_reconcile_26_agents "$max_reconcile_us" 5000 us runtime-reconcile-runs.tsv
+
+max_projection_us=0
+for idx in $(seq 1 5); do
+  file="$OUT_DIR/projection-divergence-${idx}.json"
+  op_get /operator/runtime-health > "$file"
+  elapsed="$(json_field "$file" snapshot_build_elapsed_us)"
+  printf '%s\t%s\n' "$idx" "$elapsed" >> "$OUT_DIR/projection-divergence-runs.tsv"
+  if [ "$elapsed" -gt "$max_projection_us" ]; then
+    max_projection_us="$elapsed"
+  fi
+done
+record_result projection_divergence_detection "$max_projection_us" 5000 us projection-divergence-runs.tsv
+
+flood_file="$OUT_DIR/analysis-flood.json"
+op_post /operator/runtime/analysis-flood-test '{"count":10000}' > "$flood_file"
+flood_per_request_ns="$(json_field "$flood_file" enqueue_per_request_ns)"
+record_result analysis_flood_cap "$flood_per_request_ns" 250000 ns_per_request analysis-flood.json
+
+candidate_id="$(python3 - "$OUT_DIR/health-pre.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    h = json.load(handle)
+for agent in h["agents"]:
+    if agent["runtime_present"] and agent["tracked_pid_alive"] and agent["cgroup_live_pid_count"] > 0:
+        print(agent["agent_id"])
+        break
+else:
+    raise SystemExit("no healthy benchmark candidate")
+PY
+)"
+stall_file="$OUT_DIR/stall-restart-direct.json"
+op_post /operator/runtime/stall-restart-test "{\"agent_id\":${candidate_id},\"mode\":\"direct\",\"stall_secs\":1}" > "$stall_file"
+stall_ns="$(json_field "$stall_file" bookkeeping_elapsed_ns)"
+record_result stall_recovery_bookkeeping "$stall_ns" 50000 ns stall-restart-direct.json
+wait_healthy post-stall
+
+capture_sidecars after
+
+journal_file="$OUT_DIR/daemon-journal-panic-drift.txt"
+journalctl -u sentinel-daemon --since "$START_TIME" --no-pager \
+  | grep -Ei 'panicked|thread .*panicked|projection drift detected|runtime drift|projection_drift_detected=true' \
+  > "$journal_file" || true
+if [ -s "$journal_file" ]; then
+  echo "BENCH_FAIL daemon journal contains panic/drift markers: $journal_file" >&2
+  exit 1
+fi
+
+{
+  echo "BENCH_PASS out_dir=$OUT_DIR"
+  cat "$OUT_DIR/bench-results.tsv"
+  echo "sidecars:"
+  ls -1 "$OUT_DIR"/free-*.txt "$OUT_DIR"/vmstat-*.txt "$OUT_DIR"/iostat-*.txt "$OUT_DIR"/ps-*.txt
+} | tee "$OUT_DIR/summary.txt"

--- a/scripts/vm-issue-279-soak.sh
+++ b/scripts/vm-issue-279-soak.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+duration="${ISSUE279_SOAK_SECONDS:-1800}"
+interval="${ISSUE279_POLL_INTERVAL:-60}"
+out_dir="${ISSUE279_OUT_DIR:-/tmp/issue279-soak-$(date -u +%Y%m%dT%H%M%SZ)}"
+start_epoch="$(date +%s)"
+end_epoch="$((start_epoch + duration))"
+start_since="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+
+mkdir -p "$out_dir"
+
+opcurl() {
+  if [ -x /tmp/opcurl ]; then
+    /tmp/opcurl "$@"
+  else
+    curl -s "$@"
+  fi
+}
+
+read_health() {
+  opcurl http://127.0.0.1:8084/operator/runtime-health
+}
+
+health_line() {
+  python3 -c 'import sys,json
+h=json.load(sys.stdin)
+print("{expected}\t{runtime}\t{projection}\t{cgroups}\t{stale}\t{orphans}\t{zombies}\t{drift}\t{depth}\t{dropped}\t{coalesced}".format(
+    expected=h["expected_active_agents"],
+    runtime=h["runtime_agents"],
+    projection=h["projection_agents"],
+    cgroups=h["live_cgroup_dirs"],
+    stale=h["stale_runtime_entries"],
+    orphans=h["orphan_cgroups"],
+    zombies=h["zombie_tracked_pids"],
+    drift=h["projection_drift_detected"],
+    depth=h["analysis_queue_depth"],
+    dropped=h["analysis_queue_dropped_total"],
+    coalesced=h["analysis_queue_coalesced_total"],
+))'
+}
+
+api_agents() {
+  curl -s http://127.0.0.1:8000/api/agents \
+    | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'
+}
+
+projection_active_agents() {
+  sqlite3 /opt/sentinel/data/projection.db \
+    "SELECT COUNT(*) FROM agent_live_view WHERE status='active';"
+}
+
+cgroup_dirs() {
+  find /sys/fs/cgroup/sentinel -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l
+}
+
+cgroup_live_dirs() {
+  python3 - <<'PY'
+import os
+root = "/sys/fs/cgroup/sentinel"
+count = 0
+try:
+    names = os.listdir(root)
+except FileNotFoundError:
+    names = []
+for name in names:
+    if not os.path.isdir(os.path.join(root, name)):
+        continue
+    try:
+        if open(os.path.join(root, name, "cgroup.procs")).read().strip():
+            count += 1
+    except FileNotFoundError:
+        pass
+print(count)
+PY
+}
+
+system_line() {
+  local daemon_pid projection_pid
+  daemon_pid="$(pgrep -x sentinel-daemon | head -1 || true)"
+  projection_pid="$(pgrep -f '/opt/sentinel/bin/sentinel-projection' | head -1 || true)"
+  printf "%s\t" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [ -n "$daemon_pid" ]; then
+    ps -o pid=,rss=,%cpu=,comm= -p "$daemon_pid" | awk '{printf "daemon_pid=%s\tdaemon_rss_kb=%s\tdaemon_cpu=%s\t", $1, $2, $3}'
+  else
+    printf "daemon_pid=missing\tdaemon_rss_kb=0\tdaemon_cpu=0\t"
+  fi
+  if [ -n "$projection_pid" ]; then
+    ps -o pid=,rss=,%cpu=,comm= -p "$projection_pid" | awk '{printf "projection_pid=%s\tprojection_rss_kb=%s\tprojection_cpu=%s\t", $1, $2, $3}'
+  else
+    printf "projection_pid=missing\tprojection_rss_kb=0\tprojection_cpu=0\t"
+  fi
+  df -k /opt/sentinel/data | awk 'NR==2 {printf "data_used_kb=%s\tdata_avail_kb=%s\n", $3, $4}'
+}
+
+{
+  echo "# started_at=$start_since"
+  echo "# duration_seconds=$duration"
+  echo "# interval_seconds=$interval"
+  echo -e "sample\ttimestamp\texpected\truntime\tprojection\tcgroups\tstale\torphans\tzombies\tdrift\tqueue_depth\tdropped\tcoalesced\tapi_agents\tprojection_db_active\tcgroup_dirs\tcgroup_live_dirs"
+} >"$out_dir/health.tsv"
+echo -e "timestamp\tdaemon_pid\tdaemon_rss_kb\tdaemon_cpu\tprojection_pid\tprojection_rss_kb\tprojection_cpu\tdata_used_kb\tdata_avail_kb" >"$out_dir/system.tsv"
+
+sample=0
+while [ "$(date +%s)" -le "$end_epoch" ]; do
+  sample=$((sample + 1))
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  health_json="$(read_health)"
+  printf "%s" "$health_json" >"$out_dir/health-$sample.json"
+  line="$(printf "%s" "$health_json" | health_line)"
+  api_count="$(api_agents)"
+  projection_count="$(projection_active_agents)"
+  cgroup_count="$(cgroup_dirs)"
+  live_cgroup_count="$(cgroup_live_dirs)"
+  echo -e "$sample\t$timestamp\t$line\t$api_count\t$projection_count\t$cgroup_count\t$live_cgroup_count" | tee -a "$out_dir/health.tsv"
+  system_line | tee -a "$out_dir/system.tsv" >/dev/null
+  sleep "$interval"
+done
+
+final_json="$(read_health)"
+printf "%s" "$final_json" >"$out_dir/final-health.json"
+api_final="$(api_agents)"
+projection_final="$(projection_active_agents)"
+cgroup_final="$(cgroup_dirs)"
+cgroup_live_final="$(cgroup_live_dirs)"
+
+journalctl -u sentinel-daemon --since "$start_since" --no-pager >"$out_dir/daemon-journal.log"
+journalctl -u sentinel-projection --since "$start_since" --no-pager >"$out_dir/projection-journal.log"
+
+printf "%s" "$final_json" | python3 -c 'import sys,json
+h=json.load(sys.stdin)
+ok = (
+    h["expected_active_agents"] == 26
+    and h["runtime_agents"] == 26
+    and h["projection_agents"] == 26
+    and h["live_cgroup_dirs"] == 26
+    and h["stale_runtime_entries"] == 0
+    and h["orphan_cgroups"] == 0
+    and h["zombie_tracked_pids"] == 0
+    and h["projection_drift_detected"] is False
+)
+print("final_health={}/{}/{}/{} stale={} orphans={} zombies={} drift={}".format(
+    h["expected_active_agents"],
+    h["runtime_agents"],
+    h["projection_agents"],
+    h["live_cgroup_dirs"],
+    h["stale_runtime_entries"],
+    h["orphan_cgroups"],
+    h["zombie_tracked_pids"],
+    h["projection_drift_detected"],
+))
+raise SystemExit(0 if ok else 1)'
+
+test "$api_final" = "26"
+test "$projection_final" = "26"
+test "$cgroup_final" = "26"
+test "$cgroup_live_final" = "26"
+
+if grep -Ei 'panic|drift' "$out_dir/daemon-journal.log" >/dev/null; then
+  echo "daemon_journal_panic_or_drift=FAIL"
+  grep -Ei 'panic|drift' "$out_dir/daemon-journal.log"
+  exit 1
+fi
+
+echo "api_agents=$api_final"
+echo "projection_db_active=$projection_final"
+echo "cgroup_dirs=$cgroup_final"
+echo "cgroup_live_dirs=$cgroup_live_final"
+echo "daemon_journal_panic_or_drift=0"
+echo "SOAK_PASS out_dir=$out_dir"

--- a/services/sentinel-daemon/Cargo.toml
+++ b/services/sentinel-daemon/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 sentinel-common = { path = "../../crates/sentinel-common" }
 sentinel-ecs = { path = "../../crates/sentinel-ecs" }
+sentinel-projection = { path = "../../crates/sentinel-projection" }
 sentinel-runtime = { path = "../../crates/sentinel-runtime" }
 sentinel-zenoh = { path = "../../crates/sentinel-zenoh" }
 sentinel-limbo = { path = "../../crates/sentinel-limbo" }

--- a/services/sentinel-daemon/src/config.rs
+++ b/services/sentinel-daemon/src/config.rs
@@ -484,6 +484,10 @@ pub struct PlatformControlplaneConfig {
     pub llm_max_context_events: usize,
     #[serde(default = "default_pcp_llm_max_failed_interventions")]
     pub llm_max_failed_interventions: usize,
+    #[serde(default = "default_pcp_llm_trigger_queue_capacity")]
+    pub llm_trigger_queue_capacity: usize,
+    #[serde(default = "default_pcp_llm_analysis_channel_capacity")]
+    pub llm_analysis_channel_capacity: usize,
 }
 
 fn default_pcp_enabled() -> bool {
@@ -559,6 +563,12 @@ fn default_pcp_llm_max_context_events() -> usize {
 fn default_pcp_llm_max_failed_interventions() -> usize {
     3
 }
+fn default_pcp_llm_trigger_queue_capacity() -> usize {
+    16
+}
+fn default_pcp_llm_analysis_channel_capacity() -> usize {
+    16
+}
 
 impl Default for PlatformControlplaneConfig {
     fn default() -> Self {
@@ -586,6 +596,8 @@ impl Default for PlatformControlplaneConfig {
             llm_prompt_template: default_pcp_llm_prompt_template(),
             llm_max_context_events: default_pcp_llm_max_context_events(),
             llm_max_failed_interventions: default_pcp_llm_max_failed_interventions(),
+            llm_trigger_queue_capacity: default_pcp_llm_trigger_queue_capacity(),
+            llm_analysis_channel_capacity: default_pcp_llm_analysis_channel_capacity(),
         }
     }
 }
@@ -879,6 +891,8 @@ llm_gateway_timeout_ms = 45000
 llm_prompt_template = "custom-template"
 llm_max_context_events = 23
 llm_max_failed_interventions = 5
+llm_trigger_queue_capacity = 7
+llm_analysis_channel_capacity = 11
 "#;
         let file: DaemonConfigFile = toml::from_str(toml_str).unwrap();
         let cfg = file.daemon.platform_controlplane;
@@ -904,5 +918,7 @@ llm_max_failed_interventions = 5
         assert_eq!(cfg.llm_prompt_template, "custom-template");
         assert_eq!(cfg.llm_max_context_events, 23);
         assert_eq!(cfg.llm_max_failed_interventions, 5);
+        assert_eq!(cfg.llm_trigger_queue_capacity, 7);
+        assert_eq!(cfg.llm_analysis_channel_capacity, 11);
     }
 }

--- a/services/sentinel-daemon/src/lib.rs
+++ b/services/sentinel-daemon/src/lib.rs
@@ -18,6 +18,7 @@ pub mod orchestrator;
 pub mod platform_controlplane;
 pub mod query_responder;
 pub mod resource_manager;
+pub mod runtime_control;
 pub mod runtime_health;
 pub mod service_health;
 pub mod shift;

--- a/services/sentinel-daemon/src/lib.rs
+++ b/services/sentinel-daemon/src/lib.rs
@@ -18,6 +18,7 @@ pub mod orchestrator;
 pub mod platform_controlplane;
 pub mod query_responder;
 pub mod resource_manager;
+pub mod runtime_health;
 pub mod service_health;
 pub mod shift;
 pub mod signal;

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -2393,6 +2393,7 @@ mod tests {
                     last_repair_error: None,
                     repair_last_status: Some("drift_detected".to_string()),
                     operator_auth_required: secret.is_some(),
+                    snapshot_build_elapsed_us: 0,
                     agents: vec![crate::runtime_health::RuntimeHealthAgentSnapshot {
                         agent_id: 7,
                         aggregate_id: "AGENT-07".to_string(),
@@ -2822,6 +2823,7 @@ mod tests {
                         repaired_agents: vec!["Test Agent".to_string()],
                         blocked_agents: Vec::new(),
                         errors: Vec::new(),
+                        elapsed_us: 0,
                     })
                     .unwrap();
             }
@@ -2872,6 +2874,8 @@ mod tests {
                         queue_depth: 17,
                         dropped_total: 9_983,
                         coalesced_total: 9_999,
+                        enqueue_elapsed_us: 0,
+                        enqueue_per_request_ns: 0,
                         note: "bounded queues exercised".to_string(),
                     })
                     .unwrap();
@@ -2993,6 +2997,7 @@ mod tests {
                         pid_after: Some(5252),
                         runtime_present_after: true,
                         security_runtime_present_after: true,
+                        bookkeeping_elapsed_ns: 0,
                         note: "fast_path_restart_executed_without_shift_wait".to_string(),
                     })
                     .unwrap();

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -32,8 +32,9 @@ use crate::platform_controlplane::{
     PlatformTriggerTestCommand,
 };
 use crate::runtime_control::{
-    RuntimeControlCommand, RuntimeReconcileRequest, RuntimeReconcileResponse,
-    RuntimeStallRestartTestRequest, RuntimeStallRestartTestResponse,
+    RuntimeControlCommand, RuntimePanicTestRequest, RuntimePanicTestResponse,
+    RuntimeReconcileRequest, RuntimeReconcileResponse, RuntimeStallRestartTestRequest,
+    RuntimeStallRestartTestResponse,
 };
 
 const OPERATOR_CHAOS_PATH: &str = "/operator/chaos";
@@ -52,6 +53,7 @@ const OPERATOR_PLATFORM_ANALYSIS_TEST_PATH: &str = "/operator/platform-analysis-
 const OPERATOR_PLATFORM_STATE_PATH: &str = "/operator/platform-state";
 const OPERATOR_RUNTIME_HEALTH_PATH: &str = "/operator/runtime-health";
 const OPERATOR_RUNTIME_RECONCILE_PATH: &str = "/operator/runtime/reconcile";
+const OPERATOR_RUNTIME_PANIC_TEST_PATH: &str = "/operator/runtime/panic-test";
 const OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH: &str = "/operator/runtime/stall-restart-test";
 const OPERATOR_APICP_SNAPSHOT_PATH: &str = "/operator/apicp/snapshot";
 const OPERATOR_SECURITY_FS_TRASH_PATH: &str = "/operator/security/fs-trash";
@@ -714,6 +716,18 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Err(err) => err.to_response(),
             }
         }
+        OPERATOR_RUNTIME_PANIC_TEST_PATH => {
+            let payload: RuntimePanicTestRequest = match serde_json::from_slice(&request.body) {
+                Ok(payload) => payload,
+                Err(_) => {
+                    return ApiError::BadRequest("Request-JSON ungueltig").to_response();
+                }
+            };
+            match dispatch_runtime_panic_test(payload, state) {
+                Ok(response) => json_response(200, response),
+                Err(err) => err.to_response(),
+            }
+        }
         OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH => {
             let payload: RuntimeStallRestartTestRequest =
                 match serde_json::from_slice(&request.body) {
@@ -1120,6 +1134,31 @@ fn dispatch_runtime_reconcile(
     response_rx
         .recv_timeout(std::time::Duration::from_secs(10))
         .map_err(|_| ApiError::ServiceUnavailable("Runtime-Reconcile Timeout"))
+}
+
+fn dispatch_runtime_panic_test(
+    mut payload: RuntimePanicTestRequest,
+    state: &AppState,
+) -> std::result::Result<RuntimePanicTestResponse, ApiError> {
+    payload.worker = payload.worker.trim().to_ascii_lowercase();
+    if payload.worker.is_empty() {
+        return Err(ApiError::BadRequest("worker fehlt"));
+    }
+    if payload.worker != "service_health" {
+        return Err(ApiError::BadRequest("worker muss service_health sein"));
+    }
+
+    let (response_tx, response_rx) = mpsc::sync_channel(1);
+    state
+        .runtime_tx
+        .send(RuntimeControlCommand::PanicTest {
+            request: payload,
+            response_tx,
+        })
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Control-Channel nicht verfuegbar"))?;
+    response_rx
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Panic-Test Timeout"))
 }
 
 fn dispatch_runtime_stall_restart_test(
@@ -2748,6 +2787,9 @@ mod tests {
             RuntimeControlCommand::StallRestartTest { .. } => {
                 panic!("unerwartetes StallRestartTest-Kommando");
             }
+            RuntimeControlCommand::PanicTest { .. } => {
+                panic!("unerwartetes PanicTest-Kommando");
+            }
         });
         let response = handle_http_request(
             test_request(
@@ -2768,6 +2810,60 @@ mod tests {
         assert_eq!(payload.respawned_agents, 2);
         assert!(payload.projection_rebuild_requested);
         assert_eq!(payload.repair_last_status, "repaired");
+    }
+
+    #[test]
+    fn runtime_panic_test_is_forwarded_and_returns_response() {
+        let (state, _rx, _platform_rx, runtime_rx) = test_state(None);
+        let worker = std::thread::spawn(move || match runtime_rx.recv().unwrap() {
+            RuntimeControlCommand::PanicTest {
+                request,
+                response_tx,
+            } => {
+                assert_eq!(request.worker, "service_health");
+                response_tx
+                    .send(RuntimePanicTestResponse {
+                        accepted: true,
+                        worker: "service_health".to_string(),
+                        note: "panic-test dispatched".to_string(),
+                    })
+                    .unwrap();
+            }
+            other => panic!("unerwartetes Kommando: {other:?}"),
+        });
+
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_PANIC_TEST_PATH,
+                serde_json::json!({
+                    "worker": "service_health"
+                }),
+            ),
+            &state,
+        );
+
+        worker.join().unwrap();
+        assert_eq!(response.status, 200);
+        let payload: RuntimePanicTestResponse = serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.worker, "service_health");
+        assert_eq!(payload.note, "panic-test dispatched");
+    }
+
+    #[test]
+    fn runtime_panic_test_rejects_invalid_worker() {
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_PANIC_TEST_PATH,
+                serde_json::json!({
+                    "worker": "ecs_tick_loop"
+                }),
+            ),
+            &state,
+        );
+
+        assert_eq!(response.status, 400);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -31,7 +31,6 @@ use crate::platform_controlplane::{
     PlatformAnalysisCommand, PlatformControlCommand, PlatformStateSnapshot,
     PlatformTriggerTestCommand,
 };
-
 const OPERATOR_CHAOS_PATH: &str = "/operator/chaos";
 const OPERATOR_STIMULUS_PATH: &str = "/operator/stimulus";
 const OPERATOR_NIGHTRUN_PATH: &str = "/operator/nightrun";
@@ -46,6 +45,7 @@ const OPERATOR_PLATFORM_ANALYZE_PATH: &str = "/operator/platform-analyze";
 const OPERATOR_PLATFORM_TRIGGER_TEST_PATH: &str = "/operator/platform-trigger-test";
 const OPERATOR_PLATFORM_ANALYSIS_TEST_PATH: &str = "/operator/platform-analysis-test";
 const OPERATOR_PLATFORM_STATE_PATH: &str = "/operator/platform-state";
+const OPERATOR_RUNTIME_HEALTH_PATH: &str = "/operator/runtime-health";
 const OPERATOR_APICP_SNAPSHOT_PATH: &str = "/operator/apicp/snapshot";
 const OPERATOR_SECURITY_FS_TRASH_PATH: &str = "/operator/security/fs-trash";
 const OPERATOR_SECURITY_FS_TRASH_FIXTURE_PATH: &str = "/operator/security/fs-trash-fixture";
@@ -281,6 +281,7 @@ struct AppState {
     prune_tx: mpsc::Sender<i64>,
     state_store: Arc<StateStore>,
     platform_state: Arc<std::sync::RwLock<PlatformStateSnapshot>>,
+    runtime_health: crate::runtime_health::SharedRuntimeHealthState,
     security_runtime_state: SharedSecurityRuntimeState,
 }
 
@@ -367,6 +368,7 @@ pub async fn start_server(
     prune_tx: mpsc::Sender<i64>,
     state_store: Arc<sentinel_redb::StateStore>,
     platform_state: Arc<std::sync::RwLock<PlatformStateSnapshot>>,
+    runtime_health: crate::runtime_health::SharedRuntimeHealthState,
     security_runtime_state: SharedSecurityRuntimeState,
 ) -> AnyResult<tokio::task::JoinHandle<()>> {
     let listener = TcpListener::bind(&config.bind_addr)
@@ -388,6 +390,7 @@ pub async fn start_server(
         prune_tx,
         state_store,
         platform_state,
+        runtime_health,
         security_runtime_state,
     };
 
@@ -431,7 +434,7 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
 
     // GET-Endpoints ohne Auth (read-only)
     if request.method == "GET" {
-        if (path_only == OPERATOR_APICP_SNAPSHOT_PATH || is_security_path(path_only))
+        if is_protected_read_path(path_only)
             && !is_authorized(&request.headers, state.shared_secret.as_deref())
         {
             return ApiError::Unauthorized.to_response();
@@ -464,6 +467,12 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Ok(snapshot) => json_response(200, snapshot.clone()),
                 Err(_) => {
                     ApiError::ServiceUnavailable("Platform-State nicht verfuegbar").to_response()
+                }
+            },
+            OPERATOR_RUNTIME_HEALTH_PATH => match state.runtime_health.read() {
+                Ok(snapshot) => json_response(200, snapshot.clone()),
+                Err(_) => {
+                    ApiError::ServiceUnavailable("Runtime-Health nicht verfuegbar").to_response()
                 }
             },
             OPERATOR_SECURITY_FS_TRASH_PATH => match inspect_fs_trash(query.get("hash"), state) {
@@ -1083,6 +1092,12 @@ fn parse_query_params(path: &str) -> HashMap<String, String> {
 
 fn is_security_path(path: &str) -> bool {
     path.starts_with("/operator/security/")
+}
+
+fn is_protected_read_path(path: &str) -> bool {
+    path == OPERATOR_APICP_SNAPSHOT_PATH
+        || path == OPERATOR_RUNTIME_HEALTH_PATH
+        || is_security_path(path)
 }
 
 fn open_fs_layer(state: &AppState) -> std::result::Result<Arc<LayerManager>, ApiError> {
@@ -2119,6 +2134,7 @@ fn json_response<T: Serialize>(status: u16, payload: T) -> HttpResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime_health::RuntimeHealthSnapshot;
     use sentinel_redb::{ApiCpPatternSnapshot, StateStore};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::oneshot;
@@ -2188,6 +2204,50 @@ mod tests {
                     current_profile: "normal".to_string(),
                 }],
                 ..PlatformStateSnapshot::default()
+            })),
+            runtime_health: Arc::new(std::sync::RwLock::new(RuntimeHealthSnapshot {
+                current_shift: 1,
+                expected_active_agents: 26,
+                runtime_agents: 3,
+                projection_agents: 2,
+                security_runtime_entries: 1,
+                sandbox_handles: 1,
+                tracked_processes: 1,
+                live_cgroup_dirs: 1,
+                stale_runtime_entries: 2,
+                orphan_cgroups: 1,
+                zombie_tracked_pids: 0,
+                worker_states: std::collections::BTreeMap::from([(
+                    "service_health".to_string(),
+                    crate::runtime_health::RuntimeWorkerState {
+                        running: true,
+                        restart_count: 0,
+                        last_error: None,
+                        thread_name: "service-health-checker".to_string(),
+                    },
+                )]),
+                analysis_queue_depth: 0,
+                analysis_queue_dropped_total: 0,
+                analysis_queue_coalesced_total: 0,
+                reconcile_runs_total: 0,
+                reconcile_repairs_total: 0,
+                respawn_failures: 0,
+                last_repair_error: None,
+                repair_last_status: Some("drift_detected".to_string()),
+                operator_auth_required: secret.is_some(),
+                agents: vec![crate::runtime_health::RuntimeHealthAgentSnapshot {
+                    agent_id: 7,
+                    aggregate_id: "AGENT-07".to_string(),
+                    name: "Test Agent".to_string(),
+                    runtime_present: true,
+                    projection_present: false,
+                    tracked_pid: Some(4242),
+                    tracked_pid_alive: false,
+                    tracked_pid_state: Some("Z".to_string()),
+                    cgroup_live_pid_count: 0,
+                    security_runtime_present: true,
+                    last_repair_status: Some("stale".to_string()),
+                }],
             })),
             security_runtime_state,
         };
@@ -2527,6 +2587,44 @@ mod tests {
         assert_eq!(payload.cycle_interval_ticks, 60);
         assert_eq!(payload.agents.len(), 1);
         assert_eq!(payload.agents[0].aggregate_id, "AGENT-07");
+    }
+
+    #[test]
+    fn runtime_health_endpoint_returns_snapshot() {
+        let (state, _rx, _platform_rx) = test_state(None);
+        let response = handle_http_request(
+            HttpRequest {
+                method: "GET".to_string(),
+                path: OPERATOR_RUNTIME_HEALTH_PATH.to_string(),
+                headers: HashMap::new(),
+                body: Vec::new(),
+            },
+            &state,
+        );
+
+        assert_eq!(response.status, 200);
+        let payload: RuntimeHealthSnapshot = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(payload.current_shift, 1);
+        assert_eq!(payload.expected_active_agents, 26);
+        assert_eq!(payload.stale_runtime_entries, 2);
+        assert_eq!(payload.agents.len(), 1);
+        assert_eq!(payload.agents[0].agent_id, 7);
+    }
+
+    #[test]
+    fn runtime_health_endpoint_requires_auth_when_secret_is_set() {
+        let (state, _rx, _platform_rx) = test_state(Some("secret"));
+        let response = handle_http_request(
+            HttpRequest {
+                method: "GET".to_string(),
+                path: OPERATOR_RUNTIME_HEALTH_PATH.to_string(),
+                headers: HashMap::new(),
+                body: Vec::new(),
+            },
+            &state,
+        );
+
+        assert_eq!(response.status, 401);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -32,9 +32,9 @@ use crate::platform_controlplane::{
     PlatformTriggerTestCommand,
 };
 use crate::runtime_control::{
-    RuntimeControlCommand, RuntimePanicTestRequest, RuntimePanicTestResponse,
-    RuntimeReconcileRequest, RuntimeReconcileResponse, RuntimeStallRestartTestRequest,
-    RuntimeStallRestartTestResponse,
+    RuntimeAnalysisFloodTestRequest, RuntimeAnalysisFloodTestResponse, RuntimeControlCommand,
+    RuntimePanicTestRequest, RuntimePanicTestResponse, RuntimeReconcileRequest,
+    RuntimeReconcileResponse, RuntimeStallRestartTestRequest, RuntimeStallRestartTestResponse,
 };
 
 const OPERATOR_CHAOS_PATH: &str = "/operator/chaos";
@@ -53,6 +53,7 @@ const OPERATOR_PLATFORM_ANALYSIS_TEST_PATH: &str = "/operator/platform-analysis-
 const OPERATOR_PLATFORM_STATE_PATH: &str = "/operator/platform-state";
 const OPERATOR_RUNTIME_HEALTH_PATH: &str = "/operator/runtime-health";
 const OPERATOR_RUNTIME_RECONCILE_PATH: &str = "/operator/runtime/reconcile";
+const OPERATOR_RUNTIME_ANALYSIS_FLOOD_TEST_PATH: &str = "/operator/runtime/analysis-flood-test";
 const OPERATOR_RUNTIME_PANIC_TEST_PATH: &str = "/operator/runtime/panic-test";
 const OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH: &str = "/operator/runtime/stall-restart-test";
 const OPERATOR_APICP_SNAPSHOT_PATH: &str = "/operator/apicp/snapshot";
@@ -716,6 +717,19 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Err(err) => err.to_response(),
             }
         }
+        OPERATOR_RUNTIME_ANALYSIS_FLOOD_TEST_PATH => {
+            let payload: RuntimeAnalysisFloodTestRequest =
+                match serde_json::from_slice(&request.body) {
+                    Ok(payload) => payload,
+                    Err(_) => {
+                        return ApiError::BadRequest("Request-JSON ungueltig").to_response();
+                    }
+                };
+            match dispatch_runtime_analysis_flood_test(payload, state) {
+                Ok(response) => json_response(200, response),
+                Err(err) => err.to_response(),
+            }
+        }
         OPERATOR_RUNTIME_PANIC_TEST_PATH => {
             let payload: RuntimePanicTestRequest = match serde_json::from_slice(&request.body) {
                 Ok(payload) => payload,
@@ -1134,6 +1148,27 @@ fn dispatch_runtime_reconcile(
     response_rx
         .recv_timeout(std::time::Duration::from_secs(10))
         .map_err(|_| ApiError::ServiceUnavailable("Runtime-Reconcile Timeout"))
+}
+
+fn dispatch_runtime_analysis_flood_test(
+    payload: RuntimeAnalysisFloodTestRequest,
+    state: &AppState,
+) -> std::result::Result<RuntimeAnalysisFloodTestResponse, ApiError> {
+    if payload.count == 0 {
+        return Err(ApiError::BadRequest("count muss > 0 sein"));
+    }
+
+    let (response_tx, response_rx) = mpsc::sync_channel(1);
+    state
+        .runtime_tx
+        .send(RuntimeControlCommand::AnalysisFloodTest {
+            request: payload,
+            response_tx,
+        })
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Control-Channel nicht verfuegbar"))?;
+    response_rx
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Analysis-Flood-Test Timeout"))
 }
 
 fn dispatch_runtime_panic_test(
@@ -2787,6 +2822,9 @@ mod tests {
             RuntimeControlCommand::StallRestartTest { .. } => {
                 panic!("unerwartetes StallRestartTest-Kommando");
             }
+            RuntimeControlCommand::AnalysisFloodTest { .. } => {
+                panic!("unerwartetes AnalysisFloodTest-Kommando");
+            }
             RuntimeControlCommand::PanicTest { .. } => {
                 panic!("unerwartetes PanicTest-Kommando");
             }
@@ -2810,6 +2848,66 @@ mod tests {
         assert_eq!(payload.respawned_agents, 2);
         assert!(payload.projection_rebuild_requested);
         assert_eq!(payload.repair_last_status, "repaired");
+    }
+
+    #[test]
+    fn runtime_analysis_flood_test_is_forwarded_and_returns_response() {
+        let (state, _rx, _platform_rx, runtime_rx) = test_state(None);
+        let worker = std::thread::spawn(move || match runtime_rx.recv().unwrap() {
+            RuntimeControlCommand::AnalysisFloodTest {
+                request,
+                response_tx,
+            } => {
+                assert_eq!(request.count, 10_000);
+                response_tx
+                    .send(RuntimeAnalysisFloodTestResponse {
+                        accepted: true,
+                        requested: 10_000,
+                        queue_depth: 17,
+                        dropped_total: 9_983,
+                        coalesced_total: 9_999,
+                        note: "bounded queues exercised".to_string(),
+                    })
+                    .unwrap();
+            }
+            other => panic!("unerwartetes Kommando: {other:?}"),
+        });
+
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_ANALYSIS_FLOOD_TEST_PATH,
+                serde_json::json!({
+                    "count": 10000
+                }),
+            ),
+            &state,
+        );
+
+        worker.join().unwrap();
+        assert_eq!(response.status, 200);
+        let payload: RuntimeAnalysisFloodTestResponse =
+            serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.requested, 10_000);
+        assert_eq!(payload.queue_depth, 17);
+        assert_eq!(payload.dropped_total, 9_983);
+        assert_eq!(payload.coalesced_total, 9_999);
+    }
+
+    #[test]
+    fn runtime_analysis_flood_test_rejects_zero_count() {
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_ANALYSIS_FLOOD_TEST_PATH,
+                serde_json::json!({
+                    "count": 0
+                }),
+            ),
+            &state,
+        );
+
+        assert_eq!(response.status, 400);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -2373,6 +2373,8 @@ mod tests {
                     stale_runtime_entries: 2,
                     orphan_cgroups: 1,
                     zombie_tracked_pids: 0,
+                    projection_drift_detected: true,
+                    projection_drift_agents: 1,
                     worker_states: std::collections::BTreeMap::from([(
                         "service_health".to_string(),
                         crate::runtime_health::RuntimeWorkerState {
@@ -2810,6 +2812,10 @@ mod tests {
                         respawned_agents: 2,
                         respawn_skipped_backoff: 0,
                         respawn_blocked_agents: 0,
+                        projection_drift_before: true,
+                        projection_drift_after: false,
+                        projection_restart_attempted: false,
+                        projection_restart_succeeded: false,
                         projection_rebuild_requested: true,
                         respawn_failures_total: 0,
                         repair_last_status: "repaired".to_string(),

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -31,6 +31,10 @@ use crate::platform_controlplane::{
     PlatformAnalysisCommand, PlatformControlCommand, PlatformStateSnapshot,
     PlatformTriggerTestCommand,
 };
+use crate::runtime_control::{
+    RuntimeControlCommand, RuntimeReconcileRequest, RuntimeReconcileResponse,
+};
+
 const OPERATOR_CHAOS_PATH: &str = "/operator/chaos";
 const OPERATOR_STIMULUS_PATH: &str = "/operator/stimulus";
 const OPERATOR_NIGHTRUN_PATH: &str = "/operator/nightrun";
@@ -46,6 +50,7 @@ const OPERATOR_PLATFORM_TRIGGER_TEST_PATH: &str = "/operator/platform-trigger-te
 const OPERATOR_PLATFORM_ANALYSIS_TEST_PATH: &str = "/operator/platform-analysis-test";
 const OPERATOR_PLATFORM_STATE_PATH: &str = "/operator/platform-state";
 const OPERATOR_RUNTIME_HEALTH_PATH: &str = "/operator/runtime-health";
+const OPERATOR_RUNTIME_RECONCILE_PATH: &str = "/operator/runtime/reconcile";
 const OPERATOR_APICP_SNAPSHOT_PATH: &str = "/operator/apicp/snapshot";
 const OPERATOR_SECURITY_FS_TRASH_PATH: &str = "/operator/security/fs-trash";
 const OPERATOR_SECURITY_FS_TRASH_FIXTURE_PATH: &str = "/operator/security/fs-trash-fixture";
@@ -274,6 +279,7 @@ struct AppState {
     fs_layer: Option<Arc<LayerManager>>,
     command_tx: mpsc::Sender<OperatorCommand>,
     platform_tx: mpsc::Sender<PlatformControlCommand>,
+    runtime_tx: mpsc::Sender<RuntimeControlCommand>,
     nightrun_tx: mpsc::Sender<OperatorNightrunCommand>,
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
@@ -361,6 +367,7 @@ pub async fn start_server(
     allowed_rooms: Vec<String>,
     command_tx: mpsc::Sender<OperatorCommand>,
     platform_tx: mpsc::Sender<PlatformControlCommand>,
+    runtime_tx: mpsc::Sender<RuntimeControlCommand>,
     nightrun_tx: mpsc::Sender<OperatorNightrunCommand>,
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
@@ -383,6 +390,7 @@ pub async fn start_server(
         fs_layer,
         command_tx,
         platform_tx,
+        runtime_tx,
         nightrun_tx,
         snapshot_tx,
         restore_tx,
@@ -693,6 +701,14 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
             };
             match dispatch_platform_analysis_test(payload, state) {
                 Ok(response) => json_response(202, response),
+                Err(err) => err.to_response(),
+            }
+        }
+        OPERATOR_RUNTIME_RECONCILE_PATH => {
+            let payload: RuntimeReconcileRequest =
+                serde_json::from_slice(&request.body).unwrap_or_default();
+            match dispatch_runtime_reconcile(payload, state) {
+                Ok(response) => json_response(200, response),
                 Err(err) => err.to_response(),
             }
         }
@@ -1072,6 +1088,23 @@ fn dispatch_platform_analysis_test(
         accepted: true,
         message: "Platform-Analyse-Test eingeplant".to_string(),
     })
+}
+
+fn dispatch_runtime_reconcile(
+    payload: RuntimeReconcileRequest,
+    state: &AppState,
+) -> std::result::Result<RuntimeReconcileResponse, ApiError> {
+    let (response_tx, response_rx) = mpsc::sync_channel(1);
+    state
+        .runtime_tx
+        .send(RuntimeControlCommand::Reconcile {
+            request: payload,
+            response_tx,
+        })
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Control-Channel nicht verfuegbar"))?;
+    response_rx
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Reconcile Timeout"))
 }
 
 fn request_path(path: &str) -> &str {
@@ -2134,7 +2167,6 @@ fn json_response<T: Serialize>(status: u16, payload: T) -> HttpResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime_health::RuntimeHealthSnapshot;
     use sentinel_redb::{ApiCpPatternSnapshot, StateStore};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::oneshot;
@@ -2145,9 +2177,11 @@ mod tests {
         AppState,
         mpsc::Receiver<OperatorCommand>,
         mpsc::Receiver<PlatformControlCommand>,
+        mpsc::Receiver<RuntimeControlCommand>,
     ) {
         let (tx, rx) = mpsc::channel();
         let (platform_tx, platform_rx) = mpsc::channel();
+        let (runtime_tx, runtime_rx) = mpsc::channel();
         let (nightrun_tx, _nightrun_rx) = mpsc::channel();
         let dir = tempfile::tempdir().unwrap();
         let data_dir = dir.path().join("data");
@@ -2177,6 +2211,7 @@ mod tests {
             fs_layer: None,
             command_tx: tx,
             platform_tx,
+            runtime_tx,
             nightrun_tx,
             snapshot_tx: mpsc::channel().0,
             restore_tx: mpsc::channel().0,
@@ -2205,7 +2240,8 @@ mod tests {
                 }],
                 ..PlatformStateSnapshot::default()
             })),
-            runtime_health: Arc::new(std::sync::RwLock::new(RuntimeHealthSnapshot {
+            runtime_health: Arc::new(std::sync::RwLock::new(
+                crate::runtime_health::RuntimeHealthSnapshot {
                 current_shift: 1,
                 expected_active_agents: 26,
                 runtime_agents: 3,
@@ -2248,11 +2284,12 @@ mod tests {
                     security_runtime_present: true,
                     last_repair_status: Some("stale".to_string()),
                 }],
-            })),
+            },
+            )),
             security_runtime_state,
         };
         std::mem::forget(dir);
-        (state, rx, platform_rx)
+        (state, rx, platform_rx, runtime_rx)
     }
 
     fn test_request(path: &str, body: serde_json::Value) -> HttpRequest {
@@ -2266,7 +2303,7 @@ mod tests {
 
     #[test]
     fn valid_trigger_request_is_accepted_and_forwarded() {
-        let (state, rx, _platform_rx) = test_state(None);
+        let (state, rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_CHAOS_PATH,
@@ -2300,7 +2337,7 @@ mod tests {
 
     #[test]
     fn invalid_room_returns_not_found() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_CHAOS_PATH,
@@ -2317,7 +2354,7 @@ mod tests {
 
     #[test]
     fn missing_shared_secret_is_rejected() {
-        let (state, _rx, _platform_rx) = test_state(Some("topsecret"));
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(Some("topsecret"));
         let response = handle_http_request(
             test_request(
                 OPERATOR_CHAOS_PATH,
@@ -2334,7 +2371,7 @@ mod tests {
 
     #[test]
     fn valid_shared_secret_via_header_is_accepted() {
-        let (state, rx, _platform_rx) = test_state(Some("topsecret"));
+        let (state, rx, _platform_rx, _runtime_rx) = test_state(Some("topsecret"));
         let mut request = test_request(
             OPERATOR_CHAOS_PATH,
             serde_json::json!({
@@ -2361,7 +2398,7 @@ mod tests {
 
     #[test]
     fn valid_stimulus_request_is_accepted_and_forwarded() {
-        let (state, rx, _platform_rx) = test_state(None);
+        let (state, rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_STIMULUS_PATH,
@@ -2425,7 +2462,7 @@ mod tests {
 
     #[test]
     fn zero_delta_stimulus_is_rejected() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_STIMULUS_PATH,
@@ -2443,7 +2480,7 @@ mod tests {
 
     #[test]
     fn platform_analyze_is_forwarded_to_platform_channel() {
-        let (state, _rx, platform_rx) = test_state(None);
+        let (state, _rx, platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             HttpRequest {
                 method: "POST".to_string(),
@@ -2463,7 +2500,7 @@ mod tests {
 
     #[test]
     fn unresolved_trigger_test_requires_rule_and_target() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_PLATFORM_TRIGGER_TEST_PATH,
@@ -2480,7 +2517,7 @@ mod tests {
 
     #[test]
     fn platform_trigger_test_is_forwarded() {
-        let (state, _rx, platform_rx) = test_state(None);
+        let (state, _rx, platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_PLATFORM_TRIGGER_TEST_PATH,
@@ -2508,7 +2545,7 @@ mod tests {
 
     #[test]
     fn platform_analysis_test_is_forwarded() {
-        let (state, _rx, platform_rx) = test_state(None);
+        let (state, _rx, platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_PLATFORM_ANALYSIS_TEST_PATH,
@@ -2548,7 +2585,7 @@ mod tests {
 
     #[test]
     fn platform_analysis_test_rejects_missing_force_profile_parameters() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_PLATFORM_ANALYSIS_TEST_PATH,
@@ -2570,7 +2607,7 @@ mod tests {
 
     #[test]
     fn platform_state_endpoint_returns_snapshot() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             HttpRequest {
                 method: "GET".to_string(),
@@ -2591,7 +2628,7 @@ mod tests {
 
     #[test]
     fn runtime_health_endpoint_returns_snapshot() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             HttpRequest {
                 method: "GET".to_string(),
@@ -2603,7 +2640,8 @@ mod tests {
         );
 
         assert_eq!(response.status, 200);
-        let payload: RuntimeHealthSnapshot = serde_json::from_slice(&response.body).unwrap();
+        let payload: crate::runtime_health::RuntimeHealthSnapshot =
+            serde_json::from_slice(&response.body).unwrap();
         assert_eq!(payload.current_shift, 1);
         assert_eq!(payload.expected_active_agents, 26);
         assert_eq!(payload.stale_runtime_entries, 2);
@@ -2613,7 +2651,7 @@ mod tests {
 
     #[test]
     fn runtime_health_endpoint_requires_auth_when_secret_is_set() {
-        let (state, _rx, _platform_rx) = test_state(Some("secret"));
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(Some("secret"));
         let response = handle_http_request(
             HttpRequest {
                 method: "GET".to_string(),
@@ -2625,6 +2663,62 @@ mod tests {
         );
 
         assert_eq!(response.status, 401);
+    }
+
+    #[test]
+    fn runtime_reconcile_is_forwarded_and_returns_response() {
+        let (state, _rx, _platform_rx, runtime_rx) = test_state(None);
+        let worker = std::thread::spawn(move || match runtime_rx.recv().unwrap() {
+            RuntimeControlCommand::Reconcile {
+                request,
+                response_tx,
+            } => {
+                assert!(request.respawn_missing);
+                assert!(!request.dry_run);
+                response_tx
+                    .send(RuntimeReconcileResponse {
+                        accepted: true,
+                        dry_run: false,
+                        current_shift: 1,
+                        stale_agents_before: 2,
+                        stale_agents_after: 0,
+                        orphan_cgroups_before: 1,
+                        orphan_cgroups_after: 0,
+                        security_snapshots_removed: 1,
+                        unexpected_runtime_removed: 1,
+                        orphan_cgroups_removed: 1,
+                        respawned_agents: 2,
+                        respawn_skipped_backoff: 0,
+                        respawn_blocked_agents: 0,
+                        projection_rebuild_requested: true,
+                        respawn_failures_total: 0,
+                        repair_last_status: "repaired".to_string(),
+                        repaired_agents: vec!["Test Agent".to_string()],
+                        blocked_agents: Vec::new(),
+                        errors: Vec::new(),
+                    })
+                    .unwrap();
+            }
+        });
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_RECONCILE_PATH,
+                serde_json::json!({
+                    "dry_run": false,
+                    "projection_rebuild": true,
+                    "respawn_missing": true
+                }),
+            ),
+            &state,
+        );
+
+        worker.join().unwrap();
+        assert_eq!(response.status, 200);
+        let payload: RuntimeReconcileResponse = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(payload.current_shift, 1);
+        assert_eq!(payload.respawned_agents, 2);
+        assert!(payload.projection_rebuild_requested);
+        assert_eq!(payload.repair_last_status, "repaired");
     }
 
     #[test]
@@ -2641,7 +2735,7 @@ mod tests {
 
     #[test]
     fn persist_landlock_block_event_writes_security_event() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let event_id = persist_landlock_block_event(
             &state,
             "Test Agent",
@@ -2678,7 +2772,7 @@ mod tests {
 
     #[test]
     fn agent_runtime_state_endpoint_returns_snapshot() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             HttpRequest {
                 method: "GET".to_string(),
@@ -2699,7 +2793,7 @@ mod tests {
 
     #[test]
     fn fs_trash_fixture_and_inspect_roundtrip() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let fixture = handle_http_request(
             test_request(
                 OPERATOR_SECURITY_FS_TRASH_FIXTURE_PATH,
@@ -2736,7 +2830,7 @@ mod tests {
 
     #[test]
     fn security_get_requires_auth_when_configured() {
-        let (state, _rx, _platform_rx) = test_state(Some("topsecret"));
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(Some("topsecret"));
         let unauthorized = handle_http_request(
             HttpRequest {
                 method: "GET".to_string(),
@@ -2763,7 +2857,7 @@ mod tests {
 
     #[test]
     fn write_anomaly_test_requires_tracked_runtime() {
-        let (state, _rx, _platform_rx) = test_state(None);
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
         let response = handle_http_request(
             test_request(
                 OPERATOR_SECURITY_WRITE_ANOMALY_TEST_PATH,
@@ -2780,7 +2874,7 @@ mod tests {
 
     #[test]
     fn apicp_snapshot_roundtrip_requires_auth_when_configured() {
-        let (state, _rx, _platform_rx) = test_state(Some("topsecret"));
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(Some("topsecret"));
 
         let unauthorized = HttpRequest {
             method: "GET".to_string(),

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -33,6 +33,7 @@ use crate::platform_controlplane::{
 };
 use crate::runtime_control::{
     RuntimeControlCommand, RuntimeReconcileRequest, RuntimeReconcileResponse,
+    RuntimeStallRestartTestRequest, RuntimeStallRestartTestResponse,
 };
 
 const OPERATOR_CHAOS_PATH: &str = "/operator/chaos";
@@ -51,6 +52,7 @@ const OPERATOR_PLATFORM_ANALYSIS_TEST_PATH: &str = "/operator/platform-analysis-
 const OPERATOR_PLATFORM_STATE_PATH: &str = "/operator/platform-state";
 const OPERATOR_RUNTIME_HEALTH_PATH: &str = "/operator/runtime-health";
 const OPERATOR_RUNTIME_RECONCILE_PATH: &str = "/operator/runtime/reconcile";
+const OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH: &str = "/operator/runtime/stall-restart-test";
 const OPERATOR_APICP_SNAPSHOT_PATH: &str = "/operator/apicp/snapshot";
 const OPERATOR_SECURITY_FS_TRASH_PATH: &str = "/operator/security/fs-trash";
 const OPERATOR_SECURITY_FS_TRASH_FIXTURE_PATH: &str = "/operator/security/fs-trash-fixture";
@@ -712,6 +714,19 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Err(err) => err.to_response(),
             }
         }
+        OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH => {
+            let payload: RuntimeStallRestartTestRequest =
+                match serde_json::from_slice(&request.body) {
+                    Ok(payload) => payload,
+                    Err(_) => {
+                        return ApiError::BadRequest("Request-JSON ungueltig").to_response();
+                    }
+                };
+            match dispatch_runtime_stall_restart_test(payload, state) {
+                Ok(response) => json_response(200, response),
+                Err(err) => err.to_response(),
+            }
+        }
         OPERATOR_APICP_SNAPSHOT_PATH => {
             let payload: ApiCpSnapshot = match serde_json::from_slice(&request.body) {
                 Ok(p) => p,
@@ -1105,6 +1120,37 @@ fn dispatch_runtime_reconcile(
     response_rx
         .recv_timeout(std::time::Duration::from_secs(10))
         .map_err(|_| ApiError::ServiceUnavailable("Runtime-Reconcile Timeout"))
+}
+
+fn dispatch_runtime_stall_restart_test(
+    mut payload: RuntimeStallRestartTestRequest,
+    state: &AppState,
+) -> std::result::Result<RuntimeStallRestartTestResponse, ApiError> {
+    payload.mode = payload.mode.trim().to_ascii_lowercase();
+    if payload.agent_id == 0 {
+        return Err(ApiError::BadRequest("agent_id fehlt"));
+    }
+    if payload.mode.is_empty() {
+        return Err(ApiError::BadRequest("mode fehlt"));
+    }
+    if !matches!(payload.mode.as_str(), "sigstop" | "direct") {
+        return Err(ApiError::BadRequest("mode muss sigstop oder direct sein"));
+    }
+    if payload.stall_secs == 0 {
+        return Err(ApiError::BadRequest("stall_secs muss > 0 sein"));
+    }
+
+    let (response_tx, response_rx) = mpsc::sync_channel(1);
+    state
+        .runtime_tx
+        .send(RuntimeControlCommand::StallRestartTest {
+            request: payload,
+            response_tx,
+        })
+        .map_err(|_| ApiError::ServiceUnavailable("Runtime-Control-Channel nicht verfuegbar"))?;
+    response_rx
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .map_err(|_| ApiError::ServiceUnavailable("Stall-Restart-Test Timeout"))
 }
 
 fn request_path(path: &str) -> &str {
@@ -2242,49 +2288,49 @@ mod tests {
             })),
             runtime_health: Arc::new(std::sync::RwLock::new(
                 crate::runtime_health::RuntimeHealthSnapshot {
-                current_shift: 1,
-                expected_active_agents: 26,
-                runtime_agents: 3,
-                projection_agents: 2,
-                security_runtime_entries: 1,
-                sandbox_handles: 1,
-                tracked_processes: 1,
-                live_cgroup_dirs: 1,
-                stale_runtime_entries: 2,
-                orphan_cgroups: 1,
-                zombie_tracked_pids: 0,
-                worker_states: std::collections::BTreeMap::from([(
-                    "service_health".to_string(),
-                    crate::runtime_health::RuntimeWorkerState {
-                        running: true,
-                        restart_count: 0,
-                        last_error: None,
-                        thread_name: "service-health-checker".to_string(),
-                    },
-                )]),
-                analysis_queue_depth: 0,
-                analysis_queue_dropped_total: 0,
-                analysis_queue_coalesced_total: 0,
-                reconcile_runs_total: 0,
-                reconcile_repairs_total: 0,
-                respawn_failures: 0,
-                last_repair_error: None,
-                repair_last_status: Some("drift_detected".to_string()),
-                operator_auth_required: secret.is_some(),
-                agents: vec![crate::runtime_health::RuntimeHealthAgentSnapshot {
-                    agent_id: 7,
-                    aggregate_id: "AGENT-07".to_string(),
-                    name: "Test Agent".to_string(),
-                    runtime_present: true,
-                    projection_present: false,
-                    tracked_pid: Some(4242),
-                    tracked_pid_alive: false,
-                    tracked_pid_state: Some("Z".to_string()),
-                    cgroup_live_pid_count: 0,
-                    security_runtime_present: true,
-                    last_repair_status: Some("stale".to_string()),
-                }],
-            },
+                    current_shift: 1,
+                    expected_active_agents: 26,
+                    runtime_agents: 3,
+                    projection_agents: 2,
+                    security_runtime_entries: 1,
+                    sandbox_handles: 1,
+                    tracked_processes: 1,
+                    live_cgroup_dirs: 1,
+                    stale_runtime_entries: 2,
+                    orphan_cgroups: 1,
+                    zombie_tracked_pids: 0,
+                    worker_states: std::collections::BTreeMap::from([(
+                        "service_health".to_string(),
+                        crate::runtime_health::RuntimeWorkerState {
+                            running: true,
+                            restart_count: 0,
+                            last_error: None,
+                            thread_name: "service-health-checker".to_string(),
+                        },
+                    )]),
+                    analysis_queue_depth: 0,
+                    analysis_queue_dropped_total: 0,
+                    analysis_queue_coalesced_total: 0,
+                    reconcile_runs_total: 0,
+                    reconcile_repairs_total: 0,
+                    respawn_failures: 0,
+                    last_repair_error: None,
+                    repair_last_status: Some("drift_detected".to_string()),
+                    operator_auth_required: secret.is_some(),
+                    agents: vec![crate::runtime_health::RuntimeHealthAgentSnapshot {
+                        agent_id: 7,
+                        aggregate_id: "AGENT-07".to_string(),
+                        name: "Test Agent".to_string(),
+                        runtime_present: true,
+                        projection_present: false,
+                        tracked_pid: Some(4242),
+                        tracked_pid_alive: false,
+                        tracked_pid_state: Some("Z".to_string()),
+                        cgroup_live_pid_count: 0,
+                        security_runtime_present: true,
+                        last_repair_status: Some("stale".to_string()),
+                    }],
+                },
             )),
             security_runtime_state,
         };
@@ -2699,6 +2745,9 @@ mod tests {
                     })
                     .unwrap();
             }
+            RuntimeControlCommand::StallRestartTest { .. } => {
+                panic!("unerwartetes StallRestartTest-Kommando");
+            }
         });
         let response = handle_http_request(
             test_request(
@@ -2719,6 +2768,80 @@ mod tests {
         assert_eq!(payload.respawned_agents, 2);
         assert!(payload.projection_rebuild_requested);
         assert_eq!(payload.repair_last_status, "repaired");
+    }
+
+    #[test]
+    fn runtime_stall_restart_test_is_forwarded_and_returns_response() {
+        let (state, _rx, _platform_rx, runtime_rx) = test_state(None);
+        let worker = std::thread::spawn(move || match runtime_rx.recv().unwrap() {
+            RuntimeControlCommand::StallRestartTest {
+                request,
+                response_tx,
+            } => {
+                assert_eq!(request.agent_id, 7);
+                assert_eq!(request.mode, "sigstop");
+                assert_eq!(request.stall_secs, 35);
+                response_tx
+                    .send(RuntimeStallRestartTestResponse {
+                        accepted: true,
+                        agent_id: 7,
+                        aggregate_id: "AGENT-07".to_string(),
+                        agent_name: "Test Agent".to_string(),
+                        mode: "sigstop".to_string(),
+                        stall_secs: 35,
+                        pid_before: Some(4242),
+                        pid_after: Some(5252),
+                        runtime_present_after: true,
+                        security_runtime_present_after: true,
+                        note: "fast_path_restart_executed_without_shift_wait".to_string(),
+                    })
+                    .unwrap();
+            }
+            other => panic!("unerwartetes Kommando: {other:?}"),
+        });
+
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH,
+                serde_json::json!({
+                    "agent_id": 7,
+                    "mode": "sigstop",
+                    "stall_secs": 35
+                }),
+            ),
+            &state,
+        );
+
+        worker.join().unwrap();
+        assert_eq!(response.status, 200);
+        let payload: RuntimeStallRestartTestResponse =
+            serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.agent_id, 7);
+        assert_eq!(payload.pid_before, Some(4242));
+        assert_eq!(payload.pid_after, Some(5252));
+        assert_eq!(
+            payload.note,
+            "fast_path_restart_executed_without_shift_wait"
+        );
+    }
+
+    #[test]
+    fn runtime_stall_restart_test_rejects_invalid_mode() {
+        let (state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_RUNTIME_STALL_RESTART_TEST_PATH,
+                serde_json::json!({
+                    "agent_id": 7,
+                    "mode": "bogus",
+                    "stall_secs": 35
+                }),
+            ),
+            &state,
+        );
+
+        assert_eq!(response.status, 400);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1344,6 +1344,34 @@ fn emit_runtime_repair_blocked_event(
     }
 }
 
+fn emit_runtime_projection_despawn_event(
+    event_store: &EventStore,
+    agent_id: AgentId,
+    tick_count: u64,
+) -> bool {
+    let aggregate_id = format!("AGENT-{:02}", agent_id.0);
+    let payload = DomainEventPayload::AgentDespawned {
+        agent_id,
+        reason: "runtime_reconcile_projection_only".to_string(),
+    };
+    let event = DomainEvent::new(
+        payload.event_type_str(),
+        &aggregate_id,
+        &payload.to_json(),
+        &format!("runtime-reconcile-projection-{}", agent_id.0),
+        tick_count,
+    );
+    if let Err(error) = event_store.append_event(&event) {
+        warn!(
+            agent_id = %agent_id,
+            error = %error,
+            "Projection-only Despawn-Event konnte nicht persistiert werden"
+        );
+        return false;
+    }
+    true
+}
+
 fn remove_agent_runtime_fragments(
     ctx: &mut RuntimeReconcileContext<'_>,
     agent: &runtime_health::RuntimeHealthAgentSnapshot,
@@ -1371,19 +1399,15 @@ fn remove_agent_runtime_fragments(
     }
 
     if agent.cgroup_live_pid_count > 0 {
-        match sentinel_sandbox::cgroups::list_pids_in_cgroup(&agent.name) {
-            Ok(pids) => {
-                for pid in &pids {
-                    let _ = signal_pid(*pid, "TERM");
-                }
-                if !pids.is_empty() {
-                    stats.repairs += 1;
-                }
+        match sentinel_sandbox::cgroups::kill_cgroup_processes(&agent.name) {
+            Ok(killed) if killed > 0 => {
+                stats.repairs += 1;
             }
+            Ok(_) => {}
             Err(error) => warn!(
                 agent = %agent.name,
                 error = %error,
-                "Live-Cgroup-PIDs konnten nicht beendet werden"
+                "Live-Cgroup-PIDs konnten nicht hart beendet werden"
             ),
         }
     }
@@ -1411,7 +1435,10 @@ fn remove_agent_runtime_fragments(
     }
 
     let cgroup_path = sentinel_sandbox::cgroups::cgroup_path(&agent.name);
-    if std::path::Path::new(&cgroup_path).exists() && agent.cgroup_live_pid_count == 0 {
+    let cgroup_empty = sentinel_sandbox::cgroups::list_pids_in_cgroup(&agent.name)
+        .map(|pids| pids.is_empty())
+        .unwrap_or(false);
+    if std::path::Path::new(&cgroup_path).exists() && cgroup_empty {
         match sentinel_sandbox::cgroups::remove_cgroup(&agent.name) {
             Ok(()) => {
                 stats.orphan_cgroups_removed += 1;
@@ -1500,6 +1527,7 @@ fn run_runtime_reconcile(
             let expected_active = expected_ids.contains(&agent.agent_id);
             !expected_active
                 && (agent.runtime_present
+                    || agent.projection_present
                     || agent.security_runtime_present
                     || agent.tracked_pid_alive
                     || agent.cgroup_live_pid_count > 0)
@@ -1513,6 +1541,18 @@ fn run_runtime_reconcile(
                 repaired_agents.push(agent.name.clone());
                 agent_status_updates
                     .insert(agent.agent_id, "unexpected_runtime_cleaned".to_string());
+            }
+            if agent.projection_present
+                && emit_runtime_projection_despawn_event(
+                    ctx.event_store,
+                    AgentId(agent.agent_id),
+                    ctx.tick_count,
+                )
+            {
+                repair_ops_total += 1;
+                repaired_agents.push(agent.name.clone());
+                agent_status_updates
+                    .insert(agent.agent_id, "projection_despawned".to_string());
             }
         }
 
@@ -1541,7 +1581,23 @@ fn run_runtime_reconcile(
                             repair_ops_total += 1;
                         }
                     }
-                    Ok(_) => {}
+                    Ok(_) => {
+                        match sentinel_sandbox::cgroups::kill_cgroup_processes(&name) {
+                            Ok(killed) if killed > 0 => {
+                                repair_ops_total += 1;
+                                if sentinel_sandbox::cgroups::remove_cgroup(&name).is_ok() {
+                                    orphan_cgroups_removed += 1;
+                                    repair_ops_total += 1;
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(error) => warn!(
+                                cgroup = %name,
+                                error = %error,
+                                "Orphan-Cgroup-PIDs konnten nicht hart beendet werden"
+                            ),
+                        }
+                    }
                     Err(error) => warn!(
                         cgroup = %name,
                         error = %error,
@@ -4182,6 +4238,14 @@ mod tests {
         assert!(response.projection_rebuild_requested);
         assert_eq!(PROJECTION_RESTART_CALLS.load(Ordering::SeqCst), 0);
         assert!(rebuild_request_path.exists());
+        let events = event_store.get_events_since(0, 100).unwrap();
+        assert!(
+            events.iter().any(|event| {
+                event.event_type == "agent_despawned"
+                    && event.payload.contains("runtime_reconcile_projection_only")
+            }),
+            "Projection-only Ghost-Agent muss als Despawn-Event in den append-only Truth-Stream"
+        );
     }
 
     #[test]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1552,8 +1552,7 @@ fn run_runtime_reconcile(
             {
                 repair_ops_total += 1;
                 repaired_agents.push(agent.name.clone());
-                agent_status_updates
-                    .insert(agent.agent_id, "projection_despawned".to_string());
+                agent_status_updates.insert(agent.agent_id, "projection_despawned".to_string());
             }
         }
 
@@ -1582,23 +1581,21 @@ fn run_runtime_reconcile(
                             repair_ops_total += 1;
                         }
                     }
-                    Ok(_) => {
-                        match sentinel_sandbox::cgroups::kill_cgroup_processes(&name) {
-                            Ok(killed) if killed > 0 => {
+                    Ok(_) => match sentinel_sandbox::cgroups::kill_cgroup_processes(&name) {
+                        Ok(killed) if killed > 0 => {
+                            repair_ops_total += 1;
+                            if sentinel_sandbox::cgroups::remove_cgroup(&name).is_ok() {
+                                orphan_cgroups_removed += 1;
                                 repair_ops_total += 1;
-                                if sentinel_sandbox::cgroups::remove_cgroup(&name).is_ok() {
-                                    orphan_cgroups_removed += 1;
-                                    repair_ops_total += 1;
-                                }
                             }
-                            Ok(_) => {}
-                            Err(error) => warn!(
-                                cgroup = %name,
-                                error = %error,
-                                "Orphan-Cgroup-PIDs konnten nicht hart beendet werden"
-                            ),
                         }
-                    }
+                        Ok(_) => {}
+                        Err(error) => warn!(
+                            cgroup = %name,
+                            error = %error,
+                            "Orphan-Cgroup-PIDs konnten nicht hart beendet werden"
+                        ),
+                    },
                     Err(error) => warn!(
                         cgroup = %name,
                         error = %error,

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -122,30 +122,44 @@ fn signal_pid(pid: u32, signal: &str) -> Result<()> {
     }
 }
 
-fn mountpoint_is_active(path: &std::path::Path) -> bool {
+fn mountinfo_contains_mountpoint(mountinfo: &str, path: &std::path::Path) -> bool {
     let target = path
         .canonicalize()
         .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
         .into_owned();
+
+    mountinfo
+        .lines()
+        .filter_map(|line| {
+            let (left, right) = line.split_once(" - ")?;
+            let mountpoint = left.split_whitespace().nth(4)?;
+            let mut suffix = right.split_whitespace();
+            let fs_type = suffix.next()?;
+            let mount_source = suffix.next()?;
+            Some((mountpoint, fs_type, mount_source))
+        })
+        .any(|(mountpoint, fs_type, mount_source)| {
+            mountpoint == target && fs_type == "fuse" && mount_source == "sentinel-fs"
+        })
+}
+
+fn mountpoint_is_active(path: &std::path::Path) -> bool {
     std::fs::read_to_string("/proc/self/mountinfo")
         .ok()
-        .map(|mountinfo| {
-            mountinfo
-                .lines()
-                .filter_map(|line| {
-                    let (left, right) = line.split_once(" - ")?;
-                    let mountpoint = left.split_whitespace().nth(4)?;
-                    let mut suffix = right.split_whitespace();
-                    let fs_type = suffix.next()?;
-                    let mount_source = suffix.next()?;
-                    Some((mountpoint, fs_type, mount_source))
-                })
-                .any(|(mountpoint, fs_type, mount_source)| {
-                    mountpoint == target && fs_type == "fuse" && mount_source == "sentinel-fs"
-                })
-        })
+        .map(|mountinfo| mountinfo_contains_mountpoint(&mountinfo, path))
         .unwrap_or(false)
+}
+
+fn wait_for_fuse_mount(path: &std::path::Path, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if mountpoint_is_active(path) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    mountpoint_is_active(path)
 }
 
 fn suspend_pids(pids: &[u32], tracked_pid: Option<u32>) -> Result<()> {
@@ -460,50 +474,60 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
         };
 
     // -- sentinel-fs FUSE Mount (optional, konfigurierbar) --
-    #[cfg(feature = "fuse")]
-    if let Some(ref fs_mount) = config.fs_mount {
-        let mountpoint = std::path::PathBuf::from(fs_mount);
-        let fs_layer_clone = fs_layer
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| anyhow!("sentinel-fs Layer nicht initialisiert"))?;
-        if !mountpoint.exists() {
-            std::fs::create_dir_all(&mountpoint)
-                .with_context(|| format!("FUSE mountpoint erstellen: {}", mountpoint.display()))?;
-        }
-        info!(
-            mountpoint = %mountpoint.display(),
-            data_dir = %data_dir.display(),
-            "sentinel-fs FUSE-Mount starten"
-        );
-        let mountpoint_check = mountpoint.clone();
-        std::thread::spawn(move || {
-            if let Err(e) = sentinel_fs::fuse::start_fuse_layer(fs_layer_clone, &mountpoint) {
-                error!(error = %e, "sentinel-fs FUSE-Mount fehlgeschlagen");
+    let active_fs_mount: Option<String> = {
+        #[cfg(feature = "fuse")]
+        {
+            let mut active_mount = None;
+            if let Some(ref fs_mount) = config.fs_mount {
+                let mountpoint = std::path::PathBuf::from(fs_mount);
+                let fs_layer_clone = fs_layer
+                    .as_ref()
+                    .cloned()
+                    .ok_or_else(|| anyhow!("sentinel-fs Layer nicht initialisiert"))?;
+                if !mountpoint.exists() {
+                    std::fs::create_dir_all(&mountpoint).with_context(|| {
+                        format!("FUSE mountpoint erstellen: {}", mountpoint.display())
+                    })?;
+                }
+                info!(
+                    mountpoint = %mountpoint.display(),
+                    data_dir = %data_dir.display(),
+                    "sentinel-fs FUSE-Mount starten"
+                );
+                let mountpoint_check = mountpoint.clone();
+                std::thread::spawn(move || {
+                    if let Err(e) = sentinel_fs::fuse::start_fuse_layer(fs_layer_clone, &mountpoint)
+                    {
+                        error!(error = %e, "sentinel-fs FUSE-Mount fehlgeschlagen");
+                    }
+                });
+                if wait_for_fuse_mount(&mountpoint_check, Duration::from_secs(2)) {
+                    info!(mountpoint = %mountpoint_check.display(), "sentinel-fs FUSE-Mount aktiv");
+                    active_mount = Some(fs_mount.clone());
+                } else {
+                    warn!(
+                        mountpoint = %mountpoint_check.display(),
+                        "sentinel-fs FUSE-Mount nicht aktiv, fallback auf /ram/agents"
+                    );
+                }
             }
-        });
-        let mut mount_ready = false;
-        for _ in 0..20 {
-            if mountpoint_is_active(&mountpoint_check) {
-                mount_ready = true;
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(100));
+            active_mount
         }
-        if mount_ready {
-            info!(mountpoint = %mountpoint_check.display(), "sentinel-fs FUSE-Mount aktiv");
-        } else {
-            warn!(mountpoint = %mountpoint_check.display(), "sentinel-fs FUSE-Mount moeglicherweise nicht bereit");
+        #[cfg(not(feature = "fuse"))]
+        {
+            None
         }
-    }
+    };
 
     // -- Sandbox Enforcer (Landlock + cgroups v2 + bwrap) --
     let (mut sandbox, sandbox_warnings) = SandboxEnforcer::detect();
 
-    // Wenn sentinel-fs FUSE konfiguriert: bwrap nutzt FUSE-Mount statt /ram/agents/
-    if let Some(ref fs_mount) = config.fs_mount {
+    // Wenn sentinel-fs FUSE aktiv ist: bwrap nutzt FUSE-Mount statt /ram/agents/.
+    if let Some(ref fs_mount) = active_fs_mount {
         sandbox.set_fs_mount(fs_mount.clone());
         info!(fs_mount = %fs_mount, "Sandbox nutzt sentinel-fs FUSE-Mount fuer Agent-Homes");
+    } else if config.fs_mount.is_some() {
+        warn!("Konfiguriertes fs_mount deaktiviert, weil kein tragfaehiger FUSE-Mount aktiv ist");
     }
     for w in &sandbox_warnings {
         match w {
@@ -703,7 +727,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
             operator_api::start_server(
                 config.operator_api.clone(),
                 data_dir.to_path_buf(),
-                config.fs_mount.clone(),
+                active_fs_mount.clone(),
                 fs_layer.clone(),
                 operator_room_ids,
                 operator_tx.clone(),
@@ -752,7 +776,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let ecs_platform_state = Arc::clone(&platform_state);
     let ecs_runtime_health = Arc::clone(&runtime_health);
     let ecs_security_runtime_state = Arc::clone(&security_runtime_state);
-    let ecs_fs_mount = config.fs_mount.clone();
+    let ecs_fs_mount = active_fs_mount.clone();
     let ecs_projection_db_path = projection_db_path.clone();
     let ecs_handle = std::thread::Builder::new()
         .name("ecs-tick-loop".into())
@@ -3935,6 +3959,22 @@ mod tests {
         let collector = EbpfCollector::new(MonitoringMode::Userspace);
         let (tx, _rx) = tokio::sync::mpsc::channel(4);
         (collector, tx)
+    }
+
+    #[test]
+    fn mountinfo_contains_mountpoint_matches_exact_sentinel_fuse_mount() {
+        let mountinfo = "\
+35 23 0:33 / / rw,relatime - overlay overlay rw\n\
+92 35 0:56 / /opt/sentinel/fs rw,nosuid,nodev - fuse sentinel-fs rw,user_id=0\n";
+
+        assert!(mountinfo_contains_mountpoint(
+            mountinfo,
+            std::path::Path::new("/opt/sentinel/fs")
+        ));
+        assert!(!mountinfo_contains_mountpoint(
+            mountinfo,
+            std::path::Path::new("/opt/sentinel/fs-missing")
+        ));
     }
 
     fn test_controlplane(tmp: &tempfile::TempDir) -> ControlplaneKernel {

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -10,7 +10,7 @@
 //! └─────────────────────┘                       └──────────────────┘
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -41,6 +41,10 @@ use crate::controlplane::store::ControlplaneStore;
 use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
 use crate::operator_api;
+use crate::runtime_control::{
+    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand,
+    RuntimeReconcileRequest, RuntimeReconcileResponse,
+};
 use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
 use crate::signal::wait_for_shutdown;
@@ -582,6 +586,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let (operator_tx, operator_rx) = mpsc::channel::<OperatorCommand>();
     let (platform_tx, platform_rx) =
         mpsc::channel::<crate::platform_controlplane::PlatformControlCommand>();
+    let (runtime_tx, runtime_rx) = mpsc::channel::<RuntimeControlCommand>();
     let (nightrun_tx, nightrun_rx) = mpsc::channel::<sentinel_common::OperatorNightrunCommand>();
     let (snapshot_tx, snapshot_rx) = mpsc::channel::<sentinel_common::OperatorSnapshotCommand>();
     let (restore_tx, restore_rx) = mpsc::channel::<sentinel_common::OperatorRestoreCommand>();
@@ -702,6 +707,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 operator_room_ids,
                 operator_tx.clone(),
                 platform_tx.clone(),
+                runtime_tx.clone(),
                 nightrun_tx.clone(),
                 snapshot_tx.clone(),
                 restore_tx.clone(),
@@ -756,6 +762,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 action_rx,
                 operator_rx,
                 platform_rx,
+                runtime_rx,
                 perception_tx,
                 all_agents_clone,
                 current_shift,
@@ -1134,6 +1141,455 @@ fn publish_platform_state_snapshot(
     }
 }
 
+#[derive(Debug, Default)]
+struct RuntimeCleanupStats {
+    repairs: usize,
+    security_snapshots_removed: usize,
+    orphan_cgroups_removed: usize,
+}
+
+struct RuntimeReconcileContext<'a> {
+    tick_count: u64,
+    current_shift: u8,
+    all_agents: &'a [AgentConfig],
+    world: &'a mut bevy_ecs::prelude::World,
+    runtime_orch: &'a mut RuntimeOrchestrator,
+    sandbox: &'a SandboxEnforcer,
+    sandbox_handles: &'a mut HashMap<AgentId, SandboxHandle>,
+    ebpf_collector: &'a mut EbpfCollector,
+    agent_processes: &'a mut HashMap<AgentId, sentinel_sandbox::AgentProcess>,
+    agent_command: &'a [String],
+    security_runtime_state: &'a operator_api::SharedSecurityRuntimeState,
+    event_store: &'a Arc<EventStore>,
+    runtime_health: &'a crate::runtime_health::SharedRuntimeHealthState,
+    projection_db_path: &'a std::path::Path,
+    operator_auth_required: bool,
+    service_health_state: crate::service_health::ServiceHealthWorkerSnapshot,
+    fs_mount: Option<&'a str>,
+    data_dir: &'a std::path::Path,
+}
+
+fn runtime_agent_is_healthy(agent: &runtime_health::RuntimeHealthAgentSnapshot) -> bool {
+    agent.runtime_present
+        && agent.projection_present
+        && agent.security_runtime_present
+        && agent.tracked_pid_alive
+        && agent.cgroup_live_pid_count > 0
+}
+
+fn emit_runtime_repair_blocked_event(
+    event_store: &EventStore,
+    agent_id: AgentId,
+    description: &str,
+    tick_count: u64,
+) {
+    let aggregate_id = format!("AGENT-{:02}", agent_id.0);
+    let payload = DomainEventPayload::PlatformIntervention {
+        rule_name: "runtime_reconcile".to_string(),
+        target: aggregate_id.clone(),
+        action: "repair_blocked".to_string(),
+        description: description.to_string(),
+    };
+    let event = DomainEvent::new(
+        payload.event_type_str(),
+        &aggregate_id,
+        &payload.to_json(),
+        &format!("runtime-reconcile-{}", agent_id.0),
+        tick_count,
+    );
+    if let Err(error) = event_store.append_event(&event) {
+        warn!(
+            agent_id = %agent_id,
+            error = %error,
+            "Repair-Blocked-Event konnte nicht persistiert werden"
+        );
+    }
+}
+
+fn remove_agent_runtime_fragments(
+    ctx: &mut RuntimeReconcileContext<'_>,
+    agent: &runtime_health::RuntimeHealthAgentSnapshot,
+) -> RuntimeCleanupStats {
+    let agent_id = AgentId(agent.agent_id);
+    let mut stats = RuntimeCleanupStats::default();
+
+    if let Some(handle) = ctx.sandbox_handles.remove(&agent_id) {
+        if handle.cgroup_created {
+            if let Some(cid) = sentinel_sandbox::cgroup_id(&handle.agent_name) {
+                ctx.ebpf_collector.unregister_agent(cid);
+            }
+        }
+        if let Err(error) = ctx.sandbox.teardown_agent(&handle) {
+            warn!(agent_id = %agent_id, error = %error, "Sandbox-Teardown bei Runtime-Reconcile fehlgeschlagen");
+        } else {
+            stats.repairs += 1;
+        }
+    }
+
+    if let Some(proc_handle) = ctx.agent_processes.remove(&agent_id) {
+        let _ = signal_pid(proc_handle.pid, "TERM");
+        drop(proc_handle);
+        stats.repairs += 1;
+    }
+
+    if agent.cgroup_live_pid_count > 0 {
+        match sentinel_sandbox::cgroups::list_pids_in_cgroup(&agent.name) {
+            Ok(pids) => {
+                for pid in &pids {
+                    let _ = signal_pid(*pid, "TERM");
+                }
+                if !pids.is_empty() {
+                    stats.repairs += 1;
+                }
+            }
+            Err(error) => warn!(
+                agent = %agent.name,
+                error = %error,
+                "Live-Cgroup-PIDs konnten nicht beendet werden"
+            ),
+        }
+    }
+
+    let security_removed = ctx
+        .security_runtime_state
+        .write()
+        .map(|mut state| state.remove(&agent.agent_id).is_some())
+        .unwrap_or(false);
+    if security_removed {
+        stats.security_snapshots_removed += 1;
+        stats.repairs += 1;
+    }
+
+    if ctx.runtime_orch.agents().contains_key(&agent_id) {
+        if let Err(error) = ctx.runtime_orch.despawn_agent(agent_id) {
+            warn!(agent_id = %agent_id, error = %error, "Runtime-Despawn bei Reconcile fehlgeschlagen");
+        } else {
+            stats.repairs += 1;
+        }
+    }
+
+    if despawn_agent_from_world(ctx.world, agent_id) {
+        stats.repairs += 1;
+    }
+
+    let cgroup_path = sentinel_sandbox::cgroups::cgroup_path(&agent.name);
+    if std::path::Path::new(&cgroup_path).exists() && agent.cgroup_live_pid_count == 0 {
+        match sentinel_sandbox::cgroups::remove_cgroup(&agent.name) {
+            Ok(()) => {
+                stats.orphan_cgroups_removed += 1;
+                stats.repairs += 1;
+            }
+            Err(error) => warn!(
+                agent = %agent.name,
+                error = %error,
+                "Orphan-Cgroup konnte nicht entfernt werden"
+            ),
+        }
+    }
+
+    stats
+}
+
+fn run_runtime_reconcile(
+    ctx: &mut RuntimeReconcileContext<'_>,
+    request: RuntimeReconcileRequest,
+    respawn_backoff: &mut RespawnBackoffTracker,
+) -> RuntimeReconcileResponse {
+    let previous = ctx.runtime_health.read().ok().map(|snapshot| snapshot.clone());
+    let before = runtime_health::build_runtime_health_snapshot(
+        ctx.all_agents,
+        ctx.current_shift,
+        ctx.runtime_orch,
+        ctx.sandbox_handles,
+        ctx.agent_processes,
+        ctx.security_runtime_state,
+        ctx.projection_db_path,
+        ctx.operator_auth_required,
+        ctx.service_health_state.clone(),
+        previous.as_ref(),
+    );
+    let expected_agents = agents_for_shift(ctx.all_agents, ctx.current_shift);
+    let expected_ids = expected_agents
+        .iter()
+        .map(|cfg| cfg.identity.id)
+        .collect::<HashSet<_>>();
+    let before_by_id = before
+        .agents
+        .iter()
+        .cloned()
+        .map(|agent| (agent.agent_id, agent))
+        .collect::<HashMap<_, _>>();
+
+    let mut security_snapshots_removed = 0usize;
+    let mut unexpected_runtime_removed = 0usize;
+    let mut orphan_cgroups_removed = 0usize;
+    let mut respawned_agents = 0usize;
+    let mut respawn_skipped_backoff = 0usize;
+    let mut respawn_blocked_agents = 0usize;
+    let mut repair_ops_total = 0usize;
+    let mut respawn_failures_added = 0u64;
+    let mut repaired_agents = Vec::new();
+    let mut blocked_agents = Vec::new();
+    let mut errors = Vec::new();
+    let mut agent_status_updates = HashMap::<u16, String>::new();
+
+    if !request.dry_run {
+        for agent in before.agents.iter().filter(|agent| {
+            let expected_active = expected_ids.contains(&agent.agent_id);
+            !expected_active
+                && (agent.runtime_present
+                    || agent.security_runtime_present
+                    || agent.tracked_pid_alive
+                    || agent.cgroup_live_pid_count > 0)
+        }) {
+            let stats = remove_agent_runtime_fragments(ctx, agent);
+            if stats.repairs > 0 {
+                unexpected_runtime_removed += 1;
+                security_snapshots_removed += stats.security_snapshots_removed;
+                orphan_cgroups_removed += stats.orphan_cgroups_removed;
+                repair_ops_total += stats.repairs;
+                repaired_agents.push(agent.name.clone());
+                agent_status_updates.insert(agent.agent_id, "unexpected_runtime_cleaned".to_string());
+            }
+        }
+
+        let runtime_agent_names = ctx
+            .runtime_orch
+            .agents()
+            .values()
+            .map(|handle| handle.identity.name.clone())
+            .collect::<HashSet<_>>();
+        if let Ok(entries) = std::fs::read_dir("/sys/fs/cgroup/sentinel") {
+            for entry in entries.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if !file_type.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                if runtime_agent_names.contains(&name) {
+                    continue;
+                }
+                match sentinel_sandbox::cgroups::list_pids_in_cgroup(&name) {
+                    Ok(pids) if pids.is_empty() => {
+                        if sentinel_sandbox::cgroups::remove_cgroup(&name).is_ok() {
+                            orphan_cgroups_removed += 1;
+                            repair_ops_total += 1;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(error) => warn!(
+                        cgroup = %name,
+                        error = %error,
+                        "Orphan-Cgroup konnte nicht inspiziert werden"
+                    ),
+                }
+            }
+        }
+    }
+
+    for agent_cfg in &expected_agents {
+        let agent_id = agent_cfg.identity.id;
+        let snapshot = before_by_id.get(&agent_id);
+
+        if let Some(snapshot) = snapshot {
+            let runtime_core_healthy = snapshot.runtime_present
+                && snapshot.tracked_pid_alive
+                && snapshot.cgroup_live_pid_count > 0;
+            if runtime_agent_is_healthy(snapshot) {
+                respawn_backoff.record_success(agent_id);
+                continue;
+            }
+            if runtime_core_healthy && !snapshot.security_runtime_present {
+                if request.dry_run {
+                    agent_status_updates
+                        .insert(agent_id, "security_runtime_restore_planned".to_string());
+                } else {
+                    let tracked_pid = ctx
+                        .sandbox_handles
+                        .get(&AgentId(agent_id))
+                        .and_then(|handle| handle.bwrap_pid)
+                        .or(snapshot.tracked_pid);
+                    record_security_runtime_snapshot(
+                        ctx.security_runtime_state,
+                        AgentId(agent_id),
+                        &agent_cfg.identity.name,
+                        tracked_pid,
+                        ctx.fs_mount,
+                    );
+                    repair_ops_total += 1;
+                    repaired_agents.push(agent_cfg.identity.name.clone());
+                    agent_status_updates.insert(agent_id, "security_runtime_restored".to_string());
+                }
+                respawn_backoff.record_success(agent_id);
+                continue;
+            }
+            if runtime_core_healthy && snapshot.security_runtime_present && !snapshot.projection_present
+            {
+                agent_status_updates.insert(agent_id, "projection_reconcile_pending".to_string());
+                respawn_backoff.record_success(agent_id);
+                continue;
+            }
+        }
+
+        if !request.respawn_missing {
+            continue;
+        }
+
+        match respawn_backoff.decision(agent_id, ctx.tick_count) {
+            RespawnRetryDecision::Blocked => {
+                respawn_blocked_agents += 1;
+                blocked_agents.push(agent_cfg.identity.name.clone());
+                agent_status_updates.insert(agent_id, "repair_blocked".to_string());
+                continue;
+            }
+            RespawnRetryDecision::BackoffActive { .. } => {
+                respawn_skipped_backoff += 1;
+                agent_status_updates.insert(agent_id, "respawn_backoff".to_string());
+                continue;
+            }
+            RespawnRetryDecision::Ready => {}
+        }
+
+        if request.dry_run {
+            agent_status_updates.insert(agent_id, "respawn_planned".to_string());
+            continue;
+        }
+
+        if let Some(snapshot) = snapshot {
+            let stats = remove_agent_runtime_fragments(ctx, snapshot);
+            security_snapshots_removed += stats.security_snapshots_removed;
+            orphan_cgroups_removed += stats.orphan_cgroups_removed;
+            repair_ops_total += stats.repairs;
+        }
+
+        if spawn_agent_full(
+            ctx.runtime_orch,
+            ctx.world,
+            agent_cfg,
+            ctx.sandbox,
+            ctx.sandbox_handles,
+            ctx.ebpf_collector,
+            ctx.agent_processes,
+            ctx.agent_command,
+            ctx.security_runtime_state,
+            ctx.fs_mount,
+        ) {
+            respawned_agents += 1;
+            repair_ops_total += 1;
+            repaired_agents.push(agent_cfg.identity.name.clone());
+            agent_status_updates.insert(agent_id, "respawned".to_string());
+            respawn_backoff.record_success(agent_id);
+        } else {
+            respawn_failures_added += 1;
+            let message = format!("Respawn fehlgeschlagen fuer {}", agent_cfg.identity.name);
+            errors.push(message.clone());
+            match respawn_backoff.record_failure(agent_id, ctx.tick_count) {
+                RespawnRetryDecision::Blocked => {
+                    respawn_blocked_agents += 1;
+                    blocked_agents.push(agent_cfg.identity.name.clone());
+                    agent_status_updates.insert(agent_id, "repair_blocked".to_string());
+                    emit_runtime_repair_blocked_event(
+                        ctx.event_store,
+                        AgentId(agent_id),
+                        &message,
+                        ctx.tick_count,
+                    );
+                }
+                RespawnRetryDecision::BackoffActive { .. } => {
+                    agent_status_updates.insert(agent_id, "respawn_backoff".to_string());
+                }
+                RespawnRetryDecision::Ready => {}
+            }
+        }
+    }
+
+    let projection_rebuild_requested = if request.projection_rebuild && !request.dry_run {
+        match crate::runtime_control::write_projection_rebuild_request(ctx.data_dir, ctx.tick_count) {
+            Ok(()) => {
+                repair_ops_total += 1;
+                true
+            }
+            Err(error) => {
+                errors.push(error.to_string());
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    let mut after = runtime_health::build_runtime_health_snapshot(
+        ctx.all_agents,
+        ctx.current_shift,
+        ctx.runtime_orch,
+        ctx.sandbox_handles,
+        ctx.agent_processes,
+        ctx.security_runtime_state,
+        ctx.projection_db_path,
+        ctx.operator_auth_required,
+        ctx.service_health_state.clone(),
+        Some(&before),
+    );
+    after.reconcile_runs_total = before.reconcile_runs_total.saturating_add(1);
+    after.reconcile_repairs_total = before
+        .reconcile_repairs_total
+        .saturating_add(repair_ops_total as u64);
+    after.respawn_failures = before
+        .respawn_failures
+        .saturating_add(respawn_failures_added);
+    after.last_repair_error = errors.last().cloned().or(before.last_repair_error.clone());
+    after.repair_last_status = Some(
+        if request.dry_run {
+            "dry_run".to_string()
+        } else if respawn_blocked_agents > 0 {
+            "repair_blocked".to_string()
+        } else if !errors.is_empty() {
+            "repair_error".to_string()
+        } else if repair_ops_total > 0 || projection_rebuild_requested {
+            "repaired".to_string()
+        } else if after.stale_runtime_entries == 0 && after.orphan_cgroups == 0 {
+            "healthy".to_string()
+        } else {
+            "drift_detected".to_string()
+        },
+    );
+    for agent in &mut after.agents {
+        if let Some(status) = agent_status_updates.get(&agent.agent_id) {
+            agent.last_repair_status = Some(status.clone());
+        }
+    }
+    if let Ok(mut runtime_health) = ctx.runtime_health.write() {
+        *runtime_health = after.clone();
+    }
+
+    RuntimeReconcileResponse {
+        accepted: true,
+        dry_run: request.dry_run,
+        current_shift: ctx.current_shift,
+        stale_agents_before: before.stale_runtime_entries,
+        stale_agents_after: after.stale_runtime_entries,
+        orphan_cgroups_before: before.orphan_cgroups,
+        orphan_cgroups_after: after.orphan_cgroups,
+        security_snapshots_removed,
+        unexpected_runtime_removed,
+        orphan_cgroups_removed,
+        respawned_agents,
+        respawn_skipped_backoff,
+        respawn_blocked_agents,
+        projection_rebuild_requested,
+        respawn_failures_total: after.respawn_failures,
+        repair_last_status: after
+            .repair_last_status
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        repaired_agents,
+        blocked_agents,
+        errors,
+    }
+}
+
 fn resolve_platform_analysis_target(
     runtime_orch: &RuntimeOrchestrator,
     target: &str,
@@ -1269,6 +1725,7 @@ fn ecs_tick_loop(
     action_rx: mpsc::Receiver<sentinel_common::AgentAction>,
     operator_rx: mpsc::Receiver<sentinel_common::OperatorCommand>,
     platform_rx: mpsc::Receiver<crate::platform_controlplane::PlatformControlCommand>,
+    runtime_rx: mpsc::Receiver<RuntimeControlCommand>,
     perception_tx: mpsc::SyncSender<Perception>,
     all_agents: Vec<AgentConfig>,
     initial_shift: u8,
@@ -1328,6 +1785,7 @@ fn ecs_tick_loop(
         platform_cp_config_clone.monitored_services.clone(),
         std::time::Duration::from_secs(platform_cp_config_clone.service_check_interval_secs),
     );
+    let mut respawn_backoff = RespawnBackoffTracker::new(3);
 
     // ECS World + Schedule erstellen
     let (mut world, mut schedule) = create_simulation_world();
@@ -1795,6 +2253,46 @@ fn ecs_tick_loop(
                     ) {
                         warn!(error = %error, "Platform-Analyse konnte nicht ausgefuehrt werden");
                     }
+                }
+            }
+        }
+
+        while let Ok(command) = runtime_rx.try_recv() {
+            match command {
+                RuntimeControlCommand::Reconcile {
+                    request,
+                    response_tx,
+                } => {
+                    let projection_path = std::path::Path::new(&projection_db_path);
+                    let data_dir = projection_path
+                        .parent()
+                        .unwrap_or_else(|| std::path::Path::new("."));
+                    let mut reconcile_ctx = RuntimeReconcileContext {
+                        tick_count,
+                        current_shift,
+                        all_agents: &all_agents,
+                        world: &mut world,
+                        runtime_orch: &mut runtime_orch,
+                        sandbox: &sandbox,
+                        sandbox_handles: &mut sandbox_handles,
+                        ebpf_collector: &mut ebpf_collector,
+                        agent_processes: &mut agent_processes,
+                        agent_command: &agent_command,
+                        security_runtime_state: &security_runtime_state,
+                        event_store: &event_store_for_prune,
+                        runtime_health: &runtime_health,
+                        projection_db_path: projection_path,
+                        operator_auth_required,
+                        service_health_state: service_health_checker.worker_state(),
+                        fs_mount: fs_mount.as_deref(),
+                        data_dir,
+                    };
+                    let response = run_runtime_reconcile(
+                        &mut reconcile_ctx,
+                        request,
+                        &mut respawn_backoff,
+                    );
+                    let _ = response_tx.send(response);
                 }
             }
         }
@@ -3156,6 +3654,7 @@ mod tests {
             rx,
             operator_rx,
             mpsc::channel::<crate::platform_controlplane::PlatformControlCommand>().1,
+            mpsc::channel::<RuntimeControlCommand>().1,
             ptx,
             vec![],
             1,
@@ -3238,6 +3737,7 @@ mod tests {
                 rx,
                 operator_rx,
                 mpsc::channel::<crate::platform_controlplane::PlatformControlCommand>().1,
+                mpsc::channel::<RuntimeControlCommand>().1,
                 ptx,
                 all_agents,
                 1,
@@ -3337,6 +3837,7 @@ mod tests {
                 rx,
                 operator_rx,
                 mpsc::channel::<crate::platform_controlplane::PlatformControlCommand>().1,
+                mpsc::channel::<RuntimeControlCommand>().1,
                 ptx,
                 all_agents,
                 1,
@@ -3444,6 +3945,7 @@ mod tests {
                 rx,
                 operator_rx,
                 mpsc::channel::<crate::platform_controlplane::PlatformControlCommand>().1,
+                mpsc::channel::<RuntimeControlCommand>().1,
                 ptx,
                 all_agents,
                 1,

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -42,8 +42,8 @@ use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
 use crate::operator_api;
 use crate::runtime_control::{
-    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand, RuntimeReconcileRequest,
-    RuntimeReconcileResponse, RuntimeStallRestartTestResponse,
+    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand, RuntimePanicTestResponse,
+    RuntimeReconcileRequest, RuntimeReconcileResponse, RuntimeStallRestartTestResponse,
 };
 use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
@@ -2406,6 +2406,37 @@ fn ecs_tick_loop(
                     };
                     let response =
                         run_runtime_reconcile(&mut reconcile_ctx, request, &mut respawn_backoff);
+                    let _ = response_tx.send(response);
+                }
+                RuntimeControlCommand::PanicTest {
+                    request,
+                    response_tx,
+                } => {
+                    let response = if request.worker == "service_health" {
+                        if service_health_checker.trigger_panic_test() {
+                            info!(
+                                worker = %request.worker,
+                                "panic test triggered fuer Worker"
+                            );
+                            RuntimePanicTestResponse {
+                                accepted: true,
+                                worker: request.worker,
+                                note: "panic-test dispatched".to_string(),
+                            }
+                        } else {
+                            RuntimePanicTestResponse {
+                                accepted: false,
+                                worker: request.worker,
+                                note: "service_health control channel unavailable".to_string(),
+                            }
+                        }
+                    } else {
+                        RuntimePanicTestResponse {
+                            accepted: false,
+                            worker: request.worker,
+                            note: "worker unsupported".to_string(),
+                        }
+                    };
                     let _ = response_tx.send(response);
                 }
                 RuntimeControlCommand::StallRestartTest {

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1279,6 +1279,8 @@ struct RuntimeReconcileContext<'a> {
     service_health_state: crate::service_health::ServiceHealthWorkerSnapshot,
     fs_mount: Option<&'a str>,
     data_dir: &'a std::path::Path,
+    restart_service_fn: fn(&str) -> bool,
+    is_service_active_fn: fn(&str) -> bool,
 }
 
 fn runtime_agent_is_healthy(agent: &runtime_health::RuntimeHealthAgentSnapshot) -> bool {
@@ -1435,6 +1437,7 @@ fn run_runtime_reconcile(
         .cloned()
         .map(|agent| (agent.agent_id, agent))
         .collect::<HashMap<_, _>>();
+    let projection_drift_before = before.projection_drift_detected;
 
     let mut security_snapshots_removed = 0usize;
     let mut unexpected_runtime_removed = 0usize;
@@ -1448,6 +1451,25 @@ fn run_runtime_reconcile(
     let mut blocked_agents = Vec::new();
     let mut errors = Vec::new();
     let mut agent_status_updates = HashMap::<u16, String>::new();
+    let mut projection_restart_attempted = false;
+    let mut projection_restart_succeeded = false;
+
+    if projection_drift_before && !request.dry_run {
+        let projection_service_active = (ctx.is_service_active_fn)("sentinel-projection");
+        if request.projection_rebuild && projection_service_active {
+            info!(
+                "Projection-Drift erkannt, aber laufender Projection-Service bleibt fuer Rebuild in Ruhe"
+            );
+        } else {
+            projection_restart_attempted = true;
+            if (ctx.restart_service_fn)("sentinel-projection") {
+                projection_restart_succeeded = true;
+                repair_ops_total += 1;
+            } else {
+                errors.push("Projection-Restart fehlgeschlagen".to_string());
+            }
+        }
+    }
 
     if !request.dry_run {
         for agent in before.agents.iter().filter(|agent| {
@@ -1625,8 +1647,16 @@ fn run_runtime_reconcile(
     }
 
     let projection_rebuild_requested = if request.projection_rebuild && !request.dry_run {
-        match crate::runtime_control::write_projection_rebuild_request(ctx.data_dir, ctx.tick_count)
-        {
+        let reason = if projection_drift_before {
+            "projection_drift"
+        } else {
+            "manual_request"
+        };
+        match crate::runtime_control::write_projection_rebuild_request(
+            ctx.data_dir,
+            ctx.tick_count,
+            reason,
+        ) {
             Ok(()) => {
                 repair_ops_total += 1;
                 true
@@ -1666,6 +1696,10 @@ fn run_runtime_reconcile(
         "repair_blocked".to_string()
     } else if !errors.is_empty() {
         "repair_error".to_string()
+    } else if projection_rebuild_requested {
+        "projection_rebuild_requested".to_string()
+    } else if projection_restart_attempted && after.projection_drift_detected {
+        "projection_restart_requested".to_string()
     } else if repair_ops_total > 0 || projection_rebuild_requested {
         "repaired".to_string()
     } else if after.stale_runtime_entries == 0 && after.orphan_cgroups == 0 {
@@ -1696,6 +1730,10 @@ fn run_runtime_reconcile(
         respawned_agents,
         respawn_skipped_backoff,
         respawn_blocked_agents,
+        projection_drift_before,
+        projection_drift_after: after.projection_drift_detected,
+        projection_restart_attempted,
+        projection_restart_succeeded,
         projection_rebuild_requested,
         respawn_failures_total: after.respawn_failures,
         repair_last_status: after
@@ -2404,6 +2442,8 @@ fn ecs_tick_loop(
                         service_health_state: service_health_checker.worker_state(),
                         fs_mount: fs_mount.as_deref(),
                         data_dir,
+                        restart_service_fn: crate::service_health::restart_service_now,
+                        is_service_active_fn: crate::service_health::is_service_active_now,
                     };
                     let response =
                         run_runtime_reconcile(&mut reconcile_ctx, request, &mut respawn_backoff);
@@ -3876,8 +3916,19 @@ mod tests {
     use sentinel_common::{DomainEventPayload, EventType, OperatorChaosCommand, OperatorCommand};
     use sentinel_ebpf::loader::MonitoringMode;
     use std::collections::HashMap;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
+
+    static PROJECTION_RESTART_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn record_projection_restart(_service_name: &str) -> bool {
+        PROJECTION_RESTART_CALLS.fetch_add(1, Ordering::SeqCst);
+        true
+    }
+
+    fn projection_service_active(_service_name: &str) -> bool {
+        true
+    }
 
     /// Erstellt EbpfCollector + tokio mpsc Sender fuer Tests (Userspace mode, kein tokio noetig).
     fn test_ebpf() -> (EbpfCollector, tokio::sync::mpsc::Sender<MetricsSnapshot>) {
@@ -4018,6 +4069,79 @@ mod tests {
                 "Fast-Restart sollte einen neuen PID liefern"
             );
         }
+    }
+
+    #[test]
+    fn test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place() {
+        PROJECTION_RESTART_CALLS.store(0, Ordering::SeqCst);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let events_path = tmp.path().join("events.db");
+        let projection_path = tmp.path().join("projection.db");
+        let rebuild_request_path = tmp.path().join(".projection-rebuild-request");
+        let event_store = Arc::new(EventStore::open(events_path.to_str().unwrap()).unwrap());
+        let projection_store =
+            sentinel_projection::ReadModelStore::open(projection_path.to_str().unwrap()).unwrap();
+        {
+            let txn = projection_store.begin_transaction().unwrap();
+            txn.begin().unwrap();
+            txn.upsert_agent(7, "Projection Ghost", "Tester", 1, "active", 1)
+                .unwrap();
+            txn.commit().unwrap();
+        }
+        drop(projection_store);
+
+        let (mut world, _schedule) = create_simulation_world();
+        let sandbox = test_sandbox();
+        let (mut ebpf_collector, _ebpf_tx) = test_ebpf();
+        let mut runtime_orch =
+            RuntimeOrchestrator::new(10).with_event_store(Arc::clone(&event_store));
+        let mut sandbox_handles = HashMap::new();
+        let mut agent_processes = HashMap::new();
+        let security_runtime_state = Arc::new(RwLock::new(HashMap::new()));
+        let runtime_health = Arc::new(RwLock::new(
+            crate::runtime_health::RuntimeHealthSnapshot::default(),
+        ));
+        let mut respawn_backoff = RespawnBackoffTracker::new(3);
+        let mut reconcile_ctx = RuntimeReconcileContext {
+            tick_count: 123,
+            current_shift: 1,
+            all_agents: &[],
+            world: &mut world,
+            runtime_orch: &mut runtime_orch,
+            sandbox: &sandbox,
+            sandbox_handles: &mut sandbox_handles,
+            ebpf_collector: &mut ebpf_collector,
+            agent_processes: &mut agent_processes,
+            agent_command: &[],
+            security_runtime_state: &security_runtime_state,
+            event_store: &event_store,
+            runtime_health: &runtime_health,
+            projection_db_path: &projection_path,
+            operator_auth_required: false,
+            service_health_state: crate::service_health::ServiceHealthWorkerSnapshot::default(),
+            fs_mount: None,
+            data_dir: tmp.path(),
+            restart_service_fn: record_projection_restart,
+            is_service_active_fn: projection_service_active,
+        };
+
+        let response = run_runtime_reconcile(
+            &mut reconcile_ctx,
+            RuntimeReconcileRequest {
+                dry_run: false,
+                projection_rebuild: true,
+                respawn_missing: false,
+            },
+            &mut respawn_backoff,
+        );
+
+        assert!(response.projection_drift_before);
+        assert!(!response.projection_restart_attempted);
+        assert!(!response.projection_restart_succeeded);
+        assert!(response.projection_rebuild_requested);
+        assert_eq!(PROJECTION_RESTART_CALLS.load(Ordering::SeqCst), 0);
+        assert!(rebuild_request_path.exists());
     }
 
     #[test]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -42,8 +42,8 @@ use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
 use crate::operator_api;
 use crate::runtime_control::{
-    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand,
-    RuntimeReconcileRequest, RuntimeReconcileResponse,
+    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand, RuntimeReconcileRequest,
+    RuntimeReconcileResponse, RuntimeStallRestartTestResponse,
 };
 use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
@@ -1141,6 +1141,117 @@ fn publish_platform_state_snapshot(
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct FastRestartResult {
+    agent_name: String,
+    pid_before: Option<u32>,
+    pid_after: Option<u32>,
+    runtime_present_after: bool,
+    security_runtime_present_after: bool,
+}
+
+fn tracked_pid_for_agent(
+    agent_id: AgentId,
+    sandbox_handles: &HashMap<AgentId, SandboxHandle>,
+    agent_processes: &HashMap<AgentId, sentinel_sandbox::AgentProcess>,
+    security_runtime_state: &operator_api::SharedSecurityRuntimeState,
+) -> Option<u32> {
+    sandbox_handles
+        .get(&agent_id)
+        .and_then(|handle| handle.bwrap_pid)
+        .or_else(|| agent_processes.get(&agent_id).map(|proc| proc.pid))
+        .or_else(|| {
+            security_runtime_state.read().ok().and_then(|state| {
+                state
+                    .get(&agent_id.0)
+                    .and_then(|snapshot| snapshot.bwrap_pid)
+            })
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn restart_agent_fast_path(
+    world: &mut bevy_ecs::prelude::World,
+    runtime_orch: &mut RuntimeOrchestrator,
+    agent_cfg: &AgentConfig,
+    sandbox: &SandboxEnforcer,
+    sandbox_handles: &mut HashMap<AgentId, SandboxHandle>,
+    ebpf_collector: &mut EbpfCollector,
+    agent_processes: &mut HashMap<AgentId, sentinel_sandbox::AgentProcess>,
+    agent_command: &[String],
+    security_runtime_state: &operator_api::SharedSecurityRuntimeState,
+    fs_mount: Option<&str>,
+) -> Result<FastRestartResult> {
+    let agent_id = AgentId(agent_cfg.identity.id);
+    let pid_before = tracked_pid_for_agent(
+        agent_id,
+        sandbox_handles,
+        agent_processes,
+        security_runtime_state,
+    );
+
+    if let Some(handle) = sandbox_handles.remove(&agent_id) {
+        if handle.cgroup_created {
+            if let Some(cid) = sentinel_sandbox::cgroup_id(&handle.agent_name) {
+                ebpf_collector.unregister_agent(cid);
+            }
+        }
+        if let Err(error) = sandbox.teardown_agent(&handle) {
+            warn!(
+                agent_id = %agent_id,
+                error = %error,
+                "Sandbox teardown bei Fast-Restart fehlgeschlagen"
+            );
+        }
+    }
+
+    if let Some(proc_handle) = agent_processes.remove(&agent_id) {
+        let _ = signal_pid(proc_handle.pid, "TERM");
+        drop(proc_handle);
+    }
+
+    remove_security_runtime_snapshot(security_runtime_state, agent_id);
+    let _ = despawn_agent_from_world(world, agent_id);
+    let _ = runtime_orch.despawn_agent(agent_id);
+
+    if !spawn_agent_full(
+        runtime_orch,
+        world,
+        agent_cfg,
+        sandbox,
+        sandbox_handles,
+        ebpf_collector,
+        agent_processes,
+        agent_command,
+        security_runtime_state,
+        fs_mount,
+    ) {
+        return Err(anyhow!(
+            "Fast-Respawn fuer {} fehlgeschlagen",
+            agent_cfg.identity.name
+        ));
+    }
+
+    let pid_after = tracked_pid_for_agent(
+        agent_id,
+        sandbox_handles,
+        agent_processes,
+        security_runtime_state,
+    );
+    let security_runtime_present_after = security_runtime_state
+        .read()
+        .map(|state| state.contains_key(&agent_id.0))
+        .unwrap_or(false);
+
+    Ok(FastRestartResult {
+        agent_name: agent_cfg.identity.name.clone(),
+        pid_before,
+        pid_after,
+        runtime_present_after: runtime_orch.agents().contains_key(&agent_id),
+        security_runtime_present_after,
+    })
+}
+
 #[derive(Debug, Default)]
 struct RuntimeCleanupStats {
     repairs: usize,
@@ -1295,7 +1406,11 @@ fn run_runtime_reconcile(
     request: RuntimeReconcileRequest,
     respawn_backoff: &mut RespawnBackoffTracker,
 ) -> RuntimeReconcileResponse {
-    let previous = ctx.runtime_health.read().ok().map(|snapshot| snapshot.clone());
+    let previous = ctx
+        .runtime_health
+        .read()
+        .ok()
+        .map(|snapshot| snapshot.clone());
     let before = runtime_health::build_runtime_health_snapshot(
         ctx.all_agents,
         ctx.current_shift,
@@ -1349,7 +1464,8 @@ fn run_runtime_reconcile(
                 orphan_cgroups_removed += stats.orphan_cgroups_removed;
                 repair_ops_total += stats.repairs;
                 repaired_agents.push(agent.name.clone());
-                agent_status_updates.insert(agent.agent_id, "unexpected_runtime_cleaned".to_string());
+                agent_status_updates
+                    .insert(agent.agent_id, "unexpected_runtime_cleaned".to_string());
             }
         }
 
@@ -1425,7 +1541,9 @@ fn run_runtime_reconcile(
                 respawn_backoff.record_success(agent_id);
                 continue;
             }
-            if runtime_core_healthy && snapshot.security_runtime_present && !snapshot.projection_present
+            if runtime_core_healthy
+                && snapshot.security_runtime_present
+                && !snapshot.projection_present
             {
                 agent_status_updates.insert(agent_id, "projection_reconcile_pending".to_string());
                 respawn_backoff.record_success(agent_id);
@@ -1506,7 +1624,8 @@ fn run_runtime_reconcile(
     }
 
     let projection_rebuild_requested = if request.projection_rebuild && !request.dry_run {
-        match crate::runtime_control::write_projection_rebuild_request(ctx.data_dir, ctx.tick_count) {
+        match crate::runtime_control::write_projection_rebuild_request(ctx.data_dir, ctx.tick_count)
+        {
             Ok(()) => {
                 repair_ops_total += 1;
                 true
@@ -1540,21 +1659,19 @@ fn run_runtime_reconcile(
         .respawn_failures
         .saturating_add(respawn_failures_added);
     after.last_repair_error = errors.last().cloned().or(before.last_repair_error.clone());
-    after.repair_last_status = Some(
-        if request.dry_run {
-            "dry_run".to_string()
-        } else if respawn_blocked_agents > 0 {
-            "repair_blocked".to_string()
-        } else if !errors.is_empty() {
-            "repair_error".to_string()
-        } else if repair_ops_total > 0 || projection_rebuild_requested {
-            "repaired".to_string()
-        } else if after.stale_runtime_entries == 0 && after.orphan_cgroups == 0 {
-            "healthy".to_string()
-        } else {
-            "drift_detected".to_string()
-        },
-    );
+    after.repair_last_status = Some(if request.dry_run {
+        "dry_run".to_string()
+    } else if respawn_blocked_agents > 0 {
+        "repair_blocked".to_string()
+    } else if !errors.is_empty() {
+        "repair_error".to_string()
+    } else if repair_ops_total > 0 || projection_rebuild_requested {
+        "repaired".to_string()
+    } else if after.stale_runtime_entries == 0 && after.orphan_cgroups == 0 {
+        "healthy".to_string()
+    } else {
+        "drift_detected".to_string()
+    });
     for agent in &mut after.agents {
         if let Some(status) = agent_status_updates.get(&agent.agent_id) {
             agent.last_repair_status = Some(status.clone());
@@ -2287,11 +2404,117 @@ fn ecs_tick_loop(
                         fs_mount: fs_mount.as_deref(),
                         data_dir,
                     };
-                    let response = run_runtime_reconcile(
-                        &mut reconcile_ctx,
-                        request,
-                        &mut respawn_backoff,
-                    );
+                    let response =
+                        run_runtime_reconcile(&mut reconcile_ctx, request, &mut respawn_backoff);
+                    let _ = response_tx.send(response);
+                }
+                RuntimeControlCommand::StallRestartTest {
+                    request,
+                    response_tx,
+                } => {
+                    let agent_id = AgentId(request.agent_id);
+                    let response = match all_agents
+                        .iter()
+                        .find(|cfg| cfg.identity.id == request.agent_id)
+                    {
+                        Some(agent_cfg) => {
+                            let pid_before = tracked_pid_for_agent(
+                                agent_id,
+                                &sandbox_handles,
+                                &agent_processes,
+                                &security_runtime_state,
+                            );
+                            let pre_suspend_result = match request.mode.as_str() {
+                                "sigstop" => suspend_agent_cgroup_processes(
+                                    &agent_cfg.identity.name,
+                                    pid_before,
+                                )
+                                .map(|_| ()),
+                                "direct" => Ok(()),
+                                _ => Err(anyhow!("unbekannter stall-restart-test mode")),
+                            };
+
+                            match pre_suspend_result.and_then(|_| {
+                                restart_agent_fast_path(
+                                    &mut world,
+                                    &mut runtime_orch,
+                                    agent_cfg,
+                                    &sandbox,
+                                    &mut sandbox_handles,
+                                    &mut ebpf_collector,
+                                    &mut agent_processes,
+                                    &agent_command,
+                                    &security_runtime_state,
+                                    fs_mount.as_deref(),
+                                )
+                            }) {
+                                Ok(result) => {
+                                    info!(
+                                        agent_id = %agent_id,
+                                        mode = %request.mode,
+                                        stall_secs = request.stall_secs,
+                                        pid_before = ?result.pid_before,
+                                        pid_after = ?result.pid_after,
+                                        "Deterministischer Stall-Restart-Test ausgefuehrt"
+                                    );
+                                    RuntimeStallRestartTestResponse {
+                                        accepted: true,
+                                        agent_id: request.agent_id,
+                                        aggregate_id: format!("AGENT-{:02}", request.agent_id),
+                                        agent_name: result.agent_name,
+                                        mode: request.mode,
+                                        stall_secs: request.stall_secs,
+                                        pid_before: result.pid_before,
+                                        pid_after: result.pid_after,
+                                        runtime_present_after: result.runtime_present_after,
+                                        security_runtime_present_after: result
+                                            .security_runtime_present_after,
+                                        note: "fast_path_restart_executed_without_shift_wait"
+                                            .to_string(),
+                                    }
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        agent_id = %agent_id,
+                                        mode = %request.mode,
+                                        error = %error,
+                                        "Stall-Restart-Test fehlgeschlagen"
+                                    );
+                                    RuntimeStallRestartTestResponse {
+                                        accepted: false,
+                                        agent_id: request.agent_id,
+                                        aggregate_id: format!("AGENT-{:02}", request.agent_id),
+                                        agent_name: agent_cfg.identity.name.clone(),
+                                        mode: request.mode,
+                                        stall_secs: request.stall_secs,
+                                        pid_before,
+                                        pid_after: None,
+                                        runtime_present_after: runtime_orch
+                                            .agents()
+                                            .contains_key(&agent_id),
+                                        security_runtime_present_after: security_runtime_state
+                                            .read()
+                                            .map(|state| state.contains_key(&request.agent_id))
+                                            .unwrap_or(false),
+                                        note: error.to_string(),
+                                    }
+                                }
+                            }
+                        }
+                        None => RuntimeStallRestartTestResponse {
+                            accepted: false,
+                            agent_id: request.agent_id,
+                            aggregate_id: format!("AGENT-{:02}", request.agent_id),
+                            agent_name: String::new(),
+                            mode: request.mode,
+                            stall_secs: request.stall_secs,
+                            pid_before: None,
+                            pid_after: None,
+                            runtime_present_after: false,
+                            security_runtime_present_after: false,
+                            note: "agent_id unbekannt".to_string(),
+                        },
+                    };
                     let _ = response_tx.send(response);
                 }
             }
@@ -2390,30 +2613,37 @@ fn ecs_tick_loop(
                     }
                     crate::platform_controlplane::rules::PlatformSideEffect::RestartAgent(
                         agent_id,
-                    ) => {
-                        // Sandbox teardown
-                        if let Some(handle) = sandbox_handles.remove(&agent_id) {
-                            if handle.cgroup_created {
-                                if let Some(cid) = sentinel_sandbox::cgroup_id(&handle.agent_name) {
-                                    ebpf_collector.unregister_agent(cid);
-                                }
-                            }
-                            if let Err(e) = sandbox.teardown_agent(&handle) {
-                                warn!(agent_id = %agent_id, error = %e,
-                                    "Sandbox teardown bei Stall-Restart fehlgeschlagen");
-                            }
-                        }
-                        // Agent-Prozess droppen
-                        agent_processes.remove(&agent_id);
-                        remove_security_runtime_snapshot(&security_runtime_state, agent_id);
-                        // ECS Entity despawnen
-                        despawn_agent_from_world(&mut world, agent_id);
-                        // RuntimeOrchestrator despawn
-                        let _ = runtime_orch.despawn_agent(agent_id);
-                        // Respawn bei naechstem Shift-Check
-                        info!(agent_id = %agent_id,
-                            "Agent nach Stall restartet (despawned, Respawn bei naechstem Shift-Check)");
-                    }
+                    ) => match all_agents.iter().find(|cfg| cfg.identity.id == agent_id.0) {
+                        Some(agent_cfg) => match restart_agent_fast_path(
+                            &mut world,
+                            &mut runtime_orch,
+                            agent_cfg,
+                            &sandbox,
+                            &mut sandbox_handles,
+                            &mut ebpf_collector,
+                            &mut agent_processes,
+                            &agent_command,
+                            &security_runtime_state,
+                            fs_mount.as_deref(),
+                        ) {
+                            Ok(result) => info!(
+                                agent_id = %agent_id,
+                                agent = %result.agent_name,
+                                pid_before = ?result.pid_before,
+                                pid_after = ?result.pid_after,
+                                "Agent nach Stall sofort via Fast-Respawn wiederhergestellt"
+                            ),
+                            Err(error) => warn!(
+                                agent_id = %agent_id,
+                                error = %error,
+                                "Fast-Respawn nach Stall fehlgeschlagen"
+                            ),
+                        },
+                        None => warn!(
+                            agent_id = %agent_id,
+                            "Agent-Konfiguration fuer Stall-Restart nicht gefunden"
+                        ),
+                    },
                     crate::platform_controlplane::rules::PlatformSideEffect::RestartService(
                         service_name,
                     ) => {
@@ -3625,6 +3855,70 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    #[test]
+    fn test_restart_agent_fast_path_recreates_runtime_and_security_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let events_path = tmp.path().join("events.db");
+        let event_store = Arc::new(EventStore::open(events_path.to_str().unwrap()).unwrap());
+
+        let mut runtime_orch = RuntimeOrchestrator::new(10).with_event_store(event_store);
+        let (mut world, _schedule) = create_simulation_world();
+        let sandbox = test_sandbox();
+        let (mut ebpf_collector, _ebpf_tx) = test_ebpf();
+        let mut sandbox_handles = HashMap::new();
+        let mut agent_processes = HashMap::new();
+        let security_runtime_state = Arc::new(RwLock::new(HashMap::new()));
+        let agent_cfg = test_agent_config(1, "Test Agent", "Tester", 1);
+        let agent_command = vec!["true".to_string()];
+
+        assert!(spawn_agent_full(
+            &mut runtime_orch,
+            &mut world,
+            &agent_cfg,
+            &sandbox,
+            &mut sandbox_handles,
+            &mut ebpf_collector,
+            &mut agent_processes,
+            &agent_command,
+            &security_runtime_state,
+            None,
+        ));
+
+        let before_pid = tracked_pid_for_agent(
+            AgentId(1),
+            &sandbox_handles,
+            &agent_processes,
+            &security_runtime_state,
+        );
+        let result = restart_agent_fast_path(
+            &mut world,
+            &mut runtime_orch,
+            &agent_cfg,
+            &sandbox,
+            &mut sandbox_handles,
+            &mut ebpf_collector,
+            &mut agent_processes,
+            &agent_command,
+            &security_runtime_state,
+            None,
+        )
+        .expect("fast restart");
+
+        assert_eq!(result.agent_name, "Test Agent");
+        assert_eq!(result.pid_before, before_pid);
+        assert!(result.runtime_present_after);
+        assert!(result.security_runtime_present_after);
+        assert!(runtime_orch.agents().contains_key(&AgentId(1)));
+        assert!(security_runtime_state.read().unwrap().contains_key(&1));
+        assert_eq!(runtime_orch.agent_count(), 1);
+        if let (Some(pid_before), Some(pid_after)) = (result.pid_before, result.pid_after) {
+            assert_ne!(
+                pid_before, pid_after,
+                "Fast-Restart sollte einen neuen PID liefern"
+            );
+        }
     }
 
     #[test]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -42,8 +42,9 @@ use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
 use crate::operator_api;
 use crate::runtime_control::{
-    RespawnBackoffTracker, RespawnRetryDecision, RuntimeControlCommand, RuntimePanicTestResponse,
-    RuntimeReconcileRequest, RuntimeReconcileResponse, RuntimeStallRestartTestResponse,
+    RespawnBackoffTracker, RespawnRetryDecision, RuntimeAnalysisFloodTestResponse,
+    RuntimeControlCommand, RuntimePanicTestResponse, RuntimeReconcileRequest,
+    RuntimeReconcileResponse, RuntimeStallRestartTestResponse,
 };
 use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
@@ -2408,6 +2409,58 @@ fn ecs_tick_loop(
                         run_runtime_reconcile(&mut reconcile_ctx, request, &mut respawn_backoff);
                     let _ = response_tx.send(response);
                 }
+                RuntimeControlCommand::AnalysisFloodTest {
+                    request,
+                    response_tx,
+                } => {
+                    for _ in 0..request.count {
+                        platform_cp.enqueue_control_command(
+                            crate::platform_controlplane::PlatformControlCommand::AnalyzeNow,
+                        );
+                    }
+
+                    #[cfg(feature = "llm")]
+                    for idx in 0..request.count {
+                        let synthetic = crate::platform_controlplane::PlatformAnalysisRequest {
+                            trigger: format!("flood_test_{idx}"),
+                            tick: tick_count,
+                            metrics: crate::platform_controlplane::metrics::PlatformMetrics {
+                                tick: tick_count,
+                                ..Default::default()
+                            },
+                            verify_results: HashMap::new(),
+                            failed_interventions: Vec::new(),
+                        };
+                        let _ = platform_llm_analyzer.enqueue(synthetic);
+                    }
+
+                    let mut stats = platform_cp.analysis_queue_stats();
+                    #[cfg(feature = "llm")]
+                    {
+                        let analyzer_stats = platform_llm_analyzer.queue_stats();
+                        stats.depth = stats.depth.saturating_add(analyzer_stats.depth);
+                        stats.dropped_total = stats
+                            .dropped_total
+                            .saturating_add(analyzer_stats.dropped_total);
+                        stats.coalesced_total = stats
+                            .coalesced_total
+                            .saturating_add(analyzer_stats.coalesced_total);
+                    }
+
+                    let note = if cfg!(feature = "llm") {
+                        "bounded controlplane and analyzer queues exercised"
+                    } else {
+                        "bounded controlplane queue exercised; llm feature disabled"
+                    };
+                    let _ = response_tx.send(RuntimeAnalysisFloodTestResponse {
+                        accepted: true,
+                        requested: request.count,
+                        queue_depth: stats.depth,
+                        dropped_total: stats.dropped_total,
+                        coalesced_total: stats.coalesced_total,
+                        note: note.to_string(),
+                    });
+                }
                 RuntimeControlCommand::PanicTest {
                     request,
                     response_tx,
@@ -2703,6 +2756,20 @@ fn ecs_tick_loop(
             &runtime_orch,
             &resource_manager,
         );
+        let mut analysis_queue_stats = platform_cp.analysis_queue_stats();
+        #[cfg(feature = "llm")]
+        {
+            let analyzer_stats = platform_llm_analyzer.queue_stats();
+            analysis_queue_stats.depth = analysis_queue_stats
+                .depth
+                .saturating_add(analyzer_stats.depth);
+            analysis_queue_stats.dropped_total = analysis_queue_stats
+                .dropped_total
+                .saturating_add(analyzer_stats.dropped_total);
+            analysis_queue_stats.coalesced_total = analysis_queue_stats
+                .coalesced_total
+                .saturating_add(analyzer_stats.coalesced_total);
+        }
         runtime_health::publish_runtime_health_snapshot(
             &runtime_health,
             &all_agents,
@@ -2714,6 +2781,7 @@ fn ecs_tick_loop(
             std::path::Path::new(&projection_db_path),
             operator_auth_required,
             service_health_checker.worker_state(),
+            analysis_queue_stats,
         );
 
         // Prune: Empfange Cutoff von Operator-API, arbeite 1 Batch/Tick ab

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -41,6 +41,7 @@ use crate::controlplane::store::ControlplaneStore;
 use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
 use crate::operator_api;
+use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
 use crate::signal::wait_for_shutdown;
 
@@ -591,8 +592,13 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let platform_state = Arc::new(RwLock::new(
         crate::platform_controlplane::PlatformStateSnapshot::default(),
     ));
+    let runtime_health = Arc::new(RwLock::new(
+        crate::runtime_health::RuntimeHealthSnapshot::default(),
+    ));
     let security_runtime_state: operator_api::SharedSecurityRuntimeState =
         Arc::new(RwLock::new(HashMap::new()));
+    let projection_db_path = data_dir.join("projection.db").to_string_lossy().to_string();
+    let operator_auth_required = config.operator_api.shared_secret.is_some();
 
     // -- Zenoh SentinelBus (Core-Bus fuer Real-Time Event-Verteilung) --
     let bus_config = config.zenoh.to_bus_config();
@@ -703,6 +709,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 prune_tx.clone(),
                 Arc::clone(&state_store),
                 Arc::clone(&platform_state),
+                Arc::clone(&runtime_health),
                 Arc::clone(&security_runtime_state),
             )
             .await?,
@@ -736,8 +743,10 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let platform_cp_config = config.platform_controlplane.clone();
     let events_db_path = events_path.to_string_lossy().to_string();
     let ecs_platform_state = Arc::clone(&platform_state);
+    let ecs_runtime_health = Arc::clone(&runtime_health);
     let ecs_security_runtime_state = Arc::clone(&security_runtime_state);
     let ecs_fs_mount = config.fs_mount.clone();
+    let ecs_projection_db_path = projection_db_path.clone();
     let ecs_handle = std::thread::Builder::new()
         .name("ecs-tick-loop".into())
         .spawn(move || {
@@ -774,7 +783,10 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 platform_cp_config,
                 events_db_path,
                 ecs_platform_state,
+                ecs_runtime_health,
                 ecs_security_runtime_state,
+                ecs_projection_db_path,
+                operator_auth_required,
                 ecs_fs_mount,
                 fs_layer.clone(),
                 #[cfg(feature = "llm")]
@@ -1284,7 +1296,10 @@ fn ecs_tick_loop(
     platform_cp_config: crate::config::PlatformControlplaneConfig,
     events_db_path_str: String,
     platform_state: Arc<RwLock<crate::platform_controlplane::PlatformStateSnapshot>>,
+    runtime_health: crate::runtime_health::SharedRuntimeHealthState,
     security_runtime_state: operator_api::SharedSecurityRuntimeState,
+    projection_db_path: String,
+    operator_auth_required: bool,
     fs_mount: Option<String>,
     fs_layer: Option<Arc<sentinel_fs::layer::LayerManager>>,
     #[cfg(feature = "llm")]
@@ -1928,6 +1943,18 @@ fn ecs_tick_loop(
             &platform_cp,
             &runtime_orch,
             &resource_manager,
+        );
+        runtime_health::publish_runtime_health_snapshot(
+            &runtime_health,
+            &all_agents,
+            current_shift,
+            &runtime_orch,
+            &sandbox_handles,
+            &agent_processes,
+            &security_runtime_state,
+            std::path::Path::new(&projection_db_path),
+            operator_auth_required,
+            service_health_checker.worker_state(),
         );
 
         // Prune: Empfange Cutoff von Operator-API, arbeite 1 Batch/Tick ab
@@ -3158,7 +3185,12 @@ mod tests {
             Arc::new(RwLock::new(
                 crate::platform_controlplane::PlatformStateSnapshot::default(),
             )),
+            Arc::new(RwLock::new(
+                crate::runtime_health::RuntimeHealthSnapshot::default(),
+            )),
             Arc::new(RwLock::new(HashMap::new())),
+            String::new(),
+            false,
             None,
             None,
             #[cfg(feature = "llm")]
@@ -3235,7 +3267,12 @@ mod tests {
                 Arc::new(RwLock::new(
                     crate::platform_controlplane::PlatformStateSnapshot::default(),
                 )),
+                Arc::new(RwLock::new(
+                    crate::runtime_health::RuntimeHealthSnapshot::default(),
+                )),
                 Arc::new(RwLock::new(HashMap::new())),
+                String::new(),
+                false,
                 None,
                 None,
                 #[cfg(feature = "llm")]
@@ -3329,7 +3366,12 @@ mod tests {
                 Arc::new(RwLock::new(
                     crate::platform_controlplane::PlatformStateSnapshot::default(),
                 )),
+                Arc::new(RwLock::new(
+                    crate::runtime_health::RuntimeHealthSnapshot::default(),
+                )),
                 Arc::new(RwLock::new(HashMap::new())),
+                String::new(),
+                false,
                 None,
                 None,
                 #[cfg(feature = "llm")]
@@ -3431,7 +3473,12 @@ mod tests {
                 Arc::new(RwLock::new(
                     crate::platform_controlplane::PlatformStateSnapshot::default(),
                 )),
+                Arc::new(RwLock::new(
+                    crate::runtime_health::RuntimeHealthSnapshot::default(),
+                )),
                 Arc::new(RwLock::new(HashMap::new())),
+                String::new(),
+                false,
                 None,
                 None,
                 #[cfg(feature = "llm")]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -1460,6 +1460,7 @@ fn run_runtime_reconcile(
     request: RuntimeReconcileRequest,
     respawn_backoff: &mut RespawnBackoffTracker,
 ) -> RuntimeReconcileResponse {
+    let elapsed_started = std::time::Instant::now();
     let previous = ctx
         .runtime_health
         .read()
@@ -1823,6 +1824,7 @@ fn run_runtime_reconcile(
         repaired_agents,
         blocked_agents,
         errors,
+        elapsed_us: elapsed_started.elapsed().as_micros() as u64,
     }
 }
 
@@ -2533,6 +2535,7 @@ fn ecs_tick_loop(
                     request,
                     response_tx,
                 } => {
+                    let enqueue_started = std::time::Instant::now();
                     for _ in 0..request.count {
                         platform_cp.enqueue_control_command(
                             crate::platform_controlplane::PlatformControlCommand::AnalyzeNow,
@@ -2572,12 +2575,16 @@ fn ecs_tick_loop(
                     } else {
                         "bounded controlplane queue exercised; llm feature disabled"
                     };
+                    let enqueue_elapsed_ns = enqueue_started.elapsed().as_nanos() as u64;
                     let _ = response_tx.send(RuntimeAnalysisFloodTestResponse {
                         accepted: true,
                         requested: request.count,
                         queue_depth: stats.depth,
                         dropped_total: stats.dropped_total,
                         coalesced_total: stats.coalesced_total,
+                        enqueue_elapsed_us: enqueue_elapsed_ns / 1_000,
+                        enqueue_per_request_ns: enqueue_elapsed_ns
+                            / u64::from(request.count.max(1)),
                         note: note.to_string(),
                     });
                 }
@@ -2622,12 +2629,15 @@ fn ecs_tick_loop(
                         .find(|cfg| cfg.identity.id == request.agent_id)
                     {
                         Some(agent_cfg) => {
+                            let bookkeeping_started = std::time::Instant::now();
                             let pid_before = tracked_pid_for_agent(
                                 agent_id,
                                 &sandbox_handles,
                                 &agent_processes,
                                 &security_runtime_state,
                             );
+                            let bookkeeping_elapsed_ns =
+                                bookkeeping_started.elapsed().as_nanos() as u64;
                             let pre_suspend_result = match request.mode.as_str() {
                                 "sigstop" => suspend_agent_cgroup_processes(
                                     &agent_cfg.identity.name,
@@ -2673,6 +2683,7 @@ fn ecs_tick_loop(
                                         runtime_present_after: result.runtime_present_after,
                                         security_runtime_present_after: result
                                             .security_runtime_present_after,
+                                        bookkeeping_elapsed_ns,
                                         note: "fast_path_restart_executed_without_shift_wait"
                                             .to_string(),
                                     }
@@ -2700,6 +2711,7 @@ fn ecs_tick_loop(
                                             .read()
                                             .map(|state| state.contains_key(&request.agent_id))
                                             .unwrap_or(false),
+                                        bookkeeping_elapsed_ns,
                                         note: error.to_string(),
                                     }
                                 }
@@ -2716,6 +2728,7 @@ fn ecs_tick_loop(
                             pid_after: None,
                             runtime_present_after: false,
                             security_runtime_present_after: false,
+                            bookkeeping_elapsed_ns: 0,
                             note: "agent_id unbekannt".to_string(),
                         },
                     };

--- a/services/sentinel-daemon/src/platform_controlplane/llm_analyzer.rs
+++ b/services/sentinel-daemon/src/platform_controlplane/llm_analyzer.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::mpsc as std_mpsc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -19,13 +19,12 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use super::{
-    metrics::PlatformMetrics, PlatformAnalysisCommand, PlatformAnalysisRequest,
+    metrics::PlatformMetrics, AnalysisQueueStats, PlatformAnalysisCommand, PlatformAnalysisRequest,
     PlatformControlCommand,
 };
 use crate::config::PlatformControlplaneConfig;
 
 const DEFAULT_GATEWAY_URL: &str = "http://localhost:8080";
-const DEFAULT_CHANNEL_CAPACITY: usize = 16;
 const RECENT_EVENT_SCAN_LIMIT: usize = 256;
 
 #[derive(Debug, Clone)]
@@ -48,7 +47,7 @@ impl LlmAnalyzerConfig {
             prompt_template: config.llm_prompt_template.clone(),
             max_context_events: config.llm_max_context_events.max(1),
             max_failed_interventions: config.llm_max_failed_interventions.max(1),
-            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            channel_capacity: config.llm_analysis_channel_capacity.max(1),
         }
     }
 }
@@ -62,19 +61,23 @@ impl Default for LlmAnalyzerConfig {
             prompt_template: "platform-controlplane-default".to_string(),
             max_context_events: 10,
             max_failed_interventions: 3,
-            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            channel_capacity: 16,
         }
     }
 }
 
 #[derive(Clone)]
 pub struct PlatformLlmAnalyzerHandle {
-    tx: Option<mpsc::UnboundedSender<PlatformAnalysisRequest>>,
+    tx: Option<mpsc::Sender<PlatformAnalysisRequest>>,
+    queue_stats: Arc<Mutex<AnalysisQueueStats>>,
 }
 
 impl PlatformLlmAnalyzerHandle {
     pub fn disabled() -> Self {
-        Self { tx: None }
+        Self {
+            tx: None,
+            queue_stats: Arc::new(Mutex::new(AnalysisQueueStats::default())),
+        }
     }
 
     pub fn spawn(
@@ -95,7 +98,9 @@ impl PlatformLlmAnalyzerHandle {
             }
         };
 
-        let (tx, mut rx) = mpsc::unbounded_channel::<PlatformAnalysisRequest>();
+        let (tx, mut rx) = mpsc::channel::<PlatformAnalysisRequest>(config.channel_capacity.max(1));
+        let queue_stats = Arc::new(Mutex::new(AnalysisQueueStats::default()));
+        let worker_queue_stats = Arc::clone(&queue_stats);
         let worker_config = config.clone();
         tokio::spawn(async move {
             info!(
@@ -106,6 +111,9 @@ impl PlatformLlmAnalyzerHandle {
             );
 
             while let Some(request) = rx.recv().await {
+                if let Ok(mut stats) = worker_queue_stats.lock() {
+                    stats.depth = stats.depth.saturating_sub(1);
+                }
                 if let Err(error) = analyze_and_dispatch(
                     &client,
                     &worker_config,
@@ -122,17 +130,44 @@ impl PlatformLlmAnalyzerHandle {
             info!("Platform LLM Analyzer beendet");
         });
 
-        Self { tx: Some(tx) }
+        Self {
+            tx: Some(tx),
+            queue_stats,
+        }
     }
 
     pub fn is_enabled(&self) -> bool {
         self.tx.is_some()
     }
 
+    pub fn queue_stats(&self) -> AnalysisQueueStats {
+        self.queue_stats
+            .lock()
+            .map(|stats| *stats)
+            .unwrap_or_default()
+    }
+
     pub fn enqueue(&self, request: PlatformAnalysisRequest) -> Result<()> {
         let tx = self.tx.as_ref().context("platform llm analyzer disabled")?;
-        tx.send(request)
-            .map_err(|_| anyhow!("platform llm analyzer worker not running"))
+        if let Ok(mut stats) = self.queue_stats.lock() {
+            stats.depth = stats.depth.saturating_add(1);
+        }
+        match tx.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                if let Ok(mut stats) = self.queue_stats.lock() {
+                    stats.depth = stats.depth.saturating_sub(1);
+                    stats.dropped_total = stats.dropped_total.saturating_add(1);
+                }
+                Err(anyhow!("platform llm analyzer queue full"))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                if let Ok(mut stats) = self.queue_stats.lock() {
+                    stats.depth = stats.depth.saturating_sub(1);
+                }
+                Err(anyhow!("platform llm analyzer worker not running"))
+            }
+        }
     }
 }
 
@@ -417,8 +452,6 @@ fn serialize_metrics(metrics: &PlatformMetrics) -> Value {
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -640,5 +673,23 @@ mod tests {
             command,
             PlatformControlCommand::ApplyAnalysis(PlatformAnalysisCommand { .. })
         ));
+    }
+
+    #[test]
+    fn enqueue_drops_when_bounded_queue_is_full() {
+        let (tx, _rx) = mpsc::channel(1);
+        let handle = PlatformLlmAnalyzerHandle {
+            tx: Some(tx),
+            queue_stats: Arc::new(Mutex::new(AnalysisQueueStats::default())),
+        };
+
+        handle.enqueue(request("scheduled")).unwrap();
+        let error = handle.enqueue(request("manual")).unwrap_err();
+
+        let stats = handle.queue_stats();
+        assert!(error.to_string().contains("queue full"));
+        assert_eq!(stats.depth, 1);
+        assert_eq!(stats.dropped_total, 1);
+        assert_eq!(stats.coalesced_total, 0);
     }
 }

--- a/services/sentinel-daemon/src/platform_controlplane/mod.rs
+++ b/services/sentinel-daemon/src/platform_controlplane/mod.rs
@@ -12,7 +12,7 @@ pub mod rules;
 pub mod verify;
 
 use anyhow::{anyhow, Context, Result};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 
 use sentinel_common::{DomainEvent, DomainEventPayload};
 use sentinel_limbo::EventStore;
@@ -138,7 +138,14 @@ pub struct PlatformCycleOutput {
     pub analysis_requests: Vec<PlatformAnalysisRequest>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnalysisQueueStats {
+    pub depth: usize,
+    pub dropped_total: u64,
+    pub coalesced_total: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum QueuedAnalysisTrigger {
     Manual,
     Test(PlatformTriggerTestCommand),
@@ -152,7 +159,9 @@ pub struct PlatformControlplane {
     write_rate_baselines: HashMap<String, f64>,
     unresolved_counts: HashMap<String, u32>,
     failed_interventions: Vec<FailedIntervention>,
-    queued_analysis_triggers: Vec<QueuedAnalysisTrigger>,
+    queued_analysis_triggers: VecDeque<QueuedAnalysisTrigger>,
+    analysis_queue_dropped_total: u64,
+    analysis_queue_coalesced_total: u64,
     last_analysis_tick: Option<u64>,
     last_analysis_trigger: Option<String>,
     last_scheduled_analysis_tick: Option<u64>,
@@ -168,7 +177,9 @@ impl PlatformControlplane {
             write_rate_baselines: HashMap::new(),
             unresolved_counts: HashMap::new(),
             failed_interventions: Vec::new(),
-            queued_analysis_triggers: Vec::new(),
+            queued_analysis_triggers: VecDeque::new(),
+            analysis_queue_dropped_total: 0,
+            analysis_queue_coalesced_total: 0,
             last_analysis_tick: None,
             last_analysis_trigger: None,
             last_scheduled_analysis_tick: None,
@@ -184,13 +195,21 @@ impl PlatformControlplane {
     /// Queue fuer manuelle oder deterministische Test-Trigger.
     pub fn enqueue_control_command(&mut self, command: PlatformControlCommand) {
         match command {
-            PlatformControlCommand::AnalyzeNow => self
-                .queued_analysis_triggers
-                .push(QueuedAnalysisTrigger::Manual),
-            PlatformControlCommand::TriggerTest(command) => self
-                .queued_analysis_triggers
-                .push(QueuedAnalysisTrigger::Test(command)),
+            PlatformControlCommand::AnalyzeNow => {
+                self.enqueue_analysis_trigger(QueuedAnalysisTrigger::Manual)
+            }
+            PlatformControlCommand::TriggerTest(command) => {
+                self.enqueue_analysis_trigger(QueuedAnalysisTrigger::Test(command))
+            }
             PlatformControlCommand::ApplyAnalysis(_) => {}
+        }
+    }
+
+    pub fn analysis_queue_stats(&self) -> AnalysisQueueStats {
+        AnalysisQueueStats {
+            depth: self.queued_analysis_triggers.len(),
+            dropped_total: self.analysis_queue_dropped_total,
+            coalesced_total: self.analysis_queue_coalesced_total,
         }
     }
 
@@ -216,6 +235,21 @@ impl PlatformControlplane {
 
     pub fn last_scheduled_analysis_tick(&self) -> Option<u64> {
         self.last_scheduled_analysis_tick
+    }
+
+    fn enqueue_analysis_trigger(&mut self, trigger: QueuedAnalysisTrigger) {
+        if self.queued_analysis_triggers.contains(&trigger) {
+            self.analysis_queue_coalesced_total =
+                self.analysis_queue_coalesced_total.saturating_add(1);
+            return;
+        }
+
+        let capacity = self.config.llm_trigger_queue_capacity.max(1);
+        if self.queued_analysis_triggers.len() >= capacity {
+            self.queued_analysis_triggers.pop_front();
+            self.analysis_queue_dropped_total = self.analysis_queue_dropped_total.saturating_add(1);
+        }
+        self.queued_analysis_triggers.push_back(trigger);
     }
 
     pub fn apply_threshold_override(&mut self, key: &str, value: serde_json::Value) -> Result<()> {
@@ -739,6 +773,46 @@ mod tests {
         assert_eq!(output.analysis_requests[0].trigger, "manual");
         assert_eq!(cp.last_analysis_trigger(), Some("manual"));
         assert_eq!(cp.last_analysis_tick(), Some(1));
+    }
+
+    #[test]
+    fn test_manual_trigger_queue_coalesces_duplicates() {
+        let mut cp = PlatformControlplane::new(PlatformControlplaneConfig {
+            llm_trigger_queue_capacity: 16,
+            ..PlatformControlplaneConfig::default()
+        });
+
+        cp.enqueue_control_command(PlatformControlCommand::AnalyzeNow);
+        cp.enqueue_control_command(PlatformControlCommand::AnalyzeNow);
+
+        let stats = cp.analysis_queue_stats();
+        assert_eq!(stats.depth, 1);
+        assert_eq!(stats.dropped_total, 0);
+        assert_eq!(stats.coalesced_total, 1);
+    }
+
+    #[test]
+    fn test_test_trigger_queue_drops_when_capacity_is_exceeded() {
+        let mut cp = PlatformControlplane::new(PlatformControlplaneConfig {
+            llm_trigger_queue_capacity: 2,
+            ..PlatformControlplaneConfig::default()
+        });
+
+        for idx in 0..3 {
+            cp.enqueue_control_command(PlatformControlCommand::TriggerTest(
+                PlatformTriggerTestCommand {
+                    trigger: format!("manual_{idx}"),
+                    rule_name: None,
+                    target: None,
+                    count: None,
+                },
+            ));
+        }
+
+        let stats = cp.analysis_queue_stats();
+        assert_eq!(stats.depth, 2);
+        assert_eq!(stats.dropped_total, 1);
+        assert_eq!(stats.coalesced_total, 0);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -47,6 +47,10 @@ pub enum RuntimeControlCommand {
         request: RuntimeReconcileRequest,
         response_tx: mpsc::SyncSender<RuntimeReconcileResponse>,
     },
+    PanicTest {
+        request: RuntimePanicTestRequest,
+        response_tx: mpsc::SyncSender<RuntimePanicTestResponse>,
+    },
     StallRestartTest {
         request: RuntimeStallRestartTestRequest,
         response_tx: mpsc::SyncSender<RuntimeStallRestartTestResponse>,
@@ -72,6 +76,18 @@ pub struct RuntimeStallRestartTestResponse {
     pub pid_after: Option<u32>,
     pub runtime_present_after: bool,
     pub security_runtime_present_after: bool,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimePanicTestRequest {
+    pub worker: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimePanicTestResponse {
+    pub accepted: bool,
+    pub worker: String,
     pub note: String,
 }
 

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -30,6 +30,14 @@ pub struct RuntimeReconcileResponse {
     pub respawned_agents: usize,
     pub respawn_skipped_backoff: usize,
     pub respawn_blocked_agents: usize,
+    #[serde(default)]
+    pub projection_drift_before: bool,
+    #[serde(default)]
+    pub projection_drift_after: bool,
+    #[serde(default)]
+    pub projection_restart_attempted: bool,
+    #[serde(default)]
+    pub projection_restart_succeeded: bool,
     pub projection_rebuild_requested: bool,
     pub respawn_failures_total: u64,
     pub repair_last_status: String,
@@ -173,10 +181,11 @@ impl RespawnBackoffTracker {
     }
 }
 
-pub fn write_projection_rebuild_request(data_dir: &Path, tick: u64) -> Result<()> {
+pub fn write_projection_rebuild_request(data_dir: &Path, tick: u64, reason: &str) -> Result<()> {
     let request_path = data_dir.join(".projection-rebuild-request");
     let payload = serde_json::json!({
         "requested_by": "runtime_reconcile",
+        "reason": reason,
         "tick": tick,
     });
     std::fs::write(&request_path, serde_json::to_vec_pretty(&payload)?).with_context(|| {
@@ -227,10 +236,11 @@ mod tests {
     #[test]
     fn write_projection_rebuild_request_persists_request_file() {
         let dir = tempfile::tempdir().unwrap();
-        write_projection_rebuild_request(dir.path(), 77).unwrap();
+        write_projection_rebuild_request(dir.path(), 77, "projection_drift").unwrap();
         let payload =
             std::fs::read_to_string(dir.path().join(".projection-rebuild-request")).unwrap();
         assert!(payload.contains("\"requested_by\": \"runtime_reconcile\""));
+        assert!(payload.contains("\"reason\": \"projection_drift\""));
         assert!(payload.contains("\"tick\": 77"));
     }
 }

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -1,0 +1,170 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::mpsc;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeReconcileRequest {
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub projection_rebuild: bool,
+    #[serde(default)]
+    pub respawn_missing: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeReconcileResponse {
+    pub accepted: bool,
+    pub dry_run: bool,
+    pub current_shift: u8,
+    pub stale_agents_before: usize,
+    pub stale_agents_after: usize,
+    pub orphan_cgroups_before: usize,
+    pub orphan_cgroups_after: usize,
+    pub security_snapshots_removed: usize,
+    pub unexpected_runtime_removed: usize,
+    pub orphan_cgroups_removed: usize,
+    pub respawned_agents: usize,
+    pub respawn_skipped_backoff: usize,
+    pub respawn_blocked_agents: usize,
+    pub projection_rebuild_requested: bool,
+    pub respawn_failures_total: u64,
+    pub repair_last_status: String,
+    #[serde(default)]
+    pub repaired_agents: Vec<String>,
+    #[serde(default)]
+    pub blocked_agents: Vec<String>,
+    #[serde(default)]
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum RuntimeControlCommand {
+    Reconcile {
+        request: RuntimeReconcileRequest,
+        response_tx: mpsc::SyncSender<RuntimeReconcileResponse>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RespawnRetryDecision {
+    Ready,
+    BackoffActive { retry_at_tick: u64 },
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RespawnAttemptState {
+    failures: u8,
+    next_retry_tick: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct RespawnBackoffTracker {
+    states: HashMap<u16, RespawnAttemptState>,
+    max_failures: u8,
+}
+
+impl RespawnBackoffTracker {
+    pub fn new(max_failures: u8) -> Self {
+        Self {
+            states: HashMap::new(),
+            max_failures,
+        }
+    }
+
+    pub fn decision(&self, agent_id: u16, current_tick: u64) -> RespawnRetryDecision {
+        match self.states.get(&agent_id).copied() {
+            None => RespawnRetryDecision::Ready,
+            Some(state) if state.failures >= self.max_failures => RespawnRetryDecision::Blocked,
+            Some(state) if current_tick < state.next_retry_tick => RespawnRetryDecision::BackoffActive {
+                retry_at_tick: state.next_retry_tick,
+            },
+            Some(_) => RespawnRetryDecision::Ready,
+        }
+    }
+
+    pub fn record_success(&mut self, agent_id: u16) {
+        self.states.remove(&agent_id);
+    }
+
+    pub fn record_failure(&mut self, agent_id: u16, current_tick: u64) -> RespawnRetryDecision {
+        let entry = self.states.entry(agent_id).or_insert(RespawnAttemptState {
+            failures: 0,
+            next_retry_tick: current_tick,
+        });
+        entry.failures = entry.failures.saturating_add(1);
+        if entry.failures >= self.max_failures {
+            entry.next_retry_tick = current_tick.saturating_add(4);
+            RespawnRetryDecision::Blocked
+        } else {
+            let backoff_ticks = 1u64 << (entry.failures - 1);
+            entry.next_retry_tick = current_tick.saturating_add(backoff_ticks);
+            RespawnRetryDecision::BackoffActive {
+                retry_at_tick: entry.next_retry_tick,
+            }
+        }
+    }
+}
+
+pub fn write_projection_rebuild_request(data_dir: &Path, tick: u64) -> Result<()> {
+    let request_path = data_dir.join(".projection-rebuild-request");
+    let payload = serde_json::json!({
+        "requested_by": "runtime_reconcile",
+        "tick": tick,
+    });
+    std::fs::write(&request_path, serde_json::to_vec_pretty(&payload)?).with_context(|| {
+        format!(
+            "Projection-Rebuild-Request konnte nicht geschrieben werden: {}",
+            request_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn respawn_backoff_tracker_applies_exponential_backoff_until_blocked() {
+        let mut tracker = RespawnBackoffTracker::new(3);
+
+        assert_eq!(tracker.decision(7, 10), RespawnRetryDecision::Ready);
+        assert_eq!(
+            tracker.record_failure(7, 10),
+            RespawnRetryDecision::BackoffActive { retry_at_tick: 11 }
+        );
+        assert_eq!(
+            tracker.decision(7, 10),
+            RespawnRetryDecision::BackoffActive { retry_at_tick: 11 }
+        );
+        assert_eq!(tracker.decision(7, 11), RespawnRetryDecision::Ready);
+
+        assert_eq!(
+            tracker.record_failure(7, 11),
+            RespawnRetryDecision::BackoffActive { retry_at_tick: 13 }
+        );
+        assert_eq!(tracker.decision(7, 12), RespawnRetryDecision::BackoffActive { retry_at_tick: 13 });
+        assert_eq!(tracker.decision(7, 13), RespawnRetryDecision::Ready);
+
+        assert_eq!(tracker.record_failure(7, 13), RespawnRetryDecision::Blocked);
+        assert_eq!(tracker.decision(7, 13), RespawnRetryDecision::Blocked);
+
+        tracker.record_success(7);
+        assert_eq!(tracker.decision(7, 14), RespawnRetryDecision::Ready);
+    }
+
+    #[test]
+    fn write_projection_rebuild_request_persists_request_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write_projection_rebuild_request(dir.path(), 77).unwrap();
+        let payload = std::fs::read_to_string(dir.path().join(".projection-rebuild-request"))
+            .unwrap();
+        assert!(payload.contains("\"requested_by\": \"runtime_reconcile\""));
+        assert!(payload.contains("\"tick\": 77"));
+    }
+}

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -47,6 +47,10 @@ pub enum RuntimeControlCommand {
         request: RuntimeReconcileRequest,
         response_tx: mpsc::SyncSender<RuntimeReconcileResponse>,
     },
+    AnalysisFloodTest {
+        request: RuntimeAnalysisFloodTestRequest,
+        response_tx: mpsc::SyncSender<RuntimeAnalysisFloodTestResponse>,
+    },
     PanicTest {
         request: RuntimePanicTestRequest,
         response_tx: mpsc::SyncSender<RuntimePanicTestResponse>,
@@ -55,6 +59,21 @@ pub enum RuntimeControlCommand {
         request: RuntimeStallRestartTestRequest,
         response_tx: mpsc::SyncSender<RuntimeStallRestartTestResponse>,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeAnalysisFloodTestRequest {
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeAnalysisFloodTestResponse {
+    pub accepted: bool,
+    pub requested: u32,
+    pub queue_depth: usize,
+    pub dropped_total: u64,
+    pub coalesced_total: u64,
+    pub note: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -47,6 +47,8 @@ pub struct RuntimeReconcileResponse {
     pub blocked_agents: Vec<String>,
     #[serde(default)]
     pub errors: Vec<String>,
+    #[serde(default)]
+    pub elapsed_us: u64,
 }
 
 #[derive(Debug)]
@@ -81,6 +83,10 @@ pub struct RuntimeAnalysisFloodTestResponse {
     pub queue_depth: usize,
     pub dropped_total: u64,
     pub coalesced_total: u64,
+    #[serde(default)]
+    pub enqueue_elapsed_us: u64,
+    #[serde(default)]
+    pub enqueue_per_request_ns: u64,
     pub note: String,
 }
 
@@ -103,6 +109,8 @@ pub struct RuntimeStallRestartTestResponse {
     pub pid_after: Option<u32>,
     pub runtime_present_after: bool,
     pub security_runtime_present_after: bool,
+    #[serde(default)]
+    pub bookkeeping_elapsed_ns: u64,
     pub note: String,
 }
 

--- a/services/sentinel-daemon/src/runtime_control.rs
+++ b/services/sentinel-daemon/src/runtime_control.rs
@@ -47,6 +47,32 @@ pub enum RuntimeControlCommand {
         request: RuntimeReconcileRequest,
         response_tx: mpsc::SyncSender<RuntimeReconcileResponse>,
     },
+    StallRestartTest {
+        request: RuntimeStallRestartTestRequest,
+        response_tx: mpsc::SyncSender<RuntimeStallRestartTestResponse>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeStallRestartTestRequest {
+    pub agent_id: u16,
+    pub mode: String,
+    pub stall_secs: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeStallRestartTestResponse {
+    pub accepted: bool,
+    pub agent_id: u16,
+    pub aggregate_id: String,
+    pub agent_name: String,
+    pub mode: String,
+    pub stall_secs: u64,
+    pub pid_before: Option<u32>,
+    pub pid_after: Option<u32>,
+    pub runtime_present_after: bool,
+    pub security_runtime_present_after: bool,
+    pub note: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,9 +106,11 @@ impl RespawnBackoffTracker {
         match self.states.get(&agent_id).copied() {
             None => RespawnRetryDecision::Ready,
             Some(state) if state.failures >= self.max_failures => RespawnRetryDecision::Blocked,
-            Some(state) if current_tick < state.next_retry_tick => RespawnRetryDecision::BackoffActive {
-                retry_at_tick: state.next_retry_tick,
-            },
+            Some(state) if current_tick < state.next_retry_tick => {
+                RespawnRetryDecision::BackoffActive {
+                    retry_at_tick: state.next_retry_tick,
+                }
+            }
             Some(_) => RespawnRetryDecision::Ready,
         }
     }
@@ -148,7 +176,10 @@ mod tests {
             tracker.record_failure(7, 11),
             RespawnRetryDecision::BackoffActive { retry_at_tick: 13 }
         );
-        assert_eq!(tracker.decision(7, 12), RespawnRetryDecision::BackoffActive { retry_at_tick: 13 });
+        assert_eq!(
+            tracker.decision(7, 12),
+            RespawnRetryDecision::BackoffActive { retry_at_tick: 13 }
+        );
         assert_eq!(tracker.decision(7, 13), RespawnRetryDecision::Ready);
 
         assert_eq!(tracker.record_failure(7, 13), RespawnRetryDecision::Blocked);
@@ -162,8 +193,8 @@ mod tests {
     fn write_projection_rebuild_request_persists_request_file() {
         let dir = tempfile::tempdir().unwrap();
         write_projection_rebuild_request(dir.path(), 77).unwrap();
-        let payload = std::fs::read_to_string(dir.path().join(".projection-rebuild-request"))
-            .unwrap();
+        let payload =
+            std::fs::read_to_string(dir.path().join(".projection-rebuild-request")).unwrap();
         assert!(payload.contains("\"requested_by\": \"runtime_reconcile\""));
         assert!(payload.contains("\"tick\": 77"));
     }

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -136,9 +136,9 @@ pub fn build_runtime_health_snapshot(
         });
     }
     for snapshot in security_state.values() {
-        agent_catalog.entry(snapshot.agent_id).or_insert_with(|| {
-            (snapshot.aggregate_id.clone(), snapshot.agent_name.clone())
-        });
+        agent_catalog
+            .entry(snapshot.agent_id)
+            .or_insert_with(|| (snapshot.aggregate_id.clone(), snapshot.agent_name.clone()));
     }
 
     let mut stale_runtime_entries = 0usize;
@@ -165,7 +165,11 @@ pub fn build_runtime_health_snapshot(
         if tracked_pid_state.as_deref() == Some("Z") {
             zombie_tracked_pids += 1;
         }
-        let cgroup_live_pid_count = cgroup_snapshot.live_pid_counts.get(&name).copied().unwrap_or(0);
+        let cgroup_live_pid_count = cgroup_snapshot
+            .live_pid_counts
+            .get(&name)
+            .copied()
+            .unwrap_or(0);
         let projection_present = projection_store
             .as_ref()
             .and_then(|store| store.get_agent(agent_id).ok().flatten())
@@ -294,11 +298,13 @@ pub fn build_runtime_health_snapshot(
         snapshot.respawn_failures = previous.respawn_failures;
         snapshot.last_repair_error = previous.last_repair_error.clone();
         snapshot.repair_last_status = previous.repair_last_status.clone().or_else(|| {
-            Some(if snapshot.stale_runtime_entries == 0 && snapshot.orphan_cgroups == 0 {
-                "healthy".to_string()
-            } else {
-                "drift_detected".to_string()
-            })
+            Some(
+                if snapshot.stale_runtime_entries == 0 && snapshot.orphan_cgroups == 0 {
+                    "healthy".to_string()
+                } else {
+                    "drift_detected".to_string()
+                },
+            )
         });
     } else {
         snapshot.repair_last_status = Some(

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use sentinel_common::agent_config::AgentConfig;
 use sentinel_common::AgentId;
@@ -72,6 +73,8 @@ pub struct RuntimeHealthSnapshot {
     pub repair_last_status: Option<String>,
     pub operator_auth_required: bool,
     #[serde(default)]
+    pub snapshot_build_elapsed_us: u64,
+    #[serde(default)]
     pub agents: Vec<RuntimeHealthAgentSnapshot>,
 }
 
@@ -89,6 +92,7 @@ pub fn build_runtime_health_snapshot(
     service_health_state: ServiceHealthWorkerSnapshot,
     previous: Option<&RuntimeHealthSnapshot>,
 ) -> RuntimeHealthSnapshot {
+    let snapshot_started = Instant::now();
     let expected_agents = agents_for_shift(all_agents, current_shift);
     let expected_active_ids = expected_agents
         .iter()
@@ -291,6 +295,7 @@ pub fn build_runtime_health_snapshot(
         last_repair_error: None,
         repair_last_status: None,
         operator_auth_required,
+        snapshot_build_elapsed_us: 0,
         agents,
     };
 
@@ -321,6 +326,7 @@ pub fn build_runtime_health_snapshot(
         );
     }
 
+    snapshot.snapshot_build_elapsed_us = snapshot_started.elapsed().as_micros() as u64;
     snapshot
 }
 

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -1,0 +1,474 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+
+use sentinel_common::agent_config::AgentConfig;
+use sentinel_common::AgentId;
+use sentinel_projection::ReadModelStore;
+use sentinel_runtime::RuntimeOrchestrator;
+use sentinel_sandbox::cgroups::list_pids_in_cgroup;
+use sentinel_sandbox::{AgentProcess, SandboxHandle};
+use serde::{Deserialize, Serialize};
+
+use crate::operator_api::SharedSecurityRuntimeState;
+use crate::service_health::ServiceHealthWorkerSnapshot;
+use crate::shift::agents_for_shift;
+
+const CGROUP_ROOT: &str = "/sys/fs/cgroup/sentinel";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeWorkerState {
+    pub running: bool,
+    #[serde(default)]
+    pub restart_count: u64,
+    #[serde(default)]
+    pub last_error: Option<String>,
+    #[serde(default)]
+    pub thread_name: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeHealthAgentSnapshot {
+    pub agent_id: u16,
+    pub aggregate_id: String,
+    pub name: String,
+    pub runtime_present: bool,
+    pub projection_present: bool,
+    pub tracked_pid: Option<u32>,
+    pub tracked_pid_alive: bool,
+    pub tracked_pid_state: Option<String>,
+    pub cgroup_live_pid_count: usize,
+    pub security_runtime_present: bool,
+    #[serde(default)]
+    pub last_repair_status: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeHealthSnapshot {
+    pub current_shift: u8,
+    pub expected_active_agents: usize,
+    pub runtime_agents: usize,
+    pub projection_agents: usize,
+    pub security_runtime_entries: usize,
+    pub sandbox_handles: usize,
+    pub tracked_processes: usize,
+    pub live_cgroup_dirs: usize,
+    pub stale_runtime_entries: usize,
+    pub orphan_cgroups: usize,
+    pub zombie_tracked_pids: usize,
+    #[serde(default)]
+    pub worker_states: BTreeMap<String, RuntimeWorkerState>,
+    pub analysis_queue_depth: usize,
+    pub analysis_queue_dropped_total: u64,
+    pub analysis_queue_coalesced_total: u64,
+    pub reconcile_runs_total: u64,
+    pub reconcile_repairs_total: u64,
+    pub respawn_failures: u64,
+    #[serde(default)]
+    pub last_repair_error: Option<String>,
+    #[serde(default)]
+    pub repair_last_status: Option<String>,
+    pub operator_auth_required: bool,
+    #[serde(default)]
+    pub agents: Vec<RuntimeHealthAgentSnapshot>,
+}
+
+pub type SharedRuntimeHealthState = Arc<RwLock<RuntimeHealthSnapshot>>;
+
+pub fn build_runtime_health_snapshot(
+    all_agents: &[AgentConfig],
+    current_shift: u8,
+    runtime_orch: &RuntimeOrchestrator,
+    sandbox_handles: &HashMap<AgentId, SandboxHandle>,
+    agent_processes: &HashMap<AgentId, AgentProcess>,
+    security_runtime_state: &SharedSecurityRuntimeState,
+    projection_db_path: &Path,
+    operator_auth_required: bool,
+    service_health_state: ServiceHealthWorkerSnapshot,
+    previous: Option<&RuntimeHealthSnapshot>,
+) -> RuntimeHealthSnapshot {
+    let expected_agents = agents_for_shift(all_agents, current_shift);
+    let expected_active_ids = expected_agents
+        .iter()
+        .map(|cfg| cfg.identity.id)
+        .collect::<BTreeSet<_>>();
+    let expected_active_agents = expected_active_ids.len();
+    let security_state = security_runtime_state
+        .read()
+        .map(|state| state.clone())
+        .unwrap_or_default();
+    let cgroup_snapshot = collect_cgroup_snapshot();
+    let projection_store: Option<ReadModelStore> = projection_db_path
+        .to_str()
+        .and_then(|path| ReadModelStore::open(path).ok());
+    let projection_agents = projection_store
+        .as_ref()
+        .and_then(|store| store.active_agent_count().ok())
+        .unwrap_or_default()
+        .max(0) as usize;
+    let runtime_agents = runtime_orch.agent_count();
+    let previous_agent_status = previous
+        .map(|snapshot| {
+            snapshot
+                .agents
+                .iter()
+                .map(|agent| (agent.agent_id, agent.last_repair_status.clone()))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    let mut agent_catalog = BTreeMap::<u16, (String, String)>::new();
+    for cfg in expected_agents {
+        agent_catalog.insert(
+            cfg.identity.id,
+            (
+                format!("AGENT-{:02}", cfg.identity.id),
+                cfg.identity.name.clone(),
+            ),
+        );
+    }
+    for (agent_id, handle) in runtime_orch.agents() {
+        agent_catalog.entry(agent_id.0).or_insert_with(|| {
+            (
+                format!("AGENT-{:02}", agent_id.0),
+                handle.identity.name.clone(),
+            )
+        });
+    }
+    for snapshot in security_state.values() {
+        agent_catalog.entry(snapshot.agent_id).or_insert_with(|| {
+            (snapshot.aggregate_id.clone(), snapshot.agent_name.clone())
+        });
+    }
+
+    let mut stale_runtime_entries = 0usize;
+    let mut zombie_tracked_pids = 0usize;
+    let mut agents = Vec::with_capacity(agent_catalog.len());
+
+    for (agent_id, (aggregate_id, name)) in agent_catalog {
+        let expected_active = expected_active_ids.contains(&agent_id);
+        let runtime_present = runtime_orch.agents().contains_key(&AgentId(agent_id));
+        let security_snapshot = security_state.get(&agent_id);
+        let security_runtime_present = security_snapshot.is_some();
+        let sandbox_handle = sandbox_handles.get(&AgentId(agent_id));
+        let agent_process = agent_processes.get(&AgentId(agent_id));
+        let tracked_pid = security_snapshot
+            .and_then(|snapshot| snapshot.bwrap_pid)
+            .or_else(|| sandbox_handle.and_then(|handle| handle.bwrap_pid))
+            .or_else(|| agent_process.map(|proc| proc.pid));
+        let tracked_pid_state = tracked_pid
+            .and_then(read_proc_state)
+            .map(|state| state.to_string());
+        let tracked_pid_alive = tracked_pid_state
+            .as_deref()
+            .is_some_and(|state| !matches!(state, "Z" | "X"));
+        if tracked_pid_state.as_deref() == Some("Z") {
+            zombie_tracked_pids += 1;
+        }
+        let cgroup_live_pid_count = cgroup_snapshot.live_pid_counts.get(&name).copied().unwrap_or(0);
+        let projection_present = projection_store
+            .as_ref()
+            .and_then(|store| store.get_agent(agent_id).ok().flatten())
+            .is_some_and(|view| view.status == "active");
+        let healthy = runtime_present
+            && projection_present
+            && security_runtime_present
+            && tracked_pid_alive
+            && cgroup_live_pid_count > 0;
+        let unexpected_extra = !expected_active
+            && (runtime_present
+                || projection_present
+                || security_runtime_present
+                || tracked_pid_alive
+                || cgroup_live_pid_count > 0);
+        let stale = if expected_active {
+            !healthy
+        } else {
+            unexpected_extra
+        };
+        if stale {
+            stale_runtime_entries += 1;
+        }
+        let last_repair_status = previous_agent_status
+            .get(&agent_id)
+            .cloned()
+            .flatten()
+            .or_else(|| {
+                Some(if healthy {
+                    "healthy".to_string()
+                } else if expected_active {
+                    "stale".to_string()
+                } else {
+                    "unexpected_runtime".to_string()
+                })
+            });
+        agents.push(RuntimeHealthAgentSnapshot {
+            agent_id,
+            aggregate_id,
+            name,
+            runtime_present,
+            projection_present,
+            tracked_pid,
+            tracked_pid_alive,
+            tracked_pid_state,
+            cgroup_live_pid_count,
+            security_runtime_present,
+            last_repair_status,
+        });
+    }
+
+    let runtime_agent_names = runtime_orch
+        .agents()
+        .values()
+        .map(|handle| handle.identity.name.clone())
+        .collect::<BTreeSet<_>>();
+    let orphan_cgroups = cgroup_snapshot
+        .all_dirs
+        .iter()
+        .filter(|name| !runtime_agent_names.contains(*name))
+        .count();
+    let mut worker_states = previous
+        .map(|snapshot| snapshot.worker_states.clone())
+        .unwrap_or_default();
+    worker_states.insert(
+        "ecs_tick_loop".to_string(),
+        RuntimeWorkerState {
+            running: true,
+            restart_count: worker_states
+                .get("ecs_tick_loop")
+                .map(|state| state.restart_count)
+                .unwrap_or(0),
+            last_error: worker_states
+                .get("ecs_tick_loop")
+                .and_then(|state| state.last_error.clone()),
+            thread_name: "ecs-tick-loop".to_string(),
+        },
+    );
+    worker_states.insert(
+        "service_health".to_string(),
+        RuntimeWorkerState {
+            running: service_health_state.running,
+            restart_count: worker_states
+                .get("service_health")
+                .map(|state| state.restart_count)
+                .unwrap_or(service_health_state.restart_count),
+            last_error: worker_states
+                .get("service_health")
+                .and_then(|state| state.last_error.clone())
+                .or(service_health_state.last_error),
+            thread_name: service_health_state.thread_name,
+        },
+    );
+
+    let mut snapshot = RuntimeHealthSnapshot {
+        current_shift,
+        expected_active_agents,
+        runtime_agents,
+        projection_agents,
+        security_runtime_entries: security_state.len(),
+        sandbox_handles: sandbox_handles.len(),
+        tracked_processes: agent_processes.len(),
+        live_cgroup_dirs: cgroup_snapshot.live_cgroup_dirs,
+        stale_runtime_entries,
+        orphan_cgroups,
+        zombie_tracked_pids,
+        worker_states,
+        analysis_queue_depth: 0,
+        analysis_queue_dropped_total: 0,
+        analysis_queue_coalesced_total: 0,
+        reconcile_runs_total: 0,
+        reconcile_repairs_total: 0,
+        respawn_failures: 0,
+        last_repair_error: None,
+        repair_last_status: None,
+        operator_auth_required,
+        agents,
+    };
+
+    if let Some(previous) = previous {
+        snapshot.analysis_queue_depth = previous.analysis_queue_depth;
+        snapshot.analysis_queue_dropped_total = previous.analysis_queue_dropped_total;
+        snapshot.analysis_queue_coalesced_total = previous.analysis_queue_coalesced_total;
+        snapshot.reconcile_runs_total = previous.reconcile_runs_total;
+        snapshot.reconcile_repairs_total = previous.reconcile_repairs_total;
+        snapshot.respawn_failures = previous.respawn_failures;
+        snapshot.last_repair_error = previous.last_repair_error.clone();
+        snapshot.repair_last_status = previous.repair_last_status.clone().or_else(|| {
+            Some(if snapshot.stale_runtime_entries == 0 && snapshot.orphan_cgroups == 0 {
+                "healthy".to_string()
+            } else {
+                "drift_detected".to_string()
+            })
+        });
+    } else {
+        snapshot.repair_last_status = Some(
+            if snapshot.stale_runtime_entries == 0 && snapshot.orphan_cgroups == 0 {
+                "healthy".to_string()
+            } else {
+                "drift_detected".to_string()
+            },
+        );
+    }
+
+    snapshot
+}
+
+pub fn publish_runtime_health_snapshot(
+    runtime_health: &SharedRuntimeHealthState,
+    all_agents: &[AgentConfig],
+    current_shift: u8,
+    runtime_orch: &RuntimeOrchestrator,
+    sandbox_handles: &HashMap<AgentId, SandboxHandle>,
+    agent_processes: &HashMap<AgentId, AgentProcess>,
+    security_runtime_state: &SharedSecurityRuntimeState,
+    projection_db_path: &Path,
+    operator_auth_required: bool,
+    service_health_state: ServiceHealthWorkerSnapshot,
+) {
+    let previous = runtime_health.read().ok().map(|snapshot| snapshot.clone());
+    let snapshot = build_runtime_health_snapshot(
+        all_agents,
+        current_shift,
+        runtime_orch,
+        sandbox_handles,
+        agent_processes,
+        security_runtime_state,
+        projection_db_path,
+        operator_auth_required,
+        service_health_state,
+        previous.as_ref(),
+    );
+    if let Ok(mut state) = runtime_health.write() {
+        *state = snapshot;
+    }
+}
+
+#[derive(Debug, Default)]
+struct CgroupSnapshot {
+    all_dirs: BTreeSet<String>,
+    live_pid_counts: HashMap<String, usize>,
+    live_cgroup_dirs: usize,
+}
+
+fn collect_cgroup_snapshot() -> CgroupSnapshot {
+    let mut snapshot = CgroupSnapshot::default();
+    let Ok(entries) = std::fs::read_dir(CGROUP_ROOT) else {
+        return snapshot;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        snapshot.all_dirs.insert(name.clone());
+        let pid_count = list_pids_in_cgroup(&name)
+            .map(|pids: Vec<u32>| pids.len())
+            .unwrap_or(0);
+        if pid_count > 0 {
+            snapshot.live_cgroup_dirs += 1;
+        }
+        snapshot.live_pid_counts.insert(name, pid_count);
+    }
+
+    snapshot
+}
+
+fn read_proc_state(pid: u32) -> Option<char> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix("State:")?.trim();
+        value.chars().next()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentinel_common::agent_config::{
+        AgentConfig, BackgroundConfig, IdentityConfig, PersonalityConfig, PreferencesConfig,
+    };
+    use sentinel_common::components::{AgentIdentity, ShiftInfo};
+    use tempfile::tempdir;
+
+    fn test_agent(id: u16, shift_set: u8, name: &str) -> AgentConfig {
+        AgentConfig {
+            identity: IdentityConfig {
+                id,
+                name: name.to_string(),
+                role: "Role".to_string(),
+                department: "Dept".to_string(),
+                shift_set,
+                kpis: Vec::new(),
+                reports_to: None,
+                direct_reports: Vec::new(),
+            },
+            personality: PersonalityConfig {
+                openness: 0.5,
+                conscientiousness: 0.5,
+                extraversion: 0.5,
+                agreeableness: 0.5,
+                neuroticism: 0.5,
+                caffeine_tolerance: 0.5,
+                morning_person: true,
+            },
+            preferences: PreferencesConfig {
+                favorite_room: "empfang".to_string(),
+                coffee_preference: "black".to_string(),
+                lunch_time: "12:00".to_string(),
+            },
+            background: BackgroundConfig {
+                bio: "bio".to_string(),
+                quirks: Vec::new(),
+            },
+            capabilities: Default::default(),
+        }
+    }
+
+    #[test]
+    fn build_snapshot_marks_missing_projection_and_security_as_stale() {
+        let mut runtime = RuntimeOrchestrator::new(30);
+        runtime.set_tick(42);
+        runtime
+            .spawn_agent(
+                AgentIdentity {
+                    agent_id: AgentId(7),
+                    name: "Test Agent".to_string(),
+                    role: "Role".to_string(),
+                },
+                ShiftInfo {
+                    shift_set: 1,
+                    shift_start_hour: 6,
+                    shift_end_hour: 14,
+                    is_on_duty: true,
+                },
+                "empfang",
+            )
+            .unwrap();
+        let tmp = tempdir().unwrap();
+        let snapshot = build_runtime_health_snapshot(
+            &[test_agent(7, 1, "Test Agent")],
+            1,
+            &runtime,
+            &HashMap::new(),
+            &HashMap::new(),
+            &Arc::new(RwLock::new(HashMap::new())),
+            &tmp.path().join("projection.db"),
+            false,
+            ServiceHealthWorkerSnapshot::default(),
+            None,
+        );
+
+        assert_eq!(snapshot.expected_active_agents, 1);
+        assert_eq!(snapshot.runtime_agents, 1);
+        assert_eq!(snapshot.projection_agents, 0);
+        assert_eq!(snapshot.stale_runtime_entries, 1);
+        assert_eq!(snapshot.agents.len(), 1);
+        assert!(snapshot.agents[0].runtime_present);
+        assert!(!snapshot.agents[0].projection_present);
+        assert!(!snapshot.agents[0].security_runtime_present);
+    }
+}

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -103,22 +103,16 @@ pub fn build_runtime_health_snapshot(
     let projection_store: Option<ReadModelStore> = projection_db_path
         .to_str()
         .and_then(|path| ReadModelStore::open_readonly(path).ok());
-    let projection_agents = projection_store
+    let projection_active_agents = projection_store
         .as_ref()
-        .and_then(|store| store.active_agent_count().ok())
-        .unwrap_or_default()
-        .max(0) as usize;
-    let runtime_agents = runtime_orch.agent_count();
-    let previous_agent_status = previous
-        .map(|snapshot| {
-            snapshot
-                .agents
-                .iter()
-                .map(|agent| (agent.agent_id, agent.last_repair_status.clone()))
-                .collect::<HashMap<_, _>>()
-        })
+        .and_then(|store| store.active_agents().ok())
         .unwrap_or_default();
-
+    let projection_active_by_id = projection_active_agents
+        .iter()
+        .filter_map(|view| u16::try_from(view.agent_id).ok().map(|id| (id, view)))
+        .collect::<HashMap<_, _>>();
+    let projection_agents = projection_active_by_id.len();
+    let runtime_agents = runtime_orch.agent_count();
     let mut agent_catalog = BTreeMap::<u16, (String, String)>::new();
     for cfg in expected_agents {
         agent_catalog.insert(
@@ -141,6 +135,11 @@ pub fn build_runtime_health_snapshot(
         agent_catalog
             .entry(snapshot.agent_id)
             .or_insert_with(|| (snapshot.aggregate_id.clone(), snapshot.agent_name.clone()));
+    }
+    for (agent_id, view) in &projection_active_by_id {
+        agent_catalog
+            .entry(*agent_id)
+            .or_insert_with(|| (format!("AGENT-{agent_id:02}"), view.name.clone()));
     }
 
     let mut stale_runtime_entries = 0usize;
@@ -173,10 +172,7 @@ pub fn build_runtime_health_snapshot(
             .get(&name)
             .copied()
             .unwrap_or(0);
-        let projection_present = projection_store
-            .as_ref()
-            .and_then(|store| store.get_agent(agent_id).ok().flatten())
-            .is_some_and(|view| view.status == "active");
+        let projection_present = projection_active_by_id.contains_key(&agent_id);
         let projection_drift = projection_present
             != (runtime_present
                 || security_runtime_present
@@ -204,19 +200,13 @@ pub fn build_runtime_health_snapshot(
         if stale {
             stale_runtime_entries += 1;
         }
-        let last_repair_status = previous_agent_status
-            .get(&agent_id)
-            .cloned()
-            .flatten()
-            .or_else(|| {
-                Some(if healthy {
-                    "healthy".to_string()
-                } else if expected_active {
-                    "stale".to_string()
-                } else {
-                    "unexpected_runtime".to_string()
-                })
-            });
+        let last_repair_status = Some(if healthy {
+            "healthy".to_string()
+        } else if expected_active {
+            "stale".to_string()
+        } else {
+            "unexpected_runtime".to_string()
+        });
         agents.push(RuntimeHealthAgentSnapshot {
             agent_id,
             aggregate_id,
@@ -498,6 +488,50 @@ mod tests {
         assert!(snapshot.agents[0].runtime_present);
         assert!(!snapshot.agents[0].projection_present);
         assert!(!snapshot.agents[0].security_runtime_present);
+    }
+
+    #[test]
+    fn build_snapshot_marks_projection_only_agents_as_stale() {
+        let tmp = tempdir().unwrap();
+        let projection_path = tmp.path().join("projection.db");
+        let projection_store =
+            sentinel_projection::ReadModelStore::open(projection_path.to_str().unwrap()).unwrap();
+        {
+            let txn = projection_store.begin_transaction().unwrap();
+            txn.begin().unwrap();
+            txn.upsert_agent(16, "Projection Ghost", "Tester", 2, "active", 1)
+                .unwrap();
+            txn.commit().unwrap();
+        }
+        drop(projection_store);
+
+        let snapshot = build_runtime_health_snapshot(
+            &[],
+            1,
+            &RuntimeOrchestrator::new(30),
+            &HashMap::new(),
+            &HashMap::new(),
+            &Arc::new(RwLock::new(HashMap::new())),
+            &projection_path,
+            false,
+            ServiceHealthWorkerSnapshot::default(),
+            None,
+        );
+
+        assert_eq!(snapshot.expected_active_agents, 0);
+        assert_eq!(snapshot.runtime_agents, 0);
+        assert_eq!(snapshot.projection_agents, 1);
+        assert!(snapshot.projection_drift_detected);
+        assert_eq!(snapshot.projection_drift_agents, 1);
+        assert_eq!(snapshot.stale_runtime_entries, 1);
+        assert_eq!(snapshot.agents.len(), 1);
+        assert_eq!(snapshot.agents[0].agent_id, 16);
+        assert!(!snapshot.agents[0].runtime_present);
+        assert!(snapshot.agents[0].projection_present);
+        assert_eq!(
+            snapshot.agents[0].last_repair_status.as_deref(),
+            Some("unexpected_runtime")
+        );
     }
 
     #[test]

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -319,6 +319,7 @@ pub fn build_runtime_health_snapshot(
     snapshot
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn publish_runtime_health_snapshot(
     runtime_health: &SharedRuntimeHealthState,
     all_agents: &[AgentConfig],
@@ -330,9 +331,10 @@ pub fn publish_runtime_health_snapshot(
     projection_db_path: &Path,
     operator_auth_required: bool,
     service_health_state: ServiceHealthWorkerSnapshot,
+    analysis_queue_stats: crate::platform_controlplane::AnalysisQueueStats,
 ) {
     let previous = runtime_health.read().ok().map(|snapshot| snapshot.clone());
-    let snapshot = build_runtime_health_snapshot(
+    let mut snapshot = build_runtime_health_snapshot(
         all_agents,
         current_shift,
         runtime_orch,
@@ -344,6 +346,9 @@ pub fn publish_runtime_health_snapshot(
         service_health_state,
         previous.as_ref(),
     );
+    snapshot.analysis_queue_depth = analysis_queue_stats.depth;
+    snapshot.analysis_queue_dropped_total = analysis_queue_stats.dropped_total;
+    snapshot.analysis_queue_coalesced_total = analysis_queue_stats.coalesced_total;
     if let Ok(mut state) = runtime_health.write() {
         *state = snapshot;
     }

--- a/services/sentinel-daemon/src/runtime_health.rs
+++ b/services/sentinel-daemon/src/runtime_health.rs
@@ -49,6 +49,8 @@ pub struct RuntimeHealthSnapshot {
     pub expected_active_agents: usize,
     pub runtime_agents: usize,
     pub projection_agents: usize,
+    pub projection_drift_detected: bool,
+    pub projection_drift_agents: usize,
     pub security_runtime_entries: usize,
     pub sandbox_handles: usize,
     pub tracked_processes: usize,
@@ -100,7 +102,7 @@ pub fn build_runtime_health_snapshot(
     let cgroup_snapshot = collect_cgroup_snapshot();
     let projection_store: Option<ReadModelStore> = projection_db_path
         .to_str()
-        .and_then(|path| ReadModelStore::open(path).ok());
+        .and_then(|path| ReadModelStore::open_readonly(path).ok());
     let projection_agents = projection_store
         .as_ref()
         .and_then(|store| store.active_agent_count().ok())
@@ -143,6 +145,7 @@ pub fn build_runtime_health_snapshot(
 
     let mut stale_runtime_entries = 0usize;
     let mut zombie_tracked_pids = 0usize;
+    let mut projection_drift_agents = 0usize;
     let mut agents = Vec::with_capacity(agent_catalog.len());
 
     for (agent_id, (aggregate_id, name)) in agent_catalog {
@@ -174,6 +177,14 @@ pub fn build_runtime_health_snapshot(
             .as_ref()
             .and_then(|store| store.get_agent(agent_id).ok().flatten())
             .is_some_and(|view| view.status == "active");
+        let projection_drift = projection_present
+            != (runtime_present
+                || security_runtime_present
+                || tracked_pid_alive
+                || cgroup_live_pid_count > 0);
+        if projection_drift {
+            projection_drift_agents += 1;
+        }
         let healthy = runtime_present
             && projection_present
             && security_runtime_present
@@ -255,11 +266,12 @@ pub fn build_runtime_health_snapshot(
             restart_count: worker_states
                 .get("service_health")
                 .map(|state| state.restart_count)
-                .unwrap_or(service_health_state.restart_count),
+                .unwrap_or(0)
+                .max(service_health_state.restart_count),
             last_error: worker_states
                 .get("service_health")
                 .and_then(|state| state.last_error.clone())
-                .or(service_health_state.last_error),
+                .or_else(|| service_health_state.last_error.clone()),
             thread_name: service_health_state.thread_name,
         },
     );
@@ -269,6 +281,9 @@ pub fn build_runtime_health_snapshot(
         expected_active_agents,
         runtime_agents,
         projection_agents,
+        projection_drift_detected: projection_drift_agents > 0
+            || runtime_agents != projection_agents,
+        projection_drift_agents,
         security_runtime_entries: security_state.len(),
         sandbox_handles: sandbox_handles.len(),
         tracked_processes: agent_processes.len(),
@@ -476,10 +491,55 @@ mod tests {
         assert_eq!(snapshot.expected_active_agents, 1);
         assert_eq!(snapshot.runtime_agents, 1);
         assert_eq!(snapshot.projection_agents, 0);
+        assert!(snapshot.projection_drift_detected);
+        assert_eq!(snapshot.projection_drift_agents, 1);
         assert_eq!(snapshot.stale_runtime_entries, 1);
         assert_eq!(snapshot.agents.len(), 1);
         assert!(snapshot.agents[0].runtime_present);
         assert!(!snapshot.agents[0].projection_present);
         assert!(!snapshot.agents[0].security_runtime_present);
+    }
+
+    #[test]
+    fn build_snapshot_prefers_latest_service_health_restart_count() {
+        let tmp = tempdir().unwrap();
+        let mut previous = RuntimeHealthSnapshot::default();
+        previous.worker_states.insert(
+            "service_health".to_string(),
+            RuntimeWorkerState {
+                running: true,
+                restart_count: 0,
+                last_error: None,
+                thread_name: "service-health-checker".to_string(),
+            },
+        );
+
+        let snapshot = build_runtime_health_snapshot(
+            &[],
+            1,
+            &RuntimeOrchestrator::new(30),
+            &HashMap::new(),
+            &HashMap::new(),
+            &Arc::new(RwLock::new(HashMap::new())),
+            &tmp.path().join("projection.db"),
+            false,
+            ServiceHealthWorkerSnapshot {
+                running: true,
+                restart_count: 2,
+                last_error: Some("panic-test requested for service_health".to_string()),
+                thread_name: "service-health-checker".to_string(),
+            },
+            Some(&previous),
+        );
+
+        let worker = snapshot
+            .worker_states
+            .get("service_health")
+            .expect("service_health worker state");
+        assert_eq!(worker.restart_count, 2);
+        assert_eq!(
+            worker.last_error.as_deref(),
+            Some("panic-test requested for service_health")
+        );
     }
 }

--- a/services/sentinel-daemon/src/service_health.rs
+++ b/services/sentinel-daemon/src/service_health.rs
@@ -194,6 +194,9 @@ fn is_service_active(service_name: &str) -> bool {
 
 /// Restartet einen systemd Service. Daemon laeuft als root → kein sudo noetig.
 fn restart_service(service_name: &str) -> bool {
+    let _ = std::process::Command::new("systemctl")
+        .args(["reset-failed", service_name])
+        .status();
     std::process::Command::new("systemctl")
         .args(["restart", service_name])
         .status()

--- a/services/sentinel-daemon/src/service_health.rs
+++ b/services/sentinel-daemon/src/service_health.rs
@@ -3,6 +3,7 @@
 //! Separater Thread der periodisch systemd Services prueft.
 //! Ergebnisse werden non-blocking via mpsc Channel an den Tick-Loop geliefert.
 
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::{mpsc, Arc, RwLock};
 use std::time::Duration;
 
@@ -23,6 +24,20 @@ pub struct ServiceHealthWorkerSnapshot {
 pub struct ServiceHealthChecker {
     rx: mpsc::Receiver<Vec<String>>,
     worker_state: Arc<RwLock<ServiceHealthWorkerSnapshot>>,
+    control_tx: mpsc::Sender<ServiceHealthControl>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceHealthControl {
+    PanicTest,
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceHealthWorkerExit {
+    ResultChannelClosed,
+    ControlChannelClosed,
+    ShutdownRequested,
 }
 
 impl ServiceHealthChecker {
@@ -32,6 +47,7 @@ impl ServiceHealthChecker {
     /// und sendet die Liste der failed Services ueber den Channel.
     pub fn spawn(services: Vec<String>, check_interval: Duration) -> Self {
         let (tx, rx) = mpsc::channel();
+        let (control_tx, control_rx) = mpsc::channel();
         let worker_state = Arc::new(RwLock::new(ServiceHealthWorkerSnapshot {
             running: false,
             restart_count: 0,
@@ -42,38 +58,48 @@ impl ServiceHealthChecker {
 
         std::thread::Builder::new()
             .name("service-health-checker".into())
-            .spawn(move || {
+            .spawn(move || loop {
                 if let Ok(mut state) = thread_state.write() {
                     state.running = true;
+                    state.thread_name = "service-health-checker".to_string();
                 }
-                loop {
-                    let mut failed = Vec::new();
 
-                    for service in &services {
-                        let active = is_service_active(service);
-                        if !active {
-                            warn!(
-                                service = %service,
-                                "Service nicht active — Observation an Platform-Controlplane gemeldet"
-                            );
-                            failed.push(service.clone());
-                        }
-                    }
+                let worker_run = panic::catch_unwind(AssertUnwindSafe(|| {
+                    run_service_health_worker(&services, check_interval, &tx, &control_rx)
+                }));
 
-                    // Best-effort: Wenn Receiver gedroppt wurde, Thread beenden
-                    if tx.send(failed).is_err() {
+                match worker_run {
+                    Ok(
+                        ServiceHealthWorkerExit::ResultChannelClosed
+                        | ServiceHealthWorkerExit::ControlChannelClosed
+                        | ServiceHealthWorkerExit::ShutdownRequested,
+                    ) => {
                         if let Ok(mut state) = thread_state.write() {
                             state.running = false;
                         }
                         break;
                     }
-
-                    std::thread::sleep(check_interval);
+                    Err(payload) => {
+                        let error = panic_payload_to_string(payload);
+                        warn!(
+                            error = %error,
+                            "service-health-checker panicked, respawn im selben Daemon-Prozess"
+                        );
+                        if let Ok(mut state) = thread_state.write() {
+                            state.running = false;
+                            state.restart_count = state.restart_count.saturating_add(1);
+                            state.last_error = Some(error);
+                        }
+                    }
                 }
             })
             .expect("service-health-checker Thread starten");
 
-        Self { rx, worker_state }
+        Self {
+            rx,
+            worker_state,
+            control_tx,
+        }
     }
 
     /// Non-blocking Poll: Gibt die zuletzt bekannten failed Services zurueck.
@@ -93,6 +119,67 @@ impl ServiceHealthChecker {
             .read()
             .map(|state| state.clone())
             .unwrap_or_default()
+    }
+
+    pub fn trigger_panic_test(&self) -> bool {
+        self.control_tx
+            .send(ServiceHealthControl::PanicTest)
+            .is_ok()
+    }
+}
+
+impl Drop for ServiceHealthChecker {
+    fn drop(&mut self) {
+        let _ = self.control_tx.send(ServiceHealthControl::Shutdown);
+    }
+}
+
+fn run_service_health_worker(
+    services: &[String],
+    check_interval: Duration,
+    tx: &mpsc::Sender<Vec<String>>,
+    control_rx: &mpsc::Receiver<ServiceHealthControl>,
+) -> ServiceHealthWorkerExit {
+    loop {
+        let mut failed = Vec::new();
+
+        for service in services {
+            let active = is_service_active(service);
+            if !active {
+                warn!(
+                    service = %service,
+                    "Service nicht active — Observation an Platform-Controlplane gemeldet"
+                );
+                failed.push(service.clone());
+            }
+        }
+
+        if tx.send(failed).is_err() {
+            return ServiceHealthWorkerExit::ResultChannelClosed;
+        }
+
+        match control_rx.recv_timeout(check_interval) {
+            Ok(ServiceHealthControl::PanicTest) => {
+                panic!("panic-test requested for service_health");
+            }
+            Ok(ServiceHealthControl::Shutdown) => {
+                return ServiceHealthWorkerExit::ShutdownRequested;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return ServiceHealthWorkerExit::ControlChannelClosed;
+            }
+        }
+    }
+}
+
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "service-health-checker panic".to_string(),
+        },
     }
 }
 
@@ -132,6 +219,7 @@ mod tests {
         let checker = ServiceHealthChecker {
             rx,
             worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+            control_tx: mpsc::channel().0,
         };
         assert!(checker.poll_failed().is_empty());
     }
@@ -142,6 +230,7 @@ mod tests {
         let checker = ServiceHealthChecker {
             rx,
             worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+            control_tx: mpsc::channel().0,
         };
 
         // Mehrere Nachrichten senden
@@ -160,6 +249,7 @@ mod tests {
         let checker = ServiceHealthChecker {
             rx,
             worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+            control_tx: mpsc::channel().0,
         };
 
         tx.send(vec!["sentinel-judge".into()]).unwrap();
@@ -174,10 +264,46 @@ mod tests {
         let checker = ServiceHealthChecker {
             rx,
             worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+            control_tx: mpsc::channel().0,
         };
         let state = checker.worker_state();
         assert!(!state.running);
         assert_eq!(state.restart_count, 0);
         assert!(state.last_error.is_none());
+    }
+
+    #[test]
+    fn panic_test_restarts_worker_in_process() {
+        let checker = ServiceHealthChecker::spawn(Vec::new(), Duration::from_millis(10));
+
+        for _ in 0..50 {
+            if checker.worker_state().running {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(checker.worker_state().running);
+
+        assert!(checker.trigger_panic_test());
+
+        let mut recovered = false;
+        for _ in 0..100 {
+            let state = checker.worker_state();
+            if state.running && state.restart_count >= 1 {
+                recovered = true;
+                assert_eq!(state.thread_name, "service-health-checker");
+                assert!(state
+                    .last_error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("panic-test requested")));
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            recovered,
+            "service-health worker wurde nach panic-test nicht neu gestartet"
+        );
     }
 }

--- a/services/sentinel-daemon/src/service_health.rs
+++ b/services/sentinel-daemon/src/service_health.rs
@@ -3,10 +3,18 @@
 //! Separater Thread der periodisch systemd Services prueft.
 //! Ergebnisse werden non-blocking via mpsc Channel an den Tick-Loop geliefert.
 
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, RwLock};
 use std::time::Duration;
 
 use tracing::warn;
+
+#[derive(Debug, Clone, Default)]
+pub struct ServiceHealthWorkerSnapshot {
+    pub running: bool,
+    pub restart_count: u64,
+    pub last_error: Option<String>,
+    pub thread_name: String,
+}
 
 /// Non-blocking Service-Health-Checker.
 ///
@@ -14,6 +22,7 @@ use tracing::warn;
 /// Restart-Entscheidungen passieren deterministisch im Platform-Controlplane.
 pub struct ServiceHealthChecker {
     rx: mpsc::Receiver<Vec<String>>,
+    worker_state: Arc<RwLock<ServiceHealthWorkerSnapshot>>,
 }
 
 impl ServiceHealthChecker {
@@ -23,10 +32,20 @@ impl ServiceHealthChecker {
     /// und sendet die Liste der failed Services ueber den Channel.
     pub fn spawn(services: Vec<String>, check_interval: Duration) -> Self {
         let (tx, rx) = mpsc::channel();
+        let worker_state = Arc::new(RwLock::new(ServiceHealthWorkerSnapshot {
+            running: false,
+            restart_count: 0,
+            last_error: None,
+            thread_name: "service-health-checker".to_string(),
+        }));
+        let thread_state = Arc::clone(&worker_state);
 
         std::thread::Builder::new()
             .name("service-health-checker".into())
             .spawn(move || {
+                if let Ok(mut state) = thread_state.write() {
+                    state.running = true;
+                }
                 loop {
                     let mut failed = Vec::new();
 
@@ -43,6 +62,9 @@ impl ServiceHealthChecker {
 
                     // Best-effort: Wenn Receiver gedroppt wurde, Thread beenden
                     if tx.send(failed).is_err() {
+                        if let Ok(mut state) = thread_state.write() {
+                            state.running = false;
+                        }
                         break;
                     }
 
@@ -51,7 +73,7 @@ impl ServiceHealthChecker {
             })
             .expect("service-health-checker Thread starten");
 
-        Self { rx }
+        Self { rx, worker_state }
     }
 
     /// Non-blocking Poll: Gibt die zuletzt bekannten failed Services zurueck.
@@ -64,6 +86,13 @@ impl ServiceHealthChecker {
             last = failed;
         }
         last
+    }
+
+    pub fn worker_state(&self) -> ServiceHealthWorkerSnapshot {
+        self.worker_state
+            .read()
+            .map(|state| state.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -100,14 +129,20 @@ mod tests {
     #[test]
     fn test_poll_failed_empty_when_no_messages() {
         let (_tx, rx) = mpsc::channel::<Vec<String>>();
-        let checker = ServiceHealthChecker { rx };
+        let checker = ServiceHealthChecker {
+            rx,
+            worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+        };
         assert!(checker.poll_failed().is_empty());
     }
 
     #[test]
     fn test_poll_failed_returns_latest() {
         let (tx, rx) = mpsc::channel();
-        let checker = ServiceHealthChecker { rx };
+        let checker = ServiceHealthChecker {
+            rx,
+            worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+        };
 
         // Mehrere Nachrichten senden
         tx.send(vec!["service-a".into()]).unwrap();
@@ -122,11 +157,27 @@ mod tests {
     #[test]
     fn test_poll_failed_returns_failed_services() {
         let (tx, rx) = mpsc::channel();
-        let checker = ServiceHealthChecker { rx };
+        let checker = ServiceHealthChecker {
+            rx,
+            worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+        };
 
         tx.send(vec!["sentinel-judge".into()]).unwrap();
 
         let result = checker.poll_failed();
         assert_eq!(result, vec!["sentinel-judge"]);
+    }
+
+    #[test]
+    fn worker_state_defaults_to_stopped_snapshot() {
+        let (_tx, rx) = mpsc::channel::<Vec<String>>();
+        let checker = ServiceHealthChecker {
+            rx,
+            worker_state: Arc::new(RwLock::new(ServiceHealthWorkerSnapshot::default())),
+        };
+        let state = checker.worker_state();
+        assert!(!state.running);
+        assert_eq!(state.restart_count, 0);
+        assert!(state.last_error.is_none());
     }
 }

--- a/services/sentinel-projection/src/main.rs
+++ b/services/sentinel-projection/src/main.rs
@@ -4,6 +4,7 @@
 //! materialized read models (agent_live_view, room_live_view, kpi_1m).
 //! Started via systemd, runs continuously until stopped.
 
+use std::path::Path;
 use std::process::ExitCode;
 use std::sync::Arc;
 
@@ -77,6 +78,13 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         poll_interval: std::time::Duration::from_millis(cli.poll_interval_ms),
         batch_size: cli.batch_size,
         db_path: cli.projection_db.clone(),
+        rebuild_request_path: Path::new(&cli.projection_db)
+            .parent()
+            .unwrap_or_else(|| Path::new("/opt/sentinel/data"))
+            .join(".projection-rebuild-request")
+            .to_string_lossy()
+            .to_string(),
+        rebuild_request_poll_interval: std::time::Duration::from_secs(1),
     };
 
     let worker =

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -973,3 +973,212 @@ services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(),
 ```
 
 PASS: Slice E builds, lints and keeps model selection out of the Daemon. The only runtime model-related match is the intended Gateway-default path.
+
+## Phase 7 - Slice F Projection/API-Konvergenz Evidence
+
+Date: 2026-04-23
+
+### AC-1 - Projection Rebuild Request File
+
+Code scope:
+
+```text
+crates/sentinel-projection/src/config.rs
+crates/sentinel-projection/src/worker.rs
+services/sentinel-projection/src/main.rs
+```
+
+Observed implementation:
+
+```text
+ProjectionConfig::rebuild_request_path
+ProjectionConfig::rebuild_request_poll_interval
+ProjectionWorker::handle_rebuild_request_if_present()
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -p sentinel-projection rebuild_request -- --nocapture
+```
+
+Observed:
+
+```text
+test worker::tests::rebuild_request_file_triggers_full_rebuild_and_is_removed ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+PASS: The Projection worker consumes the request file, triggers a full rebuild and removes the request file after successful processing.
+
+### AC-2 - Read-Only Projection Reads For Runtime-Health
+
+Code scope:
+
+```text
+crates/sentinel-projection/src/store.rs
+services/sentinel-daemon/src/runtime_health.rs
+```
+
+Observed implementation:
+
+```text
+ReadModelStore::open_readonly(path)
+OpenFlags::SQLITE_OPEN_READ_ONLY
+build_snapshot() uses ReadModelStore::open_readonly()
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-projection -- --nocapture
+```
+
+Observed:
+
+```text
+test store::tests::test_open_readonly_reads_existing_projection_without_writes ... ok
+test result: ok. 7 passed; 0 failed
+test result: ok. 6 passed; 0 failed
+```
+
+PASS: Runtime-health can read Projection state through a read-only connection without running migrations or startup cleanup.
+
+### AC-3 - Projection Batch Error Rollback
+
+Code scope:
+
+```text
+crates/sentinel-projection/src/worker.rs
+```
+
+Observed implementation:
+
+```text
+txn.rollback()
+Handler error, aborting batch
+handler_error_rolls_back_batch_and_returns_err
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-projection -- --nocapture
+```
+
+Observed:
+
+```text
+test worker::tests::handler_error_rolls_back_batch_and_returns_err ... ok
+```
+
+PASS: Handler failures abort and rollback the batch instead of partially applying events.
+
+### AC-4 - Runtime-Health Projection Drift Detection
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_health.rs
+```
+
+Observed implementation:
+
+```text
+projection_drift_detected
+projection_drift_agents
+ReadModelStore::open_readonly()
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-daemon runtime_health -- --nocapture
+```
+
+Observed:
+
+```text
+test runtime_health::tests::build_snapshot_marks_missing_projection_and_security_as_stale ... ok
+test runtime_health::tests::build_snapshot_prefers_latest_service_health_restart_count ... ok
+test result: ok. 4 passed; 0 failed
+```
+
+PASS: Runtime-health reports Projection drift against runtime/security/cgroup truth and preserves latest worker restart state.
+
+### AC-5 - Reconcile Requests Rebuild Without Restart Storm
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/orchestrator.rs
+services/sentinel-daemon/src/service_health.rs
+```
+
+Observed implementation:
+
+```text
+write_projection_rebuild_request(data_dir, tick, reason)
+projection_drift_before
+projection_restart_attempted
+projection_restart_succeeded
+projection service active -> no restart
+```
+
+Remote test commands:
+
+```bash
+cargo remote -c -- test -q -p sentinel-daemon runtime_control -- --nocapture
+cargo remote -c -- test -q -p sentinel-daemon test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place -- --nocapture
+```
+
+Observed:
+
+```text
+runtime_control: test result: ok. 2 passed; 0 failed
+test orchestrator::tests::test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+PASS: Runtime-reconcile writes a rebuild request for Projection drift and deliberately avoids restarting an already active Projection service.
+
+### AC-6 - Format, Clippy, Build, Artifact And Scope Guard
+
+Remote quality gate commands:
+
+```bash
+cargo remote -c -- fmt --check
+cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings
+cargo remote -c -- build -q -p sentinel-daemon --release --features fuse
+cargo remote -c -- build -q -p sentinel-projection-service --release
+```
+
+Observed:
+
+```text
+fmt: PASS
+sentinel-projection clippy: PASS exit 0
+sentinel-projection-service clippy: PASS exit 0
+sentinel-daemon clippy --features fuse: PASS exit 0
+sentinel-daemon release build --features fuse: PASS exit 0
+sentinel-projection-service release build: PASS exit 0
+3a05fc872c061ae973e3d820e0a1aaa2d0a909b201d61e9b0c8c84b080c08425  target/release/sentinel-daemon
+d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection
+```
+
+Scope guard command:
+
+```bash
+rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates || true
+```
+
+Expected/observed allowed match:
+
+```text
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+```
+
+PASS: Slice F builds, lints and keeps model selection out of the Daemon. The Projection-side release artifact is explicitly built for later VM deploy evidence.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1328,3 +1328,146 @@ services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(),
 ```
 
 PASS: Slice G builds, lints, keeps model selection out of the Daemon, and produces the release artifacts needed for VM deploy evidence.
+
+## Phase 9 - Full Remote Quality Matrix Before VM Deploy
+
+Date: 2026-04-23
+Host: remote build server via `cargo remote -c --`
+Scope: all #279 runtime-change crates plus conditional FUSE/Landlock slice
+
+### AC-1 - Daemon Full Test Suite
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-daemon -- --nocapture
+```
+
+Observed:
+
+```text
+running 193 tests
+test result: ok. 193 passed; 0 failed; 0 ignored; finished in 10.29s
+expected controlled panic-test output:
+panic-test requested for service_health
+```
+
+PASS: The full Daemon test suite is green. The panic-test output is expected and is caught by the worker-supervision path.
+
+### AC-2 - Projection Test Suites
+
+Remote test commands:
+
+```bash
+cargo remote -c -- test -q -p sentinel-projection -- --nocapture
+cargo remote -c -- test -q -p sentinel-projection-service -- --nocapture
+```
+
+Observed:
+
+```text
+sentinel-projection:
+test result: ok. 7 passed; 0 failed
+test result: ok. 6 passed; 0 failed
+
+sentinel-projection-service:
+test result: ok. 0 passed; 0 failed
+```
+
+PASS: Projection library and service test targets are green before deploy.
+
+### AC-3 - Clippy Matrix
+
+Remote clippy commands:
+
+```bash
+cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings
+```
+
+Observed:
+
+```text
+sentinel-daemon clippy --features fuse: PASS exit 0
+sentinel-projection clippy: PASS exit 0
+sentinel-projection-service clippy: PASS exit 0
+sentinel-fs clippy --features fuse-tests: PASS exit 0
+sentinel-sandbox clippy: PASS exit 0
+```
+
+PASS: All touched Rust crates pass Clippy with `-D warnings`.
+
+### AC-4 - Release Build Matrix
+
+Remote build commands:
+
+```bash
+cargo remote -c -- build -q -p sentinel-daemon --release --features fuse
+cargo remote -c -- build -q -p sentinel-projection-service --release
+cargo remote -c -- build -q -p sentinel-sandbox --release --bins
+```
+
+Observed:
+
+```text
+sentinel-daemon release build --features fuse: PASS exit 0
+sentinel-projection-service release build: PASS exit 0
+sentinel-sandbox release bin build: PASS exit 0
+```
+
+Artifact hashes:
+
+```text
+517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon
+d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection
+a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper
+03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper
+```
+
+PASS: Deployable release artifacts exist locally after remote builds.
+
+### AC-5 - Conditional FUSE/Landlock Test Matrix
+
+Remote test commands:
+
+```bash
+cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture
+cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture
+```
+
+Observed:
+
+```text
+sentinel-fs:
+93 tests: 93 passed, 0 failed
+19 tests: 19 passed, 0 failed
+2 tests: 0 passed, 0 failed, 2 ignored
+
+sentinel-sandbox:
+44 tests: 41 passed, 0 failed, 3 ignored
+16 tests: 14 passed, 0 failed, 2 ignored
+12 tests: 3 passed, 0 failed, 9 ignored
+```
+
+PASS: The conditional FUSE/Landlock slice remains green after the complete #279 port.
+
+### AC-6 - Whitespace And Model-Scope Guards
+
+Local guard commands:
+
+```bash
+git diff --check
+rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates
+```
+
+Observed:
+
+```text
+git diff --check: PASS
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+```
+
+PASS: No whitespace/conflict errors. No Daemon-side Haiku/model-policy change was introduced.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -649,3 +649,129 @@ PASS: no output, exit 0
 ```
 
 PASS: Slice C builds with the FUSE feature and has a reproducible release artifact hash.
+
+## Phase 5 - Slice D Worker-Supervision Evidence
+
+Date: 2026-04-23
+
+### AC-1 - In-Process Worker Supervision
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/service_health.rs
+```
+
+Observed implementation:
+
+```text
+ServiceHealthChecker::spawn()
+panic::catch_unwind(AssertUnwindSafe(...))
+ServiceHealthControl::PanicTest
+ServiceHealthWorkerExit
+restart_count
+last_error
+running
+thread_name
+```
+
+PASS: `service_health` panics are contained inside the worker thread, recorded in the worker snapshot, and followed by an in-process worker restart rather than a daemon-process exit.
+
+### AC-2 - Runtime Panic-Test Operator Hook
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/operator_api.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+RuntimeControlCommand::PanicTest
+RuntimePanicTestRequest { worker }
+RuntimePanicTestResponse { accepted, worker, note }
+POST /operator/runtime/panic-test
+```
+
+PASS: The hook is typed, input-validated, routed through the existing Operator API path, and dispatched into the ECS owner thread. Only `worker=service_health` is accepted.
+
+### AC-3 - Remote Tests
+
+Remote Operator API test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_panic_test -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 21.56s
+running 2 tests
+test operator_api::tests::runtime_panic_test_rejects_invalid_worker ... ok
+test operator_api::tests::runtime_panic_test_is_forwarded_and_returns_response ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 183 filtered out; finished in 0.07s
+```
+
+Remote worker-supervision test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon panic_test_restarts_worker_in_process -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 0.42s
+running 1 test
+thread 'service-health-checker' panicked at services/sentinel-daemon/src/service_health.rs:163:17:
+panic-test requested for service_health
+test service_health::tests::panic_test_restarts_worker_in_process ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 184 filtered out; finished in 0.25s
+```
+
+PASS: The panic/backtrace is the intentional test stimulus. The test passes because `catch_unwind` records the panic and restarts the worker in-process.
+
+### AC-4 - Release Build And Artifact Hash
+
+Remote format command:
+
+```bash
+cargo remote -c -- fmt --check
+```
+
+Observed:
+
+```text
+PASS: no remaining rustfmt diff.
+```
+
+Remote release build command:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+```
+
+Observed:
+
+```text
+Finished release profile [optimized] target(s) in 57.79s
+4400fcb9162fe242f3cbebda550f25175976abc8f444475ab201d0570e43c3d2  target/release/sentinel-daemon
+```
+
+Whitespace check command:
+
+```bash
+git diff --check
+```
+
+Observed:
+
+```text
+PASS: no output, exit 0
+```
+
+PASS: Slice D builds with the FUSE feature and has a reproducible release artifact hash.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -152,3 +152,135 @@ projection_pid=1473941
 PASS: The canonical-main reset is measurable without `/operator/runtime-health`, and `runtime_health_http=404` is expected for current `main`.
 
 Finding: Canonical `main` does not self-heal the drift. API and Projection remain at `57`, while only `29` cgroup directories have live processes. Therefore the full #279 recovery scope remains required.
+
+## Phase 1 - Donor-Audit und Clean Port
+
+Date: 2026-04-23
+
+### AC-1 - Donor Commits Visible And Classified
+
+Commands:
+
+```bash
+git -C /work/company/project-sentinel-issue279 log --oneline --decorate --reverse origin/main..HEAD
+git -C /work/company/project-sentinel-issue279-stack log --oneline --decorate --reverse origin/main..HEAD
+git -C /work/company/project-sentinel-279-review range-diff origin/main...feat/issue-279-daemon-hardening-stack
+git -C /work/company/project-sentinel-279-review diff --stat origin/main..feat/issue-279-daemon-hardening-stack
+```
+
+Observed donor candidates:
+
+```text
+old donor includes:
+12b5138 Task [1]: Issue-Body-/Label-Repair vor Code fuer #279
+1af0d39 Task [2]: Build runtime health snapshot and operator endpoint
+d673603 Task [3]: Add runtime reconcile control path for #279
+76a20fe Task [4]: Add fast-path stall recovery and test hook for #279
+28348eb Task [5]: Add in-process worker supervision and panic test for #279
+a7ee414 Task [6]: Bound analysis queues and add flood test for #279
+9b50cb6 Task [7]: Add projection drift healing for #279
+dbb1b8e Task [8]: Pin agent LLM requests to haiku for #279
+dbab8fb Task [9]: Add #279 bench and soak harness
+300ded0 Fix [279]: Restore live agent runtime under FUSE and Landlock
+b71e1e1 Fix [279]: stabilize projection recovery and verify daemon hardening
+
+stack donor includes:
+3c596c1 Task [1]: Issue-Body-/Label-Repair vor Code fuer #279
+29a0fb5 Task [2]: Build runtime health snapshot and operator endpoint
+146ef43 Task [3]: Add runtime reconcile control path for #279
+fdc40c7 Task [4]: Add fast-path stall recovery and test hook for #279
+6919e66 Task [5]: Add in-process worker supervision and panic test for #279
+389b5e6 Task [6]: Bound analysis queues and add flood test for #279
+14560c4 Task [7]: Add projection drift healing for #279
+ffca58b Task [9]: Add #279 bench and soak harness
+6c31975 Fix [279]: restore runtime consistency after FUSE and Landlock recovery
+b1e376b Fix [279]: stabilize projection recovery and verify daemon hardening
+4600532 Task [11]: Refresh stack evidence for #279
+```
+
+PASS: The old donor and the stack donor are visible. The stack donor is the safer source because it already removed the Haiku commit, but it is still not mergeable as a branch.
+
+### AC-2 - Out-of-Scope Material Excluded
+
+Rejected for #279:
+
+```text
+dbb1b8e / llm_bridge.rs Haiku pin:
+- out-of-scope per current #279 body
+- violates gateway/model-policy separation for this issue
+
+direct branch merge:
+- rejected because the donor diff still spans 38 files and includes stacked/history artifacts
+
+donor evidence and progress files:
+- donor PROGRESS.md is stale
+- donor test-279-verification.md is old VM evidence, not current proof
+- test-264-verification.md deletion is not part of #279
+
+broad non-#279 paths:
+- .gitignore
+- deploy/systemd/sentinel-daemon.service unless a concrete runtime need appears
+- crates/sentinel-common/src/snapshot_codec.rs
+- crates/sentinel-common/src/types.rs
+- crates/sentinel-common/tests/snapshot_roundtrip.rs
+- crates/sentinel-fs/src/metadata.rs
+- crates/sentinel-sandbox/src/bin/breakout_helper.rs
+- crates/sentinel-sandbox/src/bwrap.rs
+- crates/sentinel-sandbox/src/enforcer.rs
+- crates/sentinel-sandbox/tests/breakout.rs
+```
+
+Conditional, not rejected:
+
+```text
+6c31975 / former 300ded0:
+- keep as Slice G candidate only
+- allowed paths if needed:
+  - crates/sentinel-fs/src/fuse.rs
+  - crates/sentinel-sandbox/src/landlock.rs
+  - services/sentinel-daemon/src/orchestrator.rs
+```
+
+PASS: Haiku and stale stacked scope are explicitly excluded before any port.
+
+### AC-3 - Clean Port Order
+
+Port order:
+
+```text
+Task 3 / Slice A:
+  donor 29a0fb5, path-limited runtime health endpoint and snapshot only
+
+Task 4 / Slice B:
+  donor 146ef43, runtime_control and reconcile paths
+
+Task 5 / Slice C:
+  donor fdc40c7, fast stall recovery and deterministic test hook
+
+Task 6 / Slice D:
+  donor 6919e66, in-process worker supervision and panic-test
+
+Task 7 / Slice E:
+  donor 389b5e6, bounded analysis/recovery queues and flood-test
+
+Task 8 / Slice F:
+  donor 14560c4 plus relevant parts of b1e376b, projection convergence and rebuild request
+
+Task 9 / Slice G:
+  donor 6c31975 only if current main plus ported #279 still requires FUSE/Landlock runtime restore
+
+Task 14 / Benchmarks:
+  donor ffca58b plus updated current evidence, not old results
+```
+
+Clean-port rule:
+
+```text
+Do not merge or cherry-pick the donor branch wholesale.
+Apply donor code path-limited by slice.
+Do not port llm_bridge.rs Haiku changes.
+Do not port stale donor PROGRESS/evidence as proof.
+Refresh CHANGELOG and verification evidence in this branch only.
+```
+
+PASS: The implementation path is now deterministic and scope-clean.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1974,3 +1974,193 @@ projection-journal.log: no panic/error/database-is-locked hits during soak windo
 ```
 
 PASS: The 30-minute VM soak ended at the canonical active-agent target with no panic or drift regression.
+
+## Phase 12 - Task 14 Benchmarks
+
+Date: 2026-04-23
+
+Benchmark design:
+
+```text
+HTTP wallclock is not used as the benchmark target because Runtime-Control commands are processed on
+the synchronous 1 Hz ECS tick. Task 14 therefore adds server-side timing fields to the same live
+Operator paths and measures those fields on the deployment VM.
+```
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/runtime_health.rs
+services/sentinel-daemon/src/orchestrator.rs
+services/sentinel-daemon/src/operator_api.rs
+scripts/vm-issue-279-bench.sh
+```
+
+### Remote Quality Matrix After Benchmark Instrumentation
+
+Commands:
+
+```bash
+cargo remote -c -- fmt --all
+cargo remote -c -- test -q -p sentinel-daemon -- --nocapture
+cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings
+cargo remote -c -- build -q -p sentinel-daemon --release --features fuse
+sha256sum target/release/sentinel-daemon
+```
+
+Observed:
+
+```text
+fmt: PASS
+sentinel-daemon tests: 194 passed; 0 failed
+clippy sentinel-daemon --features fuse: PASS
+release build sentinel-daemon --features fuse: PASS
+7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d  target/release/sentinel-daemon
+```
+
+PASS: Benchmark instrumentation compiles, is formatted, passes daemon tests and clippy, and produced a release binary.
+
+### VM Deploy For Benchmark Binary
+
+Commands:
+
+```bash
+ssh ubuntu@10.0.0.240 "grep ExecStart /etc/systemd/system/sentinel-daemon.service && systemctl is-active sentinel-daemon && pgrep -x sentinel-daemon"
+scp target/release/sentinel-daemon ubuntu@10.0.0.240:/tmp/sentinel-daemon.issue279-bench
+ssh ubuntu@10.0.0.240 "sudo cp /opt/sentinel/bin/sentinel-daemon /opt/sentinel/bin/sentinel-daemon.backup-issue279-bench-$(date -u +%Y%m%dT%H%M%SZ) && sudo install -m 755 /tmp/sentinel-daemon.issue279-bench /opt/sentinel/bin/sentinel-daemon && sudo systemctl restart sentinel-daemon && systemctl is-active sentinel-daemon && sha256sum /opt/sentinel/bin/sentinel-daemon"
+```
+
+Observed:
+
+```text
+ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml
+active
+old_pid=1485419
+active
+7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d  /opt/sentinel/bin/sentinel-daemon
+```
+
+PASS: The benchmarked binary is installed at the live systemd `ExecStart` path and the VM hash matches the local release hash.
+
+### Endpoint Timing Smoke
+
+Commands:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d[\"expected_active_agents\"], d[\"runtime_agents\"], d[\"projection_agents\"], d[\"snapshot_build_elapsed_us\"], d[\"operator_auth_required\"])'"
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/reconcile -H 'Content-Type: application/json' -d '{\"dry_run\":true,\"respawn_missing\":true,\"projection_rebuild\":false}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d[\"accepted\"], d[\"dry_run\"], d[\"elapsed_us\"], d[\"repair_last_status\"])'"
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/analysis-flood-test -H 'Content-Type: application/json' -d '{\"count\":10000}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d[\"accepted\"], d[\"enqueue_elapsed_us\"], d[\"enqueue_per_request_ns\"], d[\"queue_depth\"], d[\"dropped_total\"], d[\"coalesced_total\"])'"
+```
+
+Observed:
+
+```text
+26 26 26 1021 False
+True True 2229 dry_run
+True 1517 151 17 9982 9999
+```
+
+PASS: Runtime-Health, Reconcile and Analysis-Flood expose the server-side timing fields on the running VM.
+
+### Benchmark Harness
+
+Install and run command:
+
+```bash
+scp scripts/vm-issue-279-bench.sh ubuntu@10.0.0.240:/tmp/vm-issue-279-bench.sh
+ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/vm-issue-279-bench.sh /opt/sentinel/scripts/vm-issue-279-bench.sh && /opt/sentinel/scripts/vm-issue-279-bench.sh"
+```
+
+Observed:
+
+```text
+healthy expected=26 runtime=26 projection=26 cgroups=26 stale=0 orphans=0 zombies=0 snapshot_us=1001
+healthy expected=26 runtime=26 projection=26 cgroups=26 stale=0 orphans=0 zombies=0 snapshot_us=1080
+BENCH_PASS out_dir=/tmp/issue279-bench-20260423T132030Z
+name	actual	target_exclusive	unit	pass	source
+runtime_reconcile_26_agents	2134	5000	us	PASS	runtime-reconcile-runs.tsv
+projection_divergence_detection	817	5000	us	PASS	projection-divergence-runs.tsv
+analysis_flood_cap	148	250000	ns_per_request	PASS	analysis-flood.json
+stall_recovery_bookkeeping	700	50000	ns	PASS	stall-restart-direct.json
+sidecars:
+/tmp/issue279-bench-20260423T132030Z/free-after.txt
+/tmp/issue279-bench-20260423T132030Z/free-before.txt
+/tmp/issue279-bench-20260423T132030Z/iostat-after.txt
+/tmp/issue279-bench-20260423T132030Z/iostat-before.txt
+/tmp/issue279-bench-20260423T132030Z/ps-after.txt
+/tmp/issue279-bench-20260423T132030Z/ps-before.txt
+/tmp/issue279-bench-20260423T132030Z/vmstat-after.txt
+/tmp/issue279-bench-20260423T132030Z/vmstat-before.txt
+```
+
+PASS: All four #279-specific benchmarks passed with VM-side system-monitoring artifacts.
+
+### Sidecar And Final Health Summary
+
+Artifact directory:
+
+```text
+/tmp/issue279-bench-20260423T132030Z
+```
+
+Final health:
+
+```text
+current_shift=1
+expected_active_agents=26
+runtime_agents=26
+projection_agents=26
+projection_drift_detected=false
+projection_drift_agents=0
+security_runtime_entries=26
+sandbox_handles=26
+tracked_processes=26
+live_cgroup_dirs=26
+stale_runtime_entries=0
+orphan_cgroups=0
+zombie_tracked_pids=0
+service_health running=true restart_count=0 last_error=null
+ecs_tick_loop running=true restart_count=0 last_error=null
+analysis_queue_depth=1
+analysis_queue_dropped_total=19964
+analysis_queue_coalesced_total=19998
+reconcile_runs_total=6
+reconcile_repairs_total=0
+respawn_failures=0
+repair_last_status=dry_run
+operator_auth_required=false
+snapshot_build_elapsed_us=1080
+```
+
+Process sidecar:
+
+```text
+before: daemon_pid=1495021 projection_pid=1495275 sentinel-daemon RSS=210768 KB projection RSS=6384 KB
+after:  daemon_pid=1495021 projection_pid=1495275 sentinel-daemon RSS=229172 KB projection RSS=6384 KB
+```
+
+System sidecar excerpt:
+
+```text
+Mem: total=24030MB used=1258MB free=10993MB available=22771MB
+iostat avg-cpu: user=1.39 system=0.46 iowait=0.22 steal=0.13 idle=97.80
+sda: r/s=0.80 rkB/s=17.37 w/s=18.11 wkB/s=634.71 util=1.54
+```
+
+Service gate:
+
+```text
+sentinel-daemon active
+sentinel-projection active
+sentinel-gateway active
+sentinel-nats-bridge active
+```
+
+Journal gate:
+
+```text
+journalctl -u sentinel-daemon --since <benchmark-start> panic/drift marker scan: empty
+```
+
+PASS: Benchmarks left the VM in the canonical healthy runtime state with no panic or drift regression.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1182,3 +1182,149 @@ services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(),
 ```
 
 PASS: Slice F builds, lints and keeps model selection out of the Daemon. The Projection-side release artifact is explicitly built for later VM deploy evidence.
+
+## Phase 8 - Slice G Conditional FUSE/Landlock Runtime Restore Evidence
+
+Date: 2026-04-23
+Host: remote build server via `cargo remote -c --`
+Scope: `services/sentinel-daemon/src/orchestrator.rs`, `crates/sentinel-sandbox/src/landlock.rs`
+
+### AC-1 - FUSE Mount Is Not Trusted Until Active
+
+Code scope:
+
+```text
+mountinfo_contains_mountpoint()
+mountpoint_is_active()
+wait_for_fuse_mount()
+active_fs_mount
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-daemon mountinfo_contains_mountpoint_matches_exact_sentinel_fuse_mount --features fuse -- --nocapture
+```
+
+Observed:
+
+```text
+PASS: targeted FUSE mountinfo test passed
+```
+
+PASS: The daemon recognizes only an exact `sentinel-fs` FUSE mount as active, not a configured path by itself.
+
+### AC-2 - Inactive FUSE Falls Back To `/ram/agents`
+
+Code scope:
+
+```text
+active_fs_mount: Option<String>
+sandbox.set_fs_mount(active_fs_mount)
+operator_api::start_server(..., active_fs_mount.clone(), ...)
+ecs_fs_mount = active_fs_mount.clone()
+```
+
+Observed implementation:
+
+```text
+if wait_for_fuse_mount(...) { active_mount = Some(fs_mount.clone()) }
+else { warn!("sentinel-fs FUSE-Mount nicht aktiv, fallback auf /ram/agents") }
+```
+
+PASS: Sandbox, Operator-API and ECS receive `fs_mount` only when FUSE is active; otherwise the runtime keeps the default `/ram/agents` path.
+
+### AC-3 - Landlock Execute Scope Stays Narrow
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-sandbox ruleset_for_agent_paths -- --nocapture
+```
+
+Observed:
+
+```text
+PASS: targeted Landlock ruleset test passed
+```
+
+PASS: The ruleset still rejects broad `/usr` execute allowlisting and allows only the runtime binaries plus loader paths.
+
+### AC-4 - Full Sandbox Test Matrix
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture
+```
+
+Observed:
+
+```text
+44 tests: 41 passed, 0 failed, 3 ignored
+16 tests: 14 passed, 0 failed, 2 ignored
+12 tests: 3 passed, 0 failed, 9 ignored
+```
+
+PASS: Existing sandbox behavior remains green after the Landlock loader-path change.
+
+### AC-5 - sentinel-fs Fuse Feature Gate
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture
+```
+
+Observed:
+
+```text
+93 tests: 93 passed, 0 failed
+19 tests: 19 passed, 0 failed
+2 tests: 0 passed, 0 failed, 2 ignored
+```
+
+PASS: The `sentinel-fs` crate builds and tests successfully with the FUSE feature path enabled; kernel-dependent FUSE tests remain explicitly ignored.
+
+### AC-6 - Format, Clippy, Builds, Artifact And Scope Guard
+
+Remote quality gate commands:
+
+```bash
+cargo remote -c -- fmt --check
+cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings
+cargo remote -c -- build -q -p sentinel-daemon --release --features fuse
+cargo remote -c -- build -q -p sentinel-sandbox --release --bins
+```
+
+Observed:
+
+```text
+fmt: PASS
+sentinel-sandbox clippy: PASS exit 0
+sentinel-daemon clippy --features fuse: PASS exit 0
+sentinel-fs clippy --features fuse-tests: PASS exit 0
+sentinel-daemon release build --features fuse: PASS exit 0
+sentinel-sandbox release bin build: PASS exit 0
+517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon
+a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper
+03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper
+```
+
+Local non-build guards:
+
+```bash
+git diff --check
+rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates
+```
+
+Observed:
+
+```text
+git diff --check: PASS
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+```
+
+PASS: Slice G builds, lints, keeps model selection out of the Daemon, and produces the release artifacts needed for VM deploy evidence.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1,0 +1,154 @@
+# Issue #279 Verification
+
+## Phase 0 - Issue-Repair und Baseline-Reset
+
+Date: 2026-04-23  
+Worktree: `/work/company/project-sentinel-279-review`  
+Branch: `feat/issue-279-daemon-hardening-v2`  
+Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
+
+### AC-1 - Fresh Pre-Reset VM Baseline
+
+Command target: `ubuntu@10.0.0.240`
+
+```text
+timestamp=2026-04-23T09:46:15+00:00
+kernel=6.17.0-20-generic
+services_begin
+active
+active
+active
+active
+services_end
+api_agents=57
+projection_agents=57
+cgroup_dirs=59
+runtime_health_http=200
+runtime_health.expected_active_agents=26
+runtime_health.runtime_agents=26
+runtime_health.projection_agents=57
+runtime_health.live_cgroup_dirs=29
+runtime_health.stale_runtime_entries=0
+runtime_health.orphan_cgroups=33
+runtime_health.zombie_tracked_pids=0
+runtime_health.projection_drift_detected=True
+runtime_health.analysis_queue_depth=0
+runtime_health.analysis_queue_dropped_total=3
+runtime_health.analysis_queue_coalesced_total=0
+panic_count_30m=0
+drift_count_30m=0
+error_count_30m=26
+```
+
+PASS: The VM was service-active but drifted. API and Projection exposed `57`, while the experimental runtime-health endpoint expected `26` and reported `33` orphan cgroups.
+
+### AC-2 - GitHub Issue Body Repair
+
+Command:
+
+```bash
+gh issue edit 279 --repo silentspike/project-sentinel --body-file docs/issue-279-body.md
+gh issue view 279 --repo silentspike/project-sentinel --json state,labels,updatedAt,body
+```
+
+Observed:
+
+```text
+issue_url=https://github.com/silentspike/project-sentinel/issues/279
+state=OPEN
+updatedAt=2026-04-23T09:47:19Z
+labels include status:in-progress
+body now contains fresh 2026-04-23 baseline, clean-main branch rule, Haiku/model policy out-of-scope, and strict status:verified close rule
+```
+
+PASS: Stale `Blocked by #278`, old 2026-04-21 numbers and #264-stack assumptions were removed from the GitHub SSOT.
+
+### AC-3 - Canonical Main Build And Deploy
+
+Remote build commands:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+cargo remote -c -- build -p sentinel-projection-service --release
+```
+
+Observed:
+
+```text
+sentinel-daemon: Finished release profile [optimized] target(s) in 12m 04s
+sentinel-projection-service: Finished release profile [optimized] target(s) in 1m 37s
+target/release/sentinel-daemon sha256=2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883
+target/release/sentinel-projection sha256=10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3
+```
+
+ExecStart check:
+
+```text
+# /etc/systemd/system/sentinel-daemon.service
+ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml
+# /etc/systemd/system/sentinel-projection.service
+ExecStart=/opt/sentinel/bin/sentinel-projection \
+  --event-store /opt/sentinel/data/events.db \
+  --projection-db /opt/sentinel/data/projection.db
+```
+
+Deploy observed:
+
+```text
+deploy_ts=20260423T100300Z
+2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883  /tmp/sentinel-daemon
+10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3  /tmp/sentinel-projection
+services_begin
+active
+active
+active
+active
+services_end
+2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883  /opt/sentinel/bin/sentinel-daemon
+10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3  /opt/sentinel/bin/sentinel-projection
+```
+
+PASS: Canonical `main` daemon and Projection artifacts were built through the remote Rust builder, installed at the exact systemd `ExecStart` paths, and restarted successfully.
+
+### AC-4 - Post-Reset Baseline Without Runtime-Health
+
+Command target: `ubuntu@10.0.0.240`
+
+First sample:
+
+```text
+timestamp=2026-04-23T10:03:58+00:00
+services_begin
+active
+active
+active
+active
+services_end
+api_agents=57
+projection_agents=57
+cgroup_dirs=59
+cgroup_live_procs_dirs=29
+cgroup_live_threads_dirs=29
+runtime_health_http=404
+{"error":"Endpoint unbekannt"}
+daemon_pid=1473664
+panic_count_since_deploy=0
+drift_count_since_deploy=0
+error_count_since_deploy=29
+```
+
+Second sample:
+
+```text
+timestamp=2026-04-23T10:04:19+00:00
+api_agents=57
+projection_agents=57
+cgroup_dirs=59
+cgroup_live_procs_dirs=29
+runtime_health_http=404
+projection_pid=1473941
+```
+
+PASS: The canonical-main reset is measurable without `/operator/runtime-health`, and `runtime_health_http=404` is expected for current `main`.
+
+Finding: Canonical `main` does not self-heal the drift. API and Projection remain at `57`, while only `29` cgroup directories have live processes. Therefore the full #279 recovery scope remains required.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1471,3 +1471,247 @@ services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(),
 ```
 
 PASS: No whitespace/conflict errors. No Daemon-side Haiku/model-policy change was introduced.
+
+## Phase 10 - VM Deploy, Projection Convergence And Cgroup Orphan Repair
+
+Date: 2026-04-23
+Command target: `ubuntu@10.0.0.240`
+Scope: #279 runtime deploy after clean-port plus hotfix for stopped orphan cgroups found during live verification
+
+### AC-1 - ExecStart And Artifact Deploy
+
+ExecStart preflight:
+
+```bash
+ssh ubuntu@10.0.0.240 "systemctl cat sentinel-daemon | grep -n '^ExecStart'; systemctl cat sentinel-projection | grep -n '^ExecStart'; systemctl is-active sentinel-daemon sentinel-projection"
+```
+
+Observed:
+
+```text
+13:ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml
+13:ExecStart=/opt/sentinel/bin/sentinel-projection \
+active
+active
+```
+
+Final deploy command:
+
+```bash
+ssh ubuntu@10.0.0.240 "sudo mkdir -p /opt/sentinel/backups/issue-279-20260423T142544Z && sudo cp /opt/sentinel/bin/sentinel-daemon /opt/sentinel/backups/issue-279-20260423T142544Z/sentinel-daemon && sudo systemctl stop sentinel-daemon"
+scp target/release/sentinel-daemon ubuntu@10.0.0.240:/tmp/sentinel-daemon.issue279
+ssh ubuntu@10.0.0.240 "sudo install -m 0755 /tmp/sentinel-daemon.issue279 /opt/sentinel/bin/sentinel-daemon && sudo systemctl start sentinel-daemon && sleep 2 && systemctl is-active sentinel-daemon && sha256sum /opt/sentinel/bin/sentinel-daemon"
+```
+
+Observed:
+
+```text
+active
+d6c30a324d85cbb3ec9d919a14e5f5744482cda75e59984e6133944289129d86  /opt/sentinel/bin/sentinel-daemon
+backup=/opt/sentinel/backups/issue-279-20260423T142544Z
+```
+
+PASS: The final Daemon artifact was installed at the exact systemd `ExecStart` path and restarted successfully.
+
+### AC-2 - Projection-Only Drift Repair
+
+Initial post-deploy runtime-health before reconcile:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -s http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; h=json.load(sys.stdin); print(\"expected\",h.get(\"expected_active_agents\"),\"runtime\",h.get(\"runtime_agents\"),\"projection\",h.get(\"projection_agents\"),\"cgroups\",h.get(\"live_cgroup_dirs\"),\"stale\",h.get(\"stale_runtime_entries\"),\"orphans\",h.get(\"orphan_cgroups\"),\"zombies\",h.get(\"zombie_tracked_pids\"),\"drift\",h.get(\"projection_drift_detected\"))'"
+```
+
+Observed before the first reconcile round:
+
+```text
+expected 26 runtime 26 projection 57 cgroups 29 stale 31 orphans 3 zombies 0 drift True
+api_agents=57
+projection_active_rows=57
+```
+
+Reconcile command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -s -X POST http://127.0.0.1:8084/operator/runtime/reconcile -H 'Content-Type: application/json' -d '{\"dry_run\":false,\"projection_rebuild\":true,\"respawn_missing\":true}' | python3 -m json.tool"
+```
+
+Observed first reconcile:
+
+```text
+"accepted": true
+"stale_agents_before": 31
+"stale_agents_after": 0
+"orphan_cgroups_before": 3
+"unexpected_runtime_removed": 3
+"projection_drift_before": true
+"projection_drift_after": false
+"projection_rebuild_requested": true
+"repair_last_status": "projection_rebuild_requested"
+```
+
+PASS: Projection-only ghost agents are now visible to Runtime-Health and reconciled through `agent_despawned` plus Projection rebuild instead of being hidden behind an aggregate count.
+
+### AC-3 - Stopped Orphan Cgroup Finding And Fix
+
+Runtime gate after the first reconcile still failed on live Cgroups:
+
+```text
+expected 26 runtime 26 projection 26 cgroups 29 stale 0 orphans 3 zombies 0 drift False api_agents=26
+```
+
+Orphan inspection:
+
+```bash
+ssh ubuntu@10.0.0.240 "python3 - <<'PY'
+import os
+root='/sys/fs/cgroup/sentinel'
+for name in sorted(os.listdir(root)):
+    procs=open(os.path.join(root,name,'cgroup.procs')).read().strip().split()
+    if procs:
+        print(name, ','.join(procs))
+PY"
+ssh ubuntu@10.0.0.240 "ps -o pid,stat,cmd -p 1291960,1314755,1324475 || true"
+```
+
+Observed:
+
+```text
+Carla Mendez pids=1291960
+Jonas Weber pids=1314755
+Oliver Brandt pids=1324475
+
+1291960 T /usr/bin/python3 -c ... /opt/sentinel/data/security-write-anomaly/AGENT-17/.issue264-write-anomaly.bin ...
+1314755 T /usr/bin/python3 -c ... /opt/sentinel/data/security-write-anomaly/AGENT-22/.issue264-write-anomaly.bin ...
+1324475 T /usr/bin/python3 -c ... /opt/sentinel/data/security-write-anomaly/AGENT-26/.issue264-write-anomaly.bin ...
+```
+
+Code fix:
+
+```text
+crates/sentinel-sandbox/src/cgroups.rs:
+  kill_cgroup_processes(name) uses cgroup.kill when available and SIGKILL fallback otherwise.
+
+services/sentinel-daemon/src/orchestrator.rs:
+  runtime reconcile empties orphan cgroups before remove_cgroup().
+```
+
+Post-fix remote gates:
+
+```bash
+cargo remote -c -- fmt --all
+cargo remote -c -- test -q -p sentinel-sandbox kill_nonexistent_cgroup_is_noop -- --nocapture
+cargo remote -c -- test -q -p sentinel-daemon test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place -- --nocapture
+cargo remote -c -- test -q -p sentinel-daemon -- --nocapture
+cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture
+cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings
+cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings
+cargo remote -c -- build -q -p sentinel-daemon --release --features fuse
+cargo remote -c -- build -q -p sentinel-projection-service --release
+```
+
+Observed:
+
+```text
+sentinel-sandbox targeted test: 1 passed; 0 failed
+sentinel-daemon targeted reconcile test: 1 passed; 0 failed
+sentinel-daemon full test: 194 passed; 0 failed
+sentinel-sandbox full test: 42 passed; 0 failed; 3 ignored
+sentinel-sandbox full test: 14 passed; 0 failed; 2 ignored
+sentinel-sandbox full test: 3 passed; 0 failed; 9 ignored
+sentinel-sandbox clippy: PASS exit 0
+sentinel-daemon clippy --features fuse: PASS exit 0
+sentinel-daemon release build --features fuse: PASS exit 0
+sentinel-projection-service release build: PASS exit 0
+d6c30a324d85cbb3ec9d919a14e5f5744482cda75e59984e6133944289129d86  target/release/sentinel-daemon
+67670ad90e9e72ac9e856ca88770e23fb3b5762115941ea5f26b3f94bf61c46c  target/release/sentinel-projection
+a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper
+03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper
+```
+
+PASS: Reconcile no longer leaves stopped writer processes in orphan cgroups.
+
+### AC-4 - Final Runtime Health Gate
+
+Final reconcile command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -s -X POST http://127.0.0.1:8084/operator/runtime/reconcile -H 'Content-Type: application/json' -d '{\"dry_run\":false,\"projection_rebuild\":true,\"respawn_missing\":true}' | python3 -m json.tool"
+```
+
+Observed:
+
+```text
+"accepted": true
+"stale_agents_before": 0
+"stale_agents_after": 0
+"orphan_cgroups_before": 3
+"orphan_cgroups_after": 0
+"orphan_cgroups_removed": 3
+"respawned_agents": 0
+"projection_drift_before": false
+"projection_drift_after": false
+"projection_rebuild_requested": true
+"errors": []
+```
+
+Projection rebuild completion:
+
+```text
+Full rebuild complete total=3562240
+Projection-Rebuild-Request abgearbeitet path=/opt/sentinel/data/.projection-rebuild-request events=3562240
+```
+
+Final runtime-health:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -s http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; h=json.load(sys.stdin); print(\"expected\",h[\"expected_active_agents\"],\"runtime\",h[\"runtime_agents\"],\"projection\",h[\"projection_agents\"],\"cgroups\",h[\"live_cgroup_dirs\"],\"stale\",h[\"stale_runtime_entries\"],\"orphans\",h[\"orphan_cgroups\"],\"zombies\",h[\"zombie_tracked_pids\"],\"drift\",h[\"projection_drift_detected\"],\"repair\",h.get(\"repair_last_status\"))'"
+```
+
+Observed:
+
+```text
+expected 26 runtime 26 projection 26 cgroups 26 stale 0 orphans 0 zombies 0 drift False repair projection_rebuild_requested
+```
+
+Supporting checks:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s http://127.0.0.1:8000/api/agents | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'"
+ssh ubuntu@10.0.0.240 "sqlite3 /opt/sentinel/data/projection.db \"SELECT status, COUNT(*) FROM agent_live_view GROUP BY status ORDER BY status;\""
+ssh ubuntu@10.0.0.240 "ps -o pid,stat,cmd -p 1291960,1314755,1324475 || true"
+ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon --since '5 min ago' --no-pager | grep -Ei 'panic|drift' || true"
+```
+
+Observed:
+
+```text
+api_agents=26
+active|26
+despawned|34
+PID STAT CMD
+no daemon panic/drift output
+```
+
+PASS: Runtime, Projection, Dashboard API and cgroups converge to the canonical active shift size `26`; stale, orphan and zombie counters are all zero.
+
+### AC-5 - Local Scope Guards After Deploy
+
+Commands:
+
+```bash
+git diff --check
+rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates
+gh -R silentspike/project-sentinel issue view 279 --json number,title,state,labels,url
+```
+
+Observed:
+
+```text
+git diff --check: PASS
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+state=OPEN
+labels include status:in-progress and quality:needs-spec
+url=https://github.com/silentspike/project-sentinel/issues/279
+```
+
+PASS: No Daemon-side model policy change was introduced, and #279 remains open for the AC matrix, benchmarks, PR and verified close sequence.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -407,3 +407,124 @@ no output
 ```
 
 PASS: Slice A tests and release build are green via remote Rust execution only.
+
+## Phase 3 - Slice B Runtime-Control / Reconcile Evidence
+
+### AC-1 - Runtime-Control Types And Backoff
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/lib.rs
+```
+
+Observed implementation:
+
+```text
+RuntimeReconcileRequest { dry_run, projection_rebuild, respawn_missing }
+RuntimeReconcileResponse with stale/orphan/respawn/projection counters
+RuntimeControlCommand::Reconcile
+RespawnBackoffTracker::new(3) with 1/2 tick backoff, then Blocked
+```
+
+PASS: Runtime-control is explicit, typed and bounded.
+
+### AC-2 - Operator Runtime-Reconcile Endpoint
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/operator_api.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+POST /operator/runtime/reconcile
+dispatches RuntimeControlCommand::Reconcile to the ECS thread
+waits with recv_timeout(10s)
+returns RuntimeReconcileResponse
+```
+
+PASS: The Operator API does not mutate runtime state directly; it dispatches into the ECS owner thread.
+
+### AC-3 - Runtime Repair Semantics
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+remove_agent_runtime_fragments()
+run_runtime_reconcile()
+repair_blocked PlatformIntervention event
+.projection-rebuild-request file via runtime_control::write_projection_rebuild_request()
+```
+
+PASS: Reconcile can clean unexpected runtime fragments, orphan cgroups and stale security snapshots, and it can respawn missing expected agents with bounded retries.
+
+### AC-4 - Conflict Resolution
+
+Observed conflict decision:
+
+```text
+orchestrator.rs donor conflict resolved by keeping the current suspend_pids()
+implementation with 2s multi-PID verification from the #264/main lineage.
+The donor's narrower 250ms tracked-PID-only check was not ported.
+```
+
+PASS: Slice B does not regress the stronger live-process stop verification.
+
+### AC-5 - Remote Tests And Release Build
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_control -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 26.37s
+running 2 tests
+test runtime_control::tests::respawn_backoff_tracker_applies_exponential_backoff_until_blocked ... ok
+test runtime_control::tests::write_projection_rebuild_request_persists_request_file ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 177 filtered out; finished in 0.00s
+```
+
+Remote endpoint-dispatch test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_reconcile -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 11.70s
+running 1 test
+test operator_api::tests::runtime_reconcile_is_forwarded_and_returns_response ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 178 filtered out; finished in 0.61s
+```
+
+Remote release build command:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+```
+
+Observed:
+
+```text
+Finished release profile [optimized] target(s) in 1m 00s
+19ce8b228b5588142399a4f712afd4cd89b1caca2be43c1273355a3ad30fe724  target/release/sentinel-daemon
+```
+
+PASS: Slice B tests and release build are green via remote Rust execution only.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -1715,3 +1715,262 @@ url=https://github.com/silentspike/project-sentinel/issues/279
 ```
 
 PASS: No Daemon-side model policy change was introduced, and #279 remains open for the AC matrix, benchmarks, PR and verified close sequence.
+
+## Phase 11 - Full AC Matrix On VM
+
+Date: 2026-04-23
+Command target: `ubuntu@10.0.0.240`
+Operator helper: `/tmp/opcurl`
+
+### AC-1 - Runtime-Health Is Truth-Capable
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "API_AGENTS=\$(curl -s localhost:8000/api/agents | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'); echo api_agents=\$API_AGENTS; /tmp/opcurl http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"expected_active_agents=%s\" % d[\"expected_active_agents\"]); print(\"runtime_agents=%s\" % d[\"runtime_agents\"]); print(\"projection_agents=%s\" % d[\"projection_agents\"]); print(\"projection_drift_detected=%s\" % d[\"projection_drift_detected\"]); print(\"stale_runtime_entries=%s\" % d[\"stale_runtime_entries\"]); print(\"orphan_cgroups=%s\" % d[\"orphan_cgroups\"]); print(\"zombie_tracked_pids=%s\" % d[\"zombie_tracked_pids\"])'"
+```
+
+Observed:
+
+```text
+api_agents=26
+expected_active_agents=26
+runtime_agents=26
+projection_agents=26
+projection_drift_detected=False
+stale_runtime_entries=0
+orphan_cgroups=0
+zombie_tracked_pids=0
+```
+
+PASS: API-, runtime-, projection-, drift-, stale-, orphan- and zombie-truth are live-readable.
+
+Dynamic candidate:
+
+```text
+candidate_id=1
+candidate_name=Thomas Mueller
+candidate_pid=1487965
+```
+
+### AC-2 - Stall Recovery Brings The Agent Back
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/stall-restart-test -H 'Content-Type: application/json' -d '{\"agent_id\":1,\"mode\":\"sigstop\",\"stall_secs\":35}' | python3 -m json.tool"
+```
+
+Observed:
+
+```text
+"accepted": true
+"agent_id": 1
+"agent_name": "Thomas Mueller"
+"mode": "sigstop"
+"stall_secs": 35
+"pid_before": 1487965
+"pid_after": 1488241
+"runtime_present_after": true
+"security_runtime_present_after": true
+"note": "fast_path_restart_executed_without_shift_wait"
+```
+
+Post-check:
+
+```text
+expected 26 runtime 26 projection 26 cgroups 26 stale 0 orphans 0 zombies 0 drift False
+agent_id=1 tracked_pid=1488241 tracked_pid_alive=True tracked_pid_state=S last_repair_status=healthy
+```
+
+PASS: The stalled Agent was respawned immediately, not on the shift-cycle path, and the VM returned to the healthy gate.
+
+### AC-3 - Restore And Reconcile Leave No Runtime Remainders
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/security/fs-ransomware-test -H 'Content-Type: application/json' -d '{\"agent_name\":\"Thomas Mueller\",\"relative_path\":\"issue279-restore-proof.txt\",\"snapshot_label\":\"issue279\"}' | python3 -m json.tool"
+```
+
+Observed:
+
+```text
+"accepted": true
+"agent_name": "Thomas Mueller"
+"relative_path": "issue279-restore-proof.txt"
+"host_path": "/opt/sentinel/fs/AGENT-01/issue279-restore-proof.txt"
+"snapshot_id": "019dba53-6ebb-7bf0-adc6-5de8e8569405"
+"bytes_written": 53
+"before_sha256": "697778f98aa060f58c08bf1d5802ed2ce141ca18dbcbb28eead7acfff15c4d26"
+"mutated_sha256": "9e739a632710cceab9ea861a442390633bf1c541e0f1193d64803ac79804bd3a"
+"restored_sha256": "697778f98aa060f58c08bf1d5802ed2ce141ca18dbcbb28eead7acfff15c4d26"
+"restored": true
+"snapshot_wait_ms": 996
+"restore_wait_ms": 1002
+```
+
+Reconcile command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/reconcile -H 'Content-Type: application/json' -d '{\"dry_run\":false,\"projection_rebuild\":true,\"respawn_missing\":true}' | python3 -m json.tool"
+```
+
+Observed:
+
+```text
+"accepted": true
+"stale_agents_before": 26
+"stale_agents_after": 0
+"orphan_cgroups_before": 0
+"orphan_cgroups_after": 0
+"orphan_cgroups_removed": 26
+"respawned_agents": 26
+"respawn_failures_total": 0
+"projection_rebuild_requested": true
+"errors": []
+```
+
+Final gate after Projection rebuild:
+
+```text
+expected 26 runtime 26 projection 26 cgroups 26 stale 0 orphans 0 zombies 0 drift False respawn_failures 0
+```
+
+PASS: Restore preserves original data hash and Reconcile leaves no stale runtime entries or orphan cgroups. Note: this AC also exposed a conservative full-respawn after the restore path; it ends healthy and is captured as evidence rather than hidden.
+
+### AC-4 - Projection/API Converges Back To Runtime Truth
+
+Drift trigger:
+
+```bash
+ssh ubuntu@10.0.0.240 "timeout 10 sqlite3 /opt/sentinel/data/projection.db \"PRAGMA busy_timeout=5000; SELECT COUNT(*) FROM agent_live_view WHERE agent_id=1;\" | grep -qx '1' && echo precheck_agent_row=1"
+ssh ubuntu@10.0.0.240 "set -e; out=\$(timeout 10 sqlite3 /opt/sentinel/data/projection.db \"PRAGMA busy_timeout=5000; BEGIN IMMEDIATE; DELETE FROM agent_live_view WHERE agent_id=1; SELECT changes(); COMMIT;\"); echo changes=\$out"
+```
+
+Observed:
+
+```text
+precheck_agent_row=1
+changes=5000 1
+```
+
+The row delete succeeded. The `5000` prefix is SQLite echoing `PRAGMA busy_timeout`; the command chain stopped before Reconcile because the first script variant expected exactly `1`.
+
+Repair command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/reconcile -H 'Content-Type: application/json' -d '{\"dry_run\":false,\"projection_rebuild\":true,\"respawn_missing\":false}' | python3 -m json.tool"
+```
+
+Observed:
+
+```text
+before_reconcile expected 26 runtime 26 projection 9 stale 17 drift True
+"accepted": true
+"stale_agents_before": 17
+"stale_agents_after": 17
+"projection_drift_before": true
+"projection_drift_after": true
+"projection_rebuild_requested": true
+"errors": []
+```
+
+Convergence polling:
+
+```text
+1 26 26 26 26 34 0 0 True
+2 26 26 26 26 34 0 0 True
+3 26 26 25 26 33 0 0 True
+4 26 26 26 26 0 0 0 False
+```
+
+PASS: Controlled Projection drift became visible and converged back to runtime truth without a Projection restart storm.
+
+### AC-5 - Worker Panic Causes In-Process Respawn
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "pid_before=\$(pgrep -x sentinel-daemon); /tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/panic-test -H 'Content-Type: application/json' -d '{\"worker\":\"service_health\"}'; sleep 4; pid_after=\$(pgrep -x sentinel-daemon); echo pid_before=\$pid_before pid_after=\$pid_after; /tmp/opcurl http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; d=json.load(sys.stdin); w=d[\"worker_states\"][\"service_health\"]; print(\"running=%s\" % w[\"running\"]); print(\"restart_count=%s\" % w[\"restart_count\"]); print(\"last_error=%s\" % w[\"last_error\"]); print(\"health=%s/%s/%s/%s stale=%s orphans=%s zombies=%s drift=%s\" % (d[\"expected_active_agents\"],d[\"runtime_agents\"],d[\"projection_agents\"],d[\"live_cgroup_dirs\"],d[\"stale_runtime_entries\"],d[\"orphan_cgroups\"],d[\"zombie_tracked_pids\"],d[\"projection_drift_detected\"]))'; journalctl -u sentinel-daemon --since '2 min ago' --no-pager | grep -E 'panic-test requested|Service-Health-Worker panicked|respawn' || true"
+```
+
+Observed:
+
+```text
+{"accepted":true,"worker":"service_health","note":"panic-test dispatched"}
+pid_before=1485419 pid_after=1485419
+running=True
+restart_count=1
+last_error=panic-test requested for service_health
+health=26/26/26/26 stale=34 orphans=0 zombies=0 drift=True
+panic-test requested for service_health
+service-health-checker panicked, respawn im selben Daemon-Prozess error=panic-test requested for service_health
+```
+
+Final gate after the still-running Projection rebuild:
+
+```text
+11 26 26 26 26 0 0 0 False
+```
+
+PASS: The Daemon PID stayed constant, the worker respawned in-process, and the VM returned to the healthy gate.
+
+### AC-6 - Analysis And Recovery Path Is Bounded
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "RSS_BEFORE=\$(ps -o rss= -p \$(pgrep -x sentinel-daemon) | tr -d ' '); /tmp/opcurl -X POST http://127.0.0.1:8084/operator/runtime/analysis-flood-test -H 'Content-Type: application/json' -d '{\"count\":10000}'; sleep 5; RSS_AFTER=\$(ps -o rss= -p \$(pgrep -x sentinel-daemon) | tr -d ' '); /tmp/opcurl http://127.0.0.1:8084/operator/runtime-health | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"analysis_queue_depth=%s\" % d[\"analysis_queue_depth\"]); print(\"analysis_queue_dropped_total=%s\" % d[\"analysis_queue_dropped_total\"]); print(\"analysis_queue_coalesced_total=%s\" % d[\"analysis_queue_coalesced_total\"]); print(\"health=%s/%s/%s/%s stale=%s orphans=%s zombies=%s drift=%s\" % (d[\"expected_active_agents\"],d[\"runtime_agents\"],d[\"projection_agents\"],d[\"live_cgroup_dirs\"],d[\"stale_runtime_entries\"],d[\"orphan_cgroups\"],d[\"zombie_tracked_pids\"],d[\"projection_drift_detected\"]));'; echo rss_before_kb=\$RSS_BEFORE; echo rss_after_kb=\$RSS_AFTER; echo rss_delta_kb=\$((RSS_AFTER-RSS_BEFORE))"
+```
+
+Observed:
+
+```text
+{"accepted":true,"requested":10000,"queue_depth":17,"dropped_total":9983,"coalesced_total":9999,"note":"bounded controlplane and analyzer queues exercised"}
+analysis_queue_depth=1
+analysis_queue_dropped_total=9983
+analysis_queue_coalesced_total=9999
+health=26/26/26/26 stale=0 orphans=0 zombies=0 drift=False
+rss_before_kb=218204
+rss_after_kb=218124
+rss_delta_kb=-80
+```
+
+PASS: Queue pressure is bounded, drop/coalesce counters are visible, RSS is controlled, and the healthy gate remains true.
+
+### AC-7 - 30-Minute VM Soak Ends Healthy
+
+Soak script:
+
+```bash
+scp scripts/vm-issue-279-soak.sh ubuntu@10.0.0.240:/tmp/vm-issue-279-soak.sh
+ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/vm-issue-279-soak.sh /opt/sentinel/scripts/vm-issue-279-soak.sh"
+ssh ubuntu@10.0.0.240 "ISSUE279_SOAK_SECONDS=1800 ISSUE279_POLL_INTERVAL=60 /opt/sentinel/scripts/vm-issue-279-soak.sh"
+```
+
+Observed final output:
+
+```text
+30	2026-04-23T13:05:39Z	26	26	26	26	0	0	0	False	0	9983	9999	26	26	26	26
+final_health=26/26/26/26 stale=0 orphans=0 zombies=0 drift=False
+api_agents=26
+projection_db_active=26
+cgroup_dirs=26
+cgroup_live_dirs=26
+daemon_journal_panic_or_drift=0
+SOAK_PASS out_dir=/tmp/issue279-soak-20260423T123633Z
+```
+
+Artifact summary:
+
+```text
+/tmp/issue279-soak-20260423T123633Z
+health.tsv: 30 samples, all 26/26/26/26 and drift=False
+final-health.json: expected/runtime/projection/cgroups 26/26/26/26, stale=0, orphans=0, zombies=0
+system.tsv: daemon RSS final 250748 KB, daemon CPU 0.3%, projection RSS 9564 KB
+daemon-journal.log: no panic/drift hits during soak window
+projection-journal.log: no panic/error/database-is-locked hits during soak window
+```
+
+PASS: The 30-minute VM soak ended at the canonical active-agent target with no panic or drift regression.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -528,3 +528,124 @@ Finished release profile [optimized] target(s) in 1m 00s
 ```
 
 PASS: Slice B tests and release build are green via remote Rust execution only.
+
+## Phase 4 - Slice C Fast Stall Recovery Evidence
+
+Date: 2026-04-23
+
+### AC-1 - Runtime Stall-Restart Command And Operator Hook
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/operator_api.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+RuntimeControlCommand::StallRestartTest
+RuntimeStallRestartTestRequest { agent_id, mode, stall_secs }
+RuntimeStallRestartTestResponse { pid_before, pid_after, runtime_present_after, security_runtime_present_after, note }
+POST /operator/runtime/stall-restart-test
+```
+
+PASS: The test hook is typed, input-validated, routed through the existing Operator API path, and dispatched into the ECS owner thread.
+
+### AC-2 - Fast-Restart Runtime Semantics
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+restart_agent_fast_path()
+tracked_pid_for_agent()
+PlatformSideEffect::RestartAgent => restart_agent_fast_path(...)
+```
+
+PASS: Restart now removes old runtime, sandbox, eBPF and security fragments before immediately respawning the configured agent in the same tick path.
+
+### AC-3 - Formatting And Remote Tests
+
+Remote format command:
+
+```bash
+cargo remote -c -- fmt --check
+```
+
+Observed:
+
+```text
+PASS after applying remote rustfmt diffs locally.
+```
+
+Remote Operator API test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_stall_restart -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 21.36s
+running 2 tests
+test operator_api::tests::runtime_stall_restart_test_is_forwarded_and_returns_response ... ok
+test operator_api::tests::runtime_stall_restart_test_rejects_invalid_mode ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 180 filtered out; finished in 1.49s
+```
+
+Remote fast-path unit test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon restart_agent_fast_path -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 0.41s
+running 1 test
+bwrap: Can't find source path /work/company: No such file or directory
+bwrap: Can't find source path /work/company: No such file or directory
+test orchestrator::tests::test_restart_agent_fast_path_recreates_runtime_and_security_state ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 181 filtered out; finished in 0.14s
+```
+
+PASS: Slice C behavior is covered by remote Rust tests only. The `bwrap` messages are build-server fixture path warnings and did not fail the test.
+
+### AC-4 - Release Build And Artifact Hash
+
+Remote release build command:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+```
+
+Observed:
+
+```text
+Finished release profile [optimized] target(s) in 56.20s
+3470152e8b897217e2d2e547549b8f6759b3e733ec53d8a3ea8e00745da8d2bd  target/release/sentinel-daemon
+```
+
+Whitespace check command:
+
+```bash
+git diff --check
+```
+
+Observed:
+
+```text
+PASS: no output, exit 0
+```
+
+PASS: Slice C builds with the FUSE feature and has a reproducible release artifact hash.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -284,3 +284,126 @@ Refresh CHANGELOG and verification evidence in this branch only.
 ```
 
 PASS: The implementation path is now deterministic and scope-clean.
+
+## Phase 2 / Slice A - Runtime-Health-Read-Model
+
+Date: 2026-04-23
+
+### AC-1 - Runtime-Health Snapshot Model
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_health.rs
+services/sentinel-daemon/src/orchestrator.rs
+services/sentinel-daemon/src/service_health.rs
+services/sentinel-daemon/Cargo.toml
+Cargo.lock
+```
+
+Observed implementation:
+
+```text
+RuntimeHealthSnapshot fields include:
+- current_shift
+- expected_active_agents
+- runtime_agents
+- projection_agents
+- security_runtime_entries
+- sandbox_handles
+- tracked_processes
+- live_cgroup_dirs
+- stale_runtime_entries
+- orphan_cgroups
+- zombie_tracked_pids
+- worker_states
+- analysis_queue_depth
+- analysis_queue_dropped_total
+- analysis_queue_coalesced_total
+- reconcile counters
+- operator_auth_required
+- per-agent runtime/projection/cgroup/security details
+```
+
+PASS: The snapshot is read-only and composes runtime, Projection, cgroup, security-runtime and worker-state truth without adding repair behavior in Slice A.
+
+### AC-2 - Operator Endpoint And Auth Wiring
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/operator_api.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+GET /operator/runtime-health
+protected by is_protected_read_path()
+uses existing shared-secret authorization rule when configured
+returns RuntimeHealthSnapshot from SharedRuntimeHealthState
+```
+
+Conflict resolution:
+
+```text
+operator_api.rs donor conflict resolved by keeping current main open_fs_layer()
+and adding only is_protected_read_path() for /operator/runtime-health.
+Donor open_artifact_plane() was not ported into Slice A.
+```
+
+PASS: The endpoint follows the existing Operator API read-path/auth structure and does not introduce a parallel control path.
+
+### AC-3 - Remote Tests And Release Build
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_health -- --nocapture
+```
+
+Observed:
+
+```text
+Finished test profile [unoptimized + debuginfo] target(s) in 7.36s
+running 3 tests
+test runtime_health::tests::build_snapshot_marks_missing_projection_and_security_as_stale ... ok
+test operator_api::tests::runtime_health_endpoint_returns_snapshot ... ok
+test operator_api::tests::runtime_health_endpoint_requires_auth_when_secret_is_set ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 173 filtered out; finished in 10.28s
+```
+
+Initial warning found and fixed:
+
+```text
+unused import: crate::runtime_health::RuntimeHealthSnapshot
+fix: moved RuntimeHealthSnapshot import into operator_api::tests
+```
+
+Remote release build command:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+```
+
+Observed:
+
+```text
+Finished release profile [optimized] target(s) in 1m 07s
+7b5145a77da0a55a3e9e9da00b2d9036ce943df748d327b4095f87955b0034d2  target/release/sentinel-daemon
+```
+
+Static hygiene:
+
+```bash
+git diff --check
+```
+
+Observed:
+
+```text
+no output
+```
+
+PASS: Slice A tests and release build are green via remote Rust execution only.

--- a/test-279-verification.md
+++ b/test-279-verification.md
@@ -775,3 +775,201 @@ PASS: no output, exit 0
 ```
 
 PASS: Slice D builds with the FUSE feature and has a reproducible release artifact hash.
+
+## Phase 6 - Slice E Bounded Analysis-/Recovery-Pfade Evidence
+
+Date: 2026-04-23
+
+### AC-1 - Bounded Platform-Controlplane Trigger Queue
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/platform_controlplane/mod.rs
+config/daemon.toml
+services/sentinel-daemon/src/config.rs
+```
+
+Observed implementation:
+
+```text
+llm_trigger_queue_capacity = 16
+queued_analysis_triggers: VecDeque<QueuedAnalysisTrigger>
+analysis_queue_dropped_total
+analysis_queue_coalesced_total
+enqueue_analysis_trigger()
+analysis_queue_stats()
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon trigger_queue -- --nocapture
+```
+
+Observed:
+
+```text
+running 2 tests
+test platform_controlplane::tests::test_manual_trigger_queue_coalesces_duplicates ... ok
+test platform_controlplane::tests::test_test_trigger_queue_drops_when_capacity_is_exceeded ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 188 filtered out
+```
+
+PASS: The pre-worker trigger queue is bounded, coalesces duplicate triggers and drops oldest entries when capacity is exceeded.
+
+### AC-2 - Bounded LLM Analyzer Channel
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/platform_controlplane/llm_analyzer.rs
+```
+
+Observed implementation:
+
+```text
+llm_analysis_channel_capacity = 16
+PlatformLlmAnalyzerHandle::queue_stats()
+try_send()
+TrySendError::Full
+dropped_total
+depth
+```
+
+Remote test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon enqueue_drops_when_bounded_queue_is_full -- --nocapture
+```
+
+Observed:
+
+```text
+running 1 test
+test platform_controlplane::llm_analyzer::tests::enqueue_drops_when_bounded_queue_is_full ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 189 filtered out
+```
+
+PASS: Analyzer enqueue uses bounded `try_send()` semantics and records drops when the bounded channel is full.
+
+### AC-3 - Runtime-Health Queue Stats
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_health.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+publish_runtime_health_snapshot(..., analysis_queue_stats)
+analysis_queue_depth
+analysis_queue_dropped_total
+analysis_queue_coalesced_total
+```
+
+PASS: Runtime-health snapshots receive merged Platform-Controlplane and LLM-Analyzer queue stats, so VM verification can read current depth/drop/coalescing state from the runtime truth surface after deploy.
+
+### AC-4 - Deterministic Analysis Flood Test Hook
+
+Code scope:
+
+```text
+services/sentinel-daemon/src/runtime_control.rs
+services/sentinel-daemon/src/operator_api.rs
+services/sentinel-daemon/src/orchestrator.rs
+```
+
+Observed implementation:
+
+```text
+RuntimeControlCommand::AnalysisFloodTest
+RuntimeAnalysisFloodTestRequest { count }
+RuntimeAnalysisFloodTestResponse { accepted, requested, queue_depth, dropped_total, coalesced_total, note }
+POST /operator/runtime/analysis-flood-test
+```
+
+Remote Operator API test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon runtime_analysis_flood_test -- --nocapture
+```
+
+Observed:
+
+```text
+running 2 tests
+test operator_api::tests::runtime_analysis_flood_test_rejects_zero_count ... ok
+test operator_api::tests::runtime_analysis_flood_test_is_forwarded_and_returns_response ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 188 filtered out; finished in 0.06s
+```
+
+PASS: The flood hook is typed, validates `count > 0`, dispatches through Runtime-Control into the ECS owner thread and returns queue-pressure counters.
+
+### AC-5 - Format, Clippy, Build, Artifact And Scope Guard
+
+Remote config test command:
+
+```bash
+cargo remote -c -- test -p sentinel-daemon test_parse_config -- --nocapture
+```
+
+Observed:
+
+```text
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 188 filtered out
+```
+
+Remote clippy command:
+
+```bash
+cargo remote -c -- clippy -p sentinel-daemon --all-targets --features fuse -- -D warnings
+```
+
+Observed:
+
+```text
+Finished dev profile [unoptimized + debuginfo] target(s) in 2m 59s
+```
+
+Remote release build command:
+
+```bash
+cargo remote -c -- build -p sentinel-daemon --release --features fuse
+```
+
+Observed:
+
+```text
+Finished release profile [optimized] target(s) in 56.44s
+39bf79442190541ec03f11a66c4e8be437f6a8bd1f2e2366611a0d9ad0366cb2  target/release/sentinel-daemon
+```
+
+Whitespace check command:
+
+```bash
+git diff --check
+```
+
+Observed:
+
+```text
+PASS: no output, exit 0
+```
+
+Scope guard command:
+
+```bash
+rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates || true
+```
+
+Observed:
+
+```text
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+```
+
+PASS: Slice E builds, lints and keeps model selection out of the Daemon. The only runtime model-related match is the intended Gateway-default path.

--- a/typos.toml
+++ b/typos.toml
@@ -32,6 +32,10 @@ muessen = "muessen"
 moglich = "moglich"
 Woche = "Woche"
 und = "und"
+ded = "ded"                   # commit hash fragment, e.g. 300ded0
+fand = "fand"
+relevante = "relevante"
+temporaere = "temporaere"
 
 # Sprint 2 domain words (ECS, Bio-Engine, Physics, Room System)
 Buero = "Buero"


### PR DESCRIPTION
## Summary

Implements #279 daemon resilience closure on a clean `main` slice: runtime-health truth, deterministic reconcile, fast stall recovery, worker supervision, bounded analysis queues, Projection convergence, conditional FUSE/Landlock runtime restore, VM soak, and VM benchmarks.

## Changes

- Added loopback/auth-aware runtime-health and runtime-control Operator paths for health, reconcile, stall restart, panic test, and analysis flood testing.
- Added deterministic runtime reconciliation across daemon runtime state, cgroups, security runtime state, Projection, and API-visible truth.
- Added fast same-tick Agent stall restart and in-process `service_health` supervision via `catch_unwind`.
- Bounded Platform-Controlplane and LLM-analysis trigger paths with drop/coalesce counters surfaced through runtime-health.
- Added Projection rebuild request handling and read-only Projection reads for runtime-health drift detection.
- Hardened conditional FUSE/Landlock runtime startup so inactive FUSE falls back to `/ram/agents` and Landlock execute scope remains narrow.
- Added VM soak and benchmark harnesses plus CHANGELOG and verification evidence.

## Linked Issues

- Closes #279
- Related follow-up: #314 tracks Agent model defaults in the Gateway/Inference layer and is intentionally out of scope here.

## Test Plan

- `cargo remote -c -- fmt --all`
- `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`
- `cargo remote -c -- test -q -p sentinel-projection -- --nocapture`
- `cargo remote -c -- test -q -p sentinel-projection-service -- --nocapture`
- `cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture`
- `cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture`
- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
- `cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings`
- `cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings`
- `cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings`
- `cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings`
- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
- `cargo remote -c -- build -q -p sentinel-projection-service --release`
- `cargo remote -c -- build -q -p sentinel-sandbox --release --bins`
- `git diff --check`
- `bash -n scripts/vm-issue-279-soak.sh`
- `bash -n scripts/vm-issue-279-bench.sh`
- Deployed release artifacts to `10.0.0.240` at the verified systemd `ExecStart` paths and restarted services.
- Verified every AC on `10.0.0.240` through SSH and loopback Operator API calls.

## Benchmarks

All benchmarks ran on the Deploy VM with sidecar system monitoring under `/tmp/issue279-bench-20260423T132030Z`.

| Benchmark | Actual | Target | Result |
|---|---:|---:|---|
| runtime_reconcile_26_agents | 2134us | < 5000us | PASS |
| projection_divergence_detection | 817us | < 5000us | PASS |
| analysis_flood_cap | 148ns/request | < 250000ns/request | PASS |
| stall_recovery_bookkeeping | 700ns | < 50000ns | PASS |

```text
BENCH_PASS out_dir=/tmp/issue279-bench-20260423T132030Z
sidecars: free-before/after, vmstat-before/after, iostat-before/after, ps-before/after
final health: expected/runtime/projection/cgroups = 26/26/26/26, stale=0, orphans=0, zombies=0, drift=false
journal panic/drift marker scan: empty
```

## Evidence (AC Mapping)

| Issue | AC-ID | Evidence (command/output/artifact) |
|---|---|---|
| #279 | AC-1 | `ssh ubuntu@10.0.0.240 "/tmp/opcurl http://127.0.0.1:8084/operator/runtime-health ..."` showed `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`; full output in `test-279-verification.md`. |
| #279 | AC-2 | `POST /operator/runtime/stall-restart-test` changed `Thomas Mueller` PID from `1487965` to `1488241` and returned to healthy `26/26/26/26`. |
| #279 | AC-3 | Restore test restored original file hash; Reconcile left `stale=0`, `orphans=0`, `zombies=0`, `drift=false`. |
| #279 | AC-4 | Controlled SQLite Projection drift was detected, Reconcile requested rebuild, and polling converged back to `26/26/26/26`. |
| #279 | AC-5 | `POST /operator/runtime/panic-test` kept daemon PID `1485419`, `service_health running=true`, `restart_count=1`, and final health recovered. |
| #279 | AC-6 | `POST /operator/runtime/analysis-flood-test` with `10000` triggers stayed bounded: `queue_depth=1`, `dropped=9983`, `coalesced=9999`, `rss_delta_kb=-80`. |
| #279 | AC-7 | 30-minute soak passed: `SOAK_PASS out_dir=/tmp/issue279-soak-20260423T123633Z`, final `26/26/26/26`, no panic/drift journal hits. |

Concrete evidence files:

```text
test-279-verification.md
PROGRESS.md
/tmp/issue279-soak-20260423T123633Z
/tmp/issue279-bench-20260423T132030Z
VM daemon hash: 7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d
```

## Checklist

- [x] CHANGELOG.md updated
- [x] No breaking changes expected; runtime test hooks are loopback/auth-aware Operator paths
- [x] Performance impact considered with VM benchmarks and sidecar CPU/RAM/IOPS monitoring
- [x] No secrets committed; Operator key handling remains runtime-only via shared secret when configured
- [x] Linked issue has `quality:ready` and `scope:full`
- [x] `status:verified` will be added to #279 before merge/close
- [x] NOT Tested documented

## Notes

Haiku / Agent model policy is deliberately not implemented in the daemon. It is tracked separately in #314 so model defaults remain in the Gateway/Inference layer.

## NOT Tested

- Cross-shift multi-hour soak was not run for #279; AC-7 required a scoped 30-minute VM soak, which passed.
