### PR TITLE
feat: route agent runtime model policy through gateway (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Gateway Model Policy: Agent-Runtime defaultet ueber Inference-Layer auf Haiku** (#314)
+- **Gateway Model Policy: Agent-Runtime nutzt ueber Inference-Layer standardmaessig Haiku** (#314)
   - neue Gateway-Request-Klassen fuer `external_compat`, `agent_runtime`, `platform_controlplane`, `service_internal` und `internal_other`
-  - `agent_runtime_model_policy` defaultet im Gateway-Control-State auf `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
+  - `agent_runtime_model_policy` setzt im Gateway-Control-State standardmaessig `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
   - Agent-Runtime-Requests mit positiver numerischer `agent_id` bekommen vor dem Provider-Forward effektiv `model=haiku`; explizite Request-Modelle gewinnen weiterhin
   - `/v1/messages` bleibt externer Anthropic-/MITM-Compatibility-Pfad mit `anthropic-direct`
   - Traffic-Stats, Response-Log und Journal zeigen redigiert `request_class`, `provider`, `policy_source` und `effective_model`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Gateway Model Policy: Agent-Runtime defaultet ueber Inference-Layer auf Haiku** (#314)
+  - neue Gateway-Request-Klassen fuer `external_compat`, `agent_runtime`, `platform_controlplane`, `service_internal` und `internal_other`
+  - `agent_runtime_model_policy` defaultet im Gateway-Control-State auf `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
+  - Agent-Runtime-Requests mit positiver numerischer `agent_id` bekommen vor dem Provider-Forward effektiv `model=haiku`; explizite Request-Modelle gewinnen weiterhin
+  - `/v1/messages` bleibt externer Anthropic-/MITM-Compatibility-Pfad mit `anthropic-direct`
+  - Traffic-Stats, Response-Log und Journal zeigen redigiert `request_class`, `provider`, `policy_source` und `effective_model`
+  - Response-Log-Buffer nutzt jetzt einen bounded circular buffer statt steady-state Slice-Kopie
+
 - **Daemon Hardening: Runtime-Truth, Reconcile und deterministischer Stall-Restart** (#279)
   - neues Runtime-Read-Model `RuntimeHealthSnapshot` plus `GET /operator/runtime-health` fuer Drift-, Worker- und Agent-Truth
   - neuer Runtime-Control-Pfad `POST /operator/runtime/reconcile` fuer stale cleanup, orphan-cgroup cleanup, kontrollierten Respawn und Projection-Rebuild-Request

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_4_DONE_TASK_5_PENDING`
-- Current task: `Task 5 - Phase 5: Benchmarks`
+- Overall status: `TASK_5_DONE_TASK_6_PENDING`
+- Current task: `Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -54,6 +54,14 @@
   - Response-Log-Test prueft Ring-Overwrite, chronologische Ausgabe und `LastByClass`.
   - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
   - `go build ./cmd/cortex-gateway` ist gruen.
+- Task 5 ist erledigt:
+  - Benchmark-Harness fuer `ClassifyRequest`, `ResolveModelPolicy` und `ResponseLogBuffer.Add` wurde ergaenzt.
+  - Benchmarks mit `benchmem` laufen gruen:
+    - `BenchmarkClassifyRequestAgentRuntime`: `494.9 ns/op`, `16 B/op`, `1 allocs/op`
+    - `BenchmarkResolveModelPolicyAgentRuntime`: `38.43 ns/op`, `0 B/op`, `0 allocs/op`
+    - `BenchmarkResponseLogBufferAdd`: `3831 ns/op`, `0 B/op`, `0 allocs/op`
+  - Zielwerte sind erfuellt: Classify `<1us`, Resolve `<1us`, ResponseLog Add `<10us`.
+  - `/usr/bin/time -v`, `vmstat` und `iostat` wurden fuer CPU/RAM/IO-Evidence erfasst.
 
 ## Blocked items
 
@@ -65,7 +73,7 @@
 - `a42ef76` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
 - `b953e4a` Task [2] Phase 2 - Gateway Policy-Layer
 - `114732d` Task [3] Phase 3 - Observability und Response Log
-- `TBD` Task [4] Phase 4 - Go-Tests
+- `b326a2f` Task [4] Phase 4 - Go-Tests
 - `TBD` Task [5] Phase 5 - Benchmarks
 - `TBD` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
 - `TBD` Task [7] Phase 8 - AC-Matrix und Live-Verifikation
@@ -80,11 +88,52 @@
 | 2 | Phase 2 - Gateway Policy-Layer | DONE | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
 | 3 | Phase 3 - Observability und Response Log | DONE | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, bounded circular buffer | inspect, command |
 | 4 | Phase 4 - Go-Tests | DONE | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
-| 5 | Phase 5 - Benchmarks | PENDING | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
+| 5 | Phase 5 - Benchmarks | DONE | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | PENDING | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
 | 7 | Phase 8 - AC-Matrix und Live-Verifikation | PENDING | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
 | 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
 | 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
+
+## Task 5 - Phase 5: Benchmarks
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - Benchmark-Harness fuer `ClassifyRequest`, `ResolveModelPolicy` und `ResponseLogBuffer.Add` ergaenzen oder vorhandene Benchmarks erweitern
+  - Benchmarks mit Zielwerten aus dem Plan ausfuehren
+  - System-Monitoring parallel dokumentieren: CPU, RAM, Disk/IOPS soweit lokal sinnvoll messbar
+  - Benchmark-Evidence in `test-314-verification.md` festhalten
+- Welche ACs muessen hier passen:
+  - AC-1: `ClassifyRequest` bleibt unter `1us/op`.
+  - AC-2: `ResolveModelPolicy` bleibt unter `1us/op`.
+  - AC-3: `ResponseLogBuffer.Add` bleibt unter `10us/op`.
+  - AC-4: Benchmarks laufen mit `allocs/op` sichtbar.
+  - AC-5: System-Monitoring zeigt keine auffaellige lokale Lastspitze.
+- Wie wird bewiesen:
+  - `go test ./cmd/cortex-gateway/internal/proxy -bench 'Benchmark(ClassifyRequest|ResolveModelPolicy|ResponseLogBufferAdd)' -benchmem -run '^$'`
+  - Sidecar-Monitoring per `ps`, `vmstat`, optional `iostat` falls vorhanden
+- Erwartete Dateien:
+  - `cmd/cortex-gateway/internal/proxy/bench_test.go`
+  - `test-314-verification.md`
+  - `PROGRESS.md`
+- Risiken:
+  - Go-Benchmarkzeiten variieren lokal; Zielwerte muessen mit ausreichender Marge gegen ns/op liegen, nicht aus Einzellaeufen ueberinterpretiert werden.
+
+### Outcome
+
+- `bench_test.go` enthaelt jetzt Microbenchmarks fuer `ClassifyRequest`, `ResolveModelPolicy` und `ResponseLogBuffer.Add`.
+- Alle drei Benchmarks liegen deutlich unter den Zielwerten.
+- `benchmem` zeigt Allokationen explizit.
+- Lokales System-Monitoring wurde parallel bzw. ergaenzend per `/usr/bin/time -v`, `vmstat` und `iostat` dokumentiert.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-5 Command/Output-Evidence.
+- AC-1 PASS: `ClassifyRequest` `494.9 ns/op` < `1us/op`.
+- AC-2 PASS: `ResolveModelPolicy` `38.43 ns/op` < `1us/op`.
+- AC-3 PASS: `ResponseLogBuffer.Add` `3831 ns/op` < `10us/op`.
+- AC-4 PASS: `benchmem` zeigt `B/op` und `allocs/op`.
+- AC-5 PASS: `/usr/bin/time -v`, `vmstat` und `iostat` erfasst; keine Benchmark-Blockade oder Swap-Fehler.
 
 ## Task 4 - Phase 4: Go-Tests
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_1_DONE_TASK_2_PENDING`
-- Current task: `Task 2 - Phase 2: Gateway Policy-Layer`
+- Overall status: `TASK_2_DONE_TASK_3_PENDING`
+- Current task: `Task 3 - Phase 3: Observability und Response Log`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -29,6 +29,16 @@
   - `quality:needs-spec`, `status:triage` und `status:backlog` wurden entfernt.
   - `ssh ubuntu@10.0.0.240 "/usr/bin/claude -p --model haiku 'Antworte exakt mit PONG.'"` lieferte `PONG`.
   - In Task 1 wurde kein Daemon-Code geaendert.
+- Task 2 ist erledigt:
+  - `RequestClass` wurde zentral im Gateway eingefuehrt.
+  - `agent_runtime` wird nur bei positiver numerischer `agent_id` und nach Ausschluss von Platform-/Service-/Analysepfaden gesetzt.
+  - `agent_runtime_model_policy` defaultet in der Control-Config auf `haiku`.
+  - `ResolveModelPolicy` setzt Haiku nur fuer `agent_runtime` ohne explizites Modell.
+  - `/v1/messages` bleibt `external_compat` und `PreferredProvider=anthropic-direct`.
+  - ungueltige Policy/Provider-Kombinationen failen vor dem Provider-Call mit `model policy rejected`.
+  - Zwischenfund: Die Policy wurde nach erstem Testfail aus dem Pre-Synthesis-Pfad in den echten Forward-Pfad verschoben.
+  - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
+  - `go build ./cmd/cortex-gateway` ist gruen.
 
 ## Blocked items
 
@@ -37,7 +47,7 @@
 
 ## Commit references
 
-- `TBD` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
+- `a42ef76` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
 - `TBD` Task [2] Phase 2 - Gateway Policy-Layer
 - `TBD` Task [3] Phase 3 - Observability und Response Log
 - `TBD` Task [4] Phase 4 - Go-Tests
@@ -52,7 +62,7 @@
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
 | 1 | Phase 1 - Issue-Body-Repair, Branch und Preflight | DONE | Branch von main, GitHub-Body reparieren, `quality:ready`, Haiku-String fuer claude-code pruefen, Platform-Controlplane out-of-scope bestaetigen | command, inspect, system |
-| 2 | Phase 2 - Gateway Policy-Layer | PENDING | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
+| 2 | Phase 2 - Gateway Policy-Layer | DONE | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
 | 3 | Phase 3 - Observability und Response Log | PENDING | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, ggf. bounded circular buffer | inspect, command |
 | 4 | Phase 4 - Go-Tests | PENDING | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
 | 5 | Phase 5 - Benchmarks | PENDING | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
@@ -133,3 +143,53 @@
 - Risiken:
   - aktuelle Config-Strukturen koennen in `control` statt `proxy` liegen; keine neue Parallel-Konfig bauen, sondern bestehende Patterns nutzen.
   - Response-Observability gehoert erst in Task 3; Task 2 soll Policy-Entscheidung und Request-Klassen sauber schneiden.
+
+### Outcome
+
+- `cmd/cortex-gateway/internal/proxy/policy.go` neu eingefuehrt.
+- `LLMRequest` traegt jetzt `RequestClass`, `EffectiveModel` und `PolicySource` als interne Felder.
+- `control.ConfigSnapshot` und `control.Config` enthalten `AgentRuntimeModelPolicy`.
+- Default fuer `agent_runtime_model_policy` ist `haiku`.
+- `pipeline.ServeHTTP` klassifiziert Requests frueh, wendet die Modellpolicy aber erst im echten Forward-Pfad vor Streaming/Provider.Send an.
+- Die erste Testiteration zeigte eine Pre-Synthesis-Blockade; diese wurde durch Verschieben der Policy-Anwendung behoben.
+- Testprovider `mock` mappt `haiku` fuer bestehende Gateway-Tests; unbekannte Provider bleiben fail-closed.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-2 Command/Output-Evidence.
+- AC-1 PASS: `RequestClassExternalCompat`, `RequestClassAgentRuntime`, `RequestClassPlatformControlplane`, `RequestClassServiceInternal`, `RequestClassInternalOther` in `policy.go`.
+- AC-2 PASS: `ClassifyRequest()` prueft `/v1/messages`, `platform_analysis`, `request_type`, Service-Identitaeten und erst danach numerische Agent-ID.
+- AC-3 PASS: `ResolveModelPolicy()` setzt Haiku nur fuer `RequestClassAgentRuntime` ohne explizites Modell.
+- AC-4 PASS: explizites Request-Modell gewinnt mit `PolicySourceRequestOverride`.
+- AC-5 PASS: `/v1/messages` bleibt `PreferredProvider=anthropic-direct` und `RequestClassExternalCompat`.
+- AC-6 PASS: nicht unterstuetzte Provider liefern `model policy rejected`, kein stiller Opus-Fallback.
+- Command PASS: `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`.
+- Command PASS: `go build ./cmd/cortex-gateway`.
+
+## Task 3 - Phase 3: Observability und Response Log
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - `traffic-stats` um Agent-Runtime-Policy und letzten effektiven Runtime-Forward erweitern
+  - `ResponseLogEntry` um `request_class`, `model`, `policy_source`, `agent_id`, `agent_name` erweitern
+  - Journal-Logs fuer Success-, Stream- und Provider-Error-Pfade mit Request-Klasse und Policy-Feldern anreichern
+  - pruefen, ob `ResponseLogBuffer` wegen Hot-Path-Kopieren auf bounded circular buffer umgebaut werden muss
+- Welche ACs muessen hier passen:
+  - AC-1: Traffic-Stats zeigen `agent_runtime_model_policy`, `last_agent_runtime_effective_model`, `last_agent_runtime_policy_source`.
+  - AC-2: Traffic-Responses zeigen redigiert `request_class`, `provider`, `model`, `policy_source`, `agent_id`, `agent_name`.
+  - AC-3: Success-, Stream- und Error-Logs enthalten die neuen Felder.
+  - AC-4: keine Header, Tokens oder Secrets werden in Response-Log/Stats aufgenommen.
+  - AC-5: Response-Log-Append bleibt bounded und ohne O(n)-Kopie im steady state, falls Benchmarks das erzwingen.
+- Wie wird bewiesen:
+  - Go-Tests/Build nach Edit
+  - strukturelle Inspection fuer Secret-Freiheit
+  - Benchmarks folgen in Task 5
+- Erwartete Dateien:
+  - `cmd/cortex-gateway/internal/proxy/response_log.go`
+  - `cmd/cortex-gateway/internal/proxy/pipeline.go`
+  - `cmd/cortex-gateway/main.go`
+  - Tests in `cmd/cortex-gateway/internal/proxy` und ggf. `cmd/cortex-gateway/internal/control`
+- Risiken:
+  - `traffic-stats` lebt in `main.go` und muss ohne zusaetzliche globale State-Duplikation an Gateway-Daten kommen.
+  - Error-Logs muessen AC-4 belegen koennen, auch wenn `/v1/messages` mit Dummy-Key fehlschlaegt.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_7_DONE_TASK_8_PENDING`
-- Current task: `Task 8 - Dokumentation, PR- und Close-Sequenz`
+- Overall status: `TASK_8_DONE_TASK_9_PENDING`
+- Current task: `Task 9 - Plan-Verifikation`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -79,6 +79,10 @@
   - AC-5 PASS: `traffic-stats`, `traffic-responses` und Journal zeigen redigierte Felder; Secret-Grep fand keine Token/API-Key-Werte.
   - AC-6 PASS: Go-Tests plus VM-Smoke belegen interne Runtime-Default-Policy getrennt vom externen Compatibility-Pfad.
   - Panic/Drift-Grep fuer Gateway/Daemon seit Live-Verifikation ist leer.
+- Task 8 ist erledigt:
+  - `CHANGELOG.md` enthaelt einen #314-Unreleased-Eintrag.
+  - PR-Pflichtsektionen sind fuer `gh pr create` vorbereitet: Summary, Changes, Linked Issues, Test Plan, Benchmarks, Evidence, Checklist.
+  - Issue-Close-Sequenz bleibt korrekt nachgelagert: erst PR/CI/Merge, dann `status:verified`, dann Close.
 
 ## Blocked items
 
@@ -108,7 +112,7 @@
 | 5 | Phase 5 - Benchmarks | DONE | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | DONE | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
 | 7 | Phase 8 - AC-Matrix und Live-Verifikation | DONE | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
-| 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
+| 8 | Dokumentation, PR- und Close-Sequenz | DONE | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
 | 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
 
 ## Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240
@@ -208,6 +212,43 @@
 - AC-4 PASS: `/v1/messages` Dummy-Key-Test zeigt im Journal `provider=anthropic-direct`, `request_class=external_compat`, `effective_model=claude-opus-4-6`, `policy_source=request_override`.
 - AC-5 PASS: Observability- und Secret-Grep erfolgreich.
 - AC-6 PASS: Go-Tests plus VM-Smoke decken beide Pfade ab.
+
+## Task 8 - Dokumentation, PR- und Close-Sequenz
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - `CHANGELOG.md` aktualisieren
+  - PR-Pflichtsektionen vorbereiten
+  - keine Issue-Schliessung vor PR/Merge/CI
+  - Evidence-Datei aktuell halten
+- Welche ACs muessen hier passen:
+  - AC-1: CHANGELOG enthaelt #314.
+  - AC-2: PR-Body kann alle 7 Pflichtsektionen fuellen.
+  - AC-3: Close-Sequenz bleibt `status:verified` vor `gh issue close`.
+- Wie wird bewiesen:
+  - `rg "#314|Gateway Model Policy" CHANGELOG.md`
+  - PR-Erstellung nach Task-Commit mit Pflichtsektionen
+  - Issue-Label/Close erst nach Merge
+- Erwartete Dateien:
+  - `CHANGELOG.md`
+  - `PROGRESS.md`
+  - `test-314-verification.md`
+- Risiken:
+  - PR/Close vor finaler Plan-Verifikation waere gegen `$start`; deshalb nur vorbereiten, dann Task 9 final pruefen.
+
+### Outcome
+
+- `CHANGELOG.md` hat einen Unreleased-Eintrag fuer #314.
+- PR-Body-Sektionierung ist vorbereitet.
+- Close-Reihenfolge ist dokumentiert und bleibt bis nach PR/Merge gesperrt.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-8 Command/Output-Evidence.
+- AC-1 PASS: CHANGELOG enthaelt #314-Eintrag.
+- AC-2 PASS: PR-Pflichtsektionen werden beim `gh pr create` verwendet.
+- AC-3 PASS: `status:verified`/Close bleibt nach finaler Verifikation und Merge.
 
 ## Task 5 - Phase 5: Benchmarks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_5_DONE_TASK_6_PENDING`
-- Current task: `Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240`
+- Overall status: `TASK_6_DONE_TASK_7_PENDING`
+- Current task: `Task 7 - Phase 8: AC-Matrix und Live-Verifikation`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -62,6 +62,15 @@
     - `BenchmarkResponseLogBufferAdd`: `3831 ns/op`, `0 B/op`, `0 allocs/op`
   - Zielwerte sind erfuellt: Classify `<1us`, Resolve `<1us`, ResponseLog Add `<10us`.
   - `/usr/bin/time -v`, `vmstat` und `iostat` wurden fuer CPU/RAM/IO-Evidence erfasst.
+- Task 6 ist erledigt:
+  - `sentinel-gateway` nutzt laut systemd `ExecStart=/opt/sentinel/bin/cortex-gateway`.
+  - Altes Binary wurde gesichert unter `/opt/sentinel/bin/cortex-gateway.bak-issue314-20260424062401`.
+  - Erster Copy-Versuch traf `Text file busy`; Fix war kontrolliertes `systemctl stop`, Copy, `systemctl start`.
+  - Neues Binary `/opt/sentinel/bin/cortex-gateway` ist deployed (`23244031` Bytes, `2026-04-24 06:24 UTC`).
+  - `sentinel-gateway` ist `active`.
+  - `curl -s localhost:8080/health` liefert `status=ok`.
+  - `curl -s localhost:8081/control/traffic-stats` enthaelt `agent_runtime_model_policy: haiku`.
+  - PID-basiertes Gateway-Journal seit Restart zeigt Startup-Logs ohne Panic/Fatal.
 
 ## Blocked items
 
@@ -74,7 +83,7 @@
 - `b953e4a` Task [2] Phase 2 - Gateway Policy-Layer
 - `114732d` Task [3] Phase 3 - Observability und Response Log
 - `b326a2f` Task [4] Phase 4 - Go-Tests
-- `TBD` Task [5] Phase 5 - Benchmarks
+- `9d2adf5` Task [5] Phase 5 - Benchmarks
 - `TBD` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
 - `TBD` Task [7] Phase 8 - AC-Matrix und Live-Verifikation
 - `TBD` Task [8] Dokumentation, PR- und Close-Sequenz
@@ -89,10 +98,58 @@
 | 3 | Phase 3 - Observability und Response Log | DONE | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, bounded circular buffer | inspect, command |
 | 4 | Phase 4 - Go-Tests | DONE | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
 | 5 | Phase 5 - Benchmarks | DONE | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
-| 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | PENDING | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
+| 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | DONE | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
 | 7 | Phase 8 - AC-Matrix und Live-Verifikation | PENDING | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
 | 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
 | 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
+
+## Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - VM-Servicepfad und `ExecStart` fuer `sentinel-gateway` pruefen
+  - lokales Linux/amd64 Gateway-Binary bauen
+  - Binary nach `/opt/sentinel/bin/cortex-gateway` deployen
+  - `sentinel-gateway` restart ausfuehren
+  - Smoke-Checks gegen `/health` und `/control/traffic-stats`
+  - Gateway-Journal auf offensichtliche Startfehler pruefen
+- Welche ACs muessen hier passen:
+  - AC-1: Deploy trifft den tatsaechlich von systemd gestarteten Binary-Pfad.
+  - AC-2: Service ist nach Restart `active`.
+  - AC-3: `/health` liefert OK.
+  - AC-4: `/control/traffic-stats` enthaelt `agent_runtime_model_policy`.
+  - AC-5: Journal zeigt keinen unmittelbaren Panic-/Fatal-Startfehler.
+- Wie wird bewiesen:
+  - `ssh ubuntu@10.0.0.240 "systemctl cat sentinel-gateway ..."`
+  - `GOOS=linux GOARCH=amd64 go build -o cortex-gateway ./cmd/cortex-gateway/`
+  - `scp`, `sudo cp`, `sudo systemctl restart sentinel-gateway`
+  - `curl -s localhost:8080/health`
+  - `curl -s localhost:8081/control/traffic-stats`
+  - `journalctl _PID=$(pgrep cortex-gate) --since '2 min ago' --no-pager`
+- Erwartete Dateien:
+  - lokales Build-Artefakt `cortex-gateway` untracked/ignored
+  - `test-314-verification.md`
+  - `PROGRESS.md`
+- Risiken:
+  - VM kann busy sein; falls Restart fehlschlaegt, sofort Journal lesen und Service nicht kaputt stehen lassen.
+
+### Outcome
+
+- `ExecStart=/opt/sentinel/bin/cortex-gateway` wurde verifiziert.
+- Linux/amd64 Gateway-Binary wurde lokal gebaut und auf die VM kopiert.
+- Altes Binary wurde vor Austausch gesichert.
+- Nach `Text file busy` wurde der Service kontrolliert gestoppt, das Binary ersetzt und wieder gestartet.
+- Gateway-Service ist aktiv, Health ist OK, neues Traffic-Stats-Feld ist live sichtbar.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-6 Command/Output-Evidence.
+- AC-1 PASS: systemd startet `/opt/sentinel/bin/cortex-gateway`.
+- AC-2 PASS: `systemctl is-active sentinel-gateway` liefert `active`.
+- AC-3 PASS: `/health` liefert `{"status":"ok",...}`.
+- AC-4 PASS: `/control/traffic-stats` enthaelt `"agent_runtime_model_policy": "haiku"`.
+- AC-5 PASS: PID-basiertes Journal seit Restart zeigt Startup ohne Panic/Fatal.
 
 ## Task 5 - Phase 5: Benchmarks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_8_DONE_TASK_9_PENDING`
-- Current task: `Task 9 - Plan-Verifikation`
+- Overall status: `TASK_9_DONE_READY_FOR_PR`
+- Current task: `Post-task GitHub PR/Merge/Close sequence`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -83,6 +83,13 @@
   - `CHANGELOG.md` enthaelt einen #314-Unreleased-Eintrag.
   - PR-Pflichtsektionen sind fuer `gh pr create` vorbereitet: Summary, Changes, Linked Issues, Test Plan, Benchmarks, Evidence, Checklist.
   - Issue-Close-Sequenz bleibt korrekt nachgelagert: erst PR/CI/Merge, dann `status:verified`, dann Close.
+- Task 9 ist erledigt:
+  - Plan-Slices 1-9 sind abgeschlossen.
+  - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
+  - `go build ./cmd/cortex-gateway` ist gruen.
+  - VM-Gateway `/health` ist OK; `anthropic-direct` und `claude-code` Circuit-Breaker sind geschlossen.
+  - VM-`traffic-stats` zeigt `agent_runtime_model_policy=haiku`, `last_agent_runtime_effective_model=haiku`, `last_agent_runtime_policy_source=agent_runtime_policy`.
+  - GitHub Issue #314 ist offen mit `quality:ready` und `status:in-progress`; `status:verified` wird erst nach PR/Merge gesetzt.
 
 ## Blocked items
 
@@ -98,7 +105,7 @@
 - `9d2adf5` Task [5] Phase 5 - Benchmarks
 - `9495871` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
 - `TBD` Task [7] Phase 8 - AC-Matrix und Live-Verifikation
-- `TBD` Task [8] Dokumentation, PR- und Close-Sequenz
+- `645553b` Task [8] Dokumentation, PR- und Close-Sequenz
 - `TBD` Task [9] Plan-Verifikation
 
 ## Task table
@@ -113,7 +120,7 @@
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | DONE | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
 | 7 | Phase 8 - AC-Matrix und Live-Verifikation | DONE | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
 | 8 | Dokumentation, PR- und Close-Sequenz | DONE | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
-| 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
+| 9 | Plan-Verifikation | DONE | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
 
 ## Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240
 
@@ -249,6 +256,51 @@
 - AC-1 PASS: CHANGELOG enthaelt #314-Eintrag.
 - AC-2 PASS: PR-Pflichtsektionen werden beim `gh pr create` verwendet.
 - AC-3 PASS: `status:verified`/Close bleibt nach finaler Verifikation und Merge.
+
+## Task 9 - Plan-Verifikation
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - `codex-plan314.md` gegen den umgesetzten Stand pruefen
+  - Issue-ACs, Benchmarks, Deploy, CHANGELOG und Evidence vollstaendig abgleichen
+  - finalen Git-Status pruefen
+  - keine offenen lokalen Code-/Doku-Aenderungen ausser Task-9-Progress/Evidence hinterlassen
+- Welche ACs muessen hier passen:
+  - AC-1: alle Plan-Slices sind erledigt oder explizit nicht relevant.
+  - AC-2: alle 6 GitHub-ACs sind PASS.
+  - AC-3: Benchmarks liegen unter Zielwert.
+  - AC-4: VM-Deploy ist live.
+  - AC-5: CHANGELOG und PR-Vorbereitung sind vorhanden.
+  - AC-6: Git-Status ist vor Push sauber nach Task-9-Commit.
+- Wie wird bewiesen:
+  - `git status --short`
+  - `go test`, `go build`
+  - `gh issue view 314`
+  - VM `health`, `traffic-stats`, `traffic-responses`
+  - Plan-/Evidence-Inspection
+- Erwartete Dateien:
+  - `PROGRESS.md`
+  - `test-314-verification.md`
+- Risiken:
+  - Nach Task 9 bleiben Push/PR/CI/Merge/Close als GitHub-Sequenz; nicht vor lokal sauberem Stand starten.
+
+### Outcome
+
+- Alle Planphasen wurden gegen Code, Tests, Benchmarks, Deploy, VM-Evidence und CHANGELOG abgeglichen.
+- Keine Planabweichung bleibt offen.
+- Issue #314 bleibt vor PR/Merge korrekt offen und nicht verfrueht `status:verified`.
+- Lokaler Abschluss ist bereit fuer Push/PR/CI/Merge/Close-Sequenz.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-9 Command/Output-Evidence.
+- AC-1 PASS: Plan-Slices 1-9 erledigt.
+- AC-2 PASS: GitHub-ACs 1-6 sind in Task 7 PASS.
+- AC-3 PASS: Benchmark-Zielwerte in Task 5 PASS.
+- AC-4 PASS: VM-Deploy in Task 6/7 live belegt.
+- AC-5 PASS: CHANGELOG und PR-Vorbereitung in Task 8 PASS.
+- AC-6 PASS: finaler Test-/Build-/VM-Smoke ist gruen.
 
 ## Task 5 - Phase 5: Benchmarks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,838 +2,134 @@
 
 ## Status
 
-- Plan source: `/work/company/codex-plan279.md`
-- Overall status: `TASK_14_DONE_TASK_15_PENDING`
-- Current task: `Task 15 - PR- und Close-Sequenz`
-- Current branch: `feat/issue-279-daemon-hardening-v2`
-- Worktree: `/work/company/project-sentinel-279-review`
-- Base: `origin/main @ 83ab01c8835804fd951e619aa048324b7ff76ddf`
+- Plan source: `/work/company/codex-plan314.md`
+- Overall status: `TASK_1_DONE_TASK_2_PENDING`
+- Current task: `Task 2 - Phase 2: Gateway Policy-Layer`
+- Current branch: `feat/issue-314-agent-model-policy`
+- Worktree: `/work/company/project-sentinel`
+- Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
 - Hook status: `PreToolUse TaskUpdate + PostToolUse start-enforcer projektlokal registriert`
-- Last refresh: `2026-04-23 Europe/Vienna`
+- Last refresh: `2026-04-24 Europe/Vienna`
 
 ## Current findings
 
-- `$start` wurde fuer diese Ausfuehrung aktiviert.
-- Projektregeln, globale Regeln, Workspace-Handover und der komplette `#279`-Plan wurden in dieser Session frisch gelesen.
-- Der neue Worktree ist sauber von `origin/main` geschnitten; alte #264/#279-Stack-Worktrees bleiben unangetastet.
-- `gh issue view 279` ist erreichbar; GitHub ist aktuell die SSOT.
-- `#279` ist `OPEN` und steht aktuell auf `status:in-progress`.
-- Der GitHub-Issue-Body war stale und wurde in Phase 0 truth-repaired; aktuelle SSOT ist `#279` mit `status:in-progress`.
-- `mainrag search "issue 279 daemon hardening runtime" --source claude-conversations --limit 5` ist aktuell nicht nutzbar, weil `localhost:3001` `Connection refused` liefert. Das ist kein Task-Blocker, aber ein dokumentierter Kontextverlust.
-- Phase 0 ist erledigt:
-  - frische Pre-Reset-VM-Baseline ist in `test-279-verification.md` dokumentiert
-  - GitHub-Issue `#279` wurde auf frische 2026-04-23-Wahrheit repariert
-  - canonical `main` wurde remote gebaut und auf `10.0.0.240` deployed
-  - Post-Reset-Baseline zeigt erwartetes `runtime_health_http=404`
-  - Drift bleibt auf `main` reproduzierbar: API/Projection `57`, live cgroups `29`
-- Review-Entscheidungen aus dem Plan:
-  - Haiku-/Model-Policy ist out-of-scope fuer `#279`.
-  - Der Branch darf keine #264-Stack-Commits enthalten.
-  - Frische VM-Zahlen muessen dynamisch gemessen werden, nicht aus alten Reviews kopiert werden.
-  - Canonical-main-Reset muss ohne `/operator/runtime-health` messbar sein, weil `main` diesen Endpoint noch nicht hat.
-  - Operator-Auth wird spaeter ueber einen gemeinsamen `/tmp/opcurl` Helper operationalisiert.
-- FUSE/Landlock bekommt nur bei aktivem Slice G eigene Build-/Deploy-Gates.
-- Slice A ist erledigt:
-  - `GET /operator/runtime-health` ist als read-only Operator-Pfad verdrahtet
-  - Snapshot deckt Runtime, Projection, Cgroups, Security-Runtime und Worker-State ab
-  - Operator-Auth-Schutz fuer den Endpoint ist im Unit-Test belegt
-  - initialer Warnungsfund `unused import RuntimeHealthSnapshot` wurde vor Commit bereinigt
-- Slice B ist erledigt:
-  - `POST /operator/runtime/reconcile` ist als Runtime-Control-Pfad verdrahtet
-  - Reconcile entfernt unerwartete Runtime-Fragmente, orphan Cgroups und stale Security-Snapshots
-  - Expected active Agents koennen mit Backoff N=3 respawned werden
-  - Projection-Rebuild wird ueber `.projection-rebuild-request` entkoppelt angefordert
-  - aktuelle #264-SIGSTOP-Semantik wurde bei Konfliktauflösung beibehalten
-- Slice C ist erledigt:
-  - `POST /operator/runtime/stall-restart-test` ist als synchroner Operator-Testhook verdrahtet
-  - `PlatformSideEffect::RestartAgent` nutzt jetzt einen same-tick Fast-Respawn statt verzögertem Despawn
-  - der Fast-Restart entfernt alte Runtime-, Security- und Sandbox-Fragmente und respawned danach denselben Agent
-  - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
-- Slice D ist erledigt:
-  - `service_health` ist per `catch_unwind` in-process supervised
-  - `POST /operator/runtime/panic-test` triggert kontrolliert den Service-Health-Panic-Test ueber den ECS-Thread
-  - Runtime-Health-Worker-State zeigt `running`, `restart_count`, `last_error` und `thread_name`
-  - Remote-Tests, FUSE-Release-Build und Artifact-Hash sind dokumentiert
-- Slice E ist erledigt:
-  - Platform-Controlplane-Triggerqueue ist bounded und coalesced doppelte Trigger
-  - LLM-Analyzer-Channel ist bounded und zaehlt Dropped-Requests
-  - Runtime-Health publiziert Queue-Depth, Dropped- und Coalesced-Counter
-  - `POST /operator/runtime/analysis-flood-test` erzeugt deterministische Queue-Pressure fuer VM-/AC-Evidence
-  - Remote-Tests, FUSE-Release-Build, Clippy, Scope-Guard und Artifact-Hash sind dokumentiert
-- Slice F ist erledigt:
-  - Projection-Worker konsumiert `.projection-rebuild-request` und fuehrt Full-Rebuild in-place aus
-  - Projection-Store bietet read-only Open fuer Runtime-Health ohne Migration/Startup-Cleanup
-  - Runtime-Health erkennt Projection-Drift und zaehlt driftende Projection-Agenten
-  - Runtime-Reconcile fordert Projection-Rebuilds per Request-Datei an und vermeidet Restart-Storms, wenn `sentinel-projection` bereits aktiv ist
-  - Remote-Tests, Clippy, Release-Builds und Artifact-Hashes fuer Daemon und Projection sind dokumentiert
-- Slice G ist erledigt:
-  - Daemon aktiviert `fs_mount` fuer Sandbox, Operator-API und ECS nur noch, wenn `sentinel-fs` wirklich als FUSE-Mount aktiv ist
-  - bei fehlendem FUSE-Mount faellt die Runtime explizit auf `/ram/agents` zurueck statt bwrap auf einen toten Mountpoint zu richten
-  - Landlock-Exec-Allowlist bleibt schmal und enthaelt zusaetzlich die notwendigen dynamischen ELF-Loader
-  - Remote-Tests, Clippy, FUSE-Release-Builds, Sandbox-Binary-Build, Scope-Guard und Artifact-Hashes sind dokumentiert
-- Task 10 ist erledigt:
-  - Es gab kein separates offenes Haiku-/Agent-Model-Policy-Issue
-  - neues Follow-up `#314` wurde fuer Gateway-/Inference-Agent-Model-Defaults erstellt
-  - `#279` wurde mit der Scope-Entscheidung kommentiert: keine Modellentscheidung im Daemon, Gateway waehlt Default
-- Task 11 ist erledigt:
-  - komplette Remote-Testmatrix fuer Daemon, Projection und Projection-Service ist gruen
-  - Clippy ist fuer Daemon, Projection, Projection-Service, `sentinel-fs` und `sentinel-sandbox` gruen
-  - Release-Artefakte fuer Daemon, Projection und Sandbox-Helper wurden remote gebaut
-  - conditional FUSE/Landlock-Gates wurden erneut auf demselben Branch wiederholt
-  - `git diff --check`, Haiku-Scope-Guard und Artifact-Hashes sind dokumentiert
-- Task 12 ist erledigt:
-  - Release-Artefakte wurden an den systemd `ExecStart`-Pfaden auf `10.0.0.240` installiert
-  - erste Runtime-Reconcile-Runde reparierte Projection-only Drift von `57` auf `26`, deckte aber drei verwaiste gestoppte #264-Write-Anomaly-Cgroups auf
-  - Cgroup-Reconcile wurde gehärtet: verwaiste Live-Cgroups werden ueber `cgroup.kill`/SIGKILL-Fallback geleert und danach entfernt
-  - zweiter VM-Deploy mit Daemon-Hash `d6c30a324d85cbb3ec9d919a14e5f5744482cda75e59984e6133944289129d86`
-  - Live-Reconcile meldete `orphan_cgroups_before=3`, `orphan_cgroups_after=0`, `orphan_cgroups_removed=3`
-  - finaler Runtime-Health-Gate ist gruen: `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`, Dashboard-API `26`
-- Task 13 ist erledigt:
-  - `/tmp/opcurl` ist auf der VM installiert und operator-auth-aware
-  - AC-1 bis AC-7 wurden auf `10.0.0.240` mit echten Commands/Outputs belegt
-  - AC-2 Stall-Restart wechselte `Thomas Mueller` von PID `1487965` auf `1488241` und blieb healthy
-  - AC-3 Restore stellte den Original-Hash wieder her; Reconcile brachte die VM danach zurueck auf `26/26/26/26`
-  - AC-4 Projection-Drift wurde per SQLite-Delete erzeugt und durch Reconcile/Rebuild wieder auf `26/26/26/26` gebracht
-  - AC-5 `service_health` Panic-Test blieb im selben Daemon-PID `1485419`, Worker `running=true`, `restart_count=1`
-  - AC-6 Flood-Test mit `10000` Triggern blieb bounded: `queue_depth=1`, `dropped=9983`, `coalesced=9999`, `rss_delta_kb=-80`
-  - AC-7 30-Minuten-Soak endete PASS; Artefakte liegen auf der VM unter `/tmp/issue279-soak-20260423T123633Z`
-- Task 14 ist erledigt:
-  - Benchmark-Instrumentierung fuer `elapsed_us`, `snapshot_build_elapsed_us`, `enqueue_per_request_ns` und `bookkeeping_elapsed_ns` wurde implementiert
-  - Remote-Qualitaetsmatrix nach Instrumentierung ist gruen: `fmt`, Daemon-Tests `194 passed`, Clippy Daemon mit `--features fuse`, Release-Build Daemon
-  - finaler Daemon-Hash wurde auf die VM deployed: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`
-  - Benchmark-Harness `/opt/sentinel/scripts/vm-issue-279-bench.sh` lief auf `10.0.0.240` mit Sidecars fuer RAM, CPU, IOPS und Prozesszustand
-  - Benchmark-Artefakte liegen auf der VM unter `/tmp/issue279-bench-20260423T132030Z`
-  - alle vier Pflicht-Benchmarks sind PASS: Reconcile `2134us < 5000us`, Projection-Drift-Detection `817us < 5000us`, Analysis-Flood `148ns/request < 250000ns/request`, Stall-Bookkeeping `700ns < 50000ns`
+- `$start` wurde fuer #314 aktiviert.
+- Hook-Skripte existieren und sind ausfuehrbar:
+  `pretooluse-task-checklist-gate.sh`, `pretooluse-start-progress-gate.sh`, `posttooluse-start-enforcer.sh`.
+- Projektlokale Hooks wurden in `.claude/settings.json` registriert und die Start-Counter wurden zurueckgesetzt.
+- Projektregeln, globale Regeln, Workspace-Handover, `.claude/AGENTS.md` und der komplette #314-Plan wurden in dieser Session frisch gelesen.
+- `mainrag search "Issue 314 Haiku Gateway model policy" --source claude-conversations --limit 5` ist aktuell nicht nutzbar, weil `localhost:3001` `Connection refused` liefert. Das ist dokumentiert, aber kein Task-Blocker.
+- `git fetch origin` lief, `main` ist synchron mit `origin/main` (`ahead/behind 0/0`), kein Pull war notwendig.
+- GitHub-Issue `#314` ist offen und traegt aktuell `quality:needs-spec`, `status:triage`, `status:backlog`.
+- Der Issue-Quality-Bot fordert die fehlenden Sektionen `Scope`, `Out of Scope`, `Benchmarks`.
+- Umsetzungsscope bleibt Go/Gateway-zentriert; Daemon-Haiku-Pinning ist out-of-scope.
+- Task 1 ist erledigt:
+  - `issue-314-body.md` wurde als Issue-Body-Artefakt erstellt.
+  - GitHub-Issue `#314` wurde aktualisiert und steht jetzt auf `quality:ready` und `status:in-progress`.
+  - `quality:needs-spec`, `status:triage` und `status:backlog` wurden entfernt.
+  - `ssh ubuntu@10.0.0.240 "/usr/bin/claude -p --model haiku 'Antworte exakt mit PONG.'"` lieferte `PONG`.
+  - In Task 1 wurde kein Daemon-Code geaendert.
 
 ## Blocked items
 
-- Kein harter technischer Blocker beim Setup.
-- `mainrag` ist lokal nicht verfuegbar; fuer `#279` nicht blockierend.
-- Kein Phase-0-Blocker mehr.
-- Der Main-Reset bestaetigt, dass der volle #279-Recovery-Scope notwendig bleibt.
+- Kein technischer Blocker beim Setup.
+- `mainrag` ist lokal nicht erreichbar; falls fuer spaetere Architekturfragen relevant, erneut pruefen.
 
 ## Commit references
 
-- `dca25ac` Task [1] Phase 0 - Issue-Repair und Baseline-Reset
-- `e2e7523` Task [2] Phase 1 - Donor-Audit und Clean Port
-- `f5be73b` Task [3] Slice A - Runtime-Health-Read-Model
-- `ca44759` Task [4] Slice B - Runtime-Control / Reconcile
-- `f5e3dd9` Task [5] Slice C - Fast Stall Recovery
-- `b3b7786` Task [6] Slice D - Worker-Supervision
-- `bc57b4c` Task [7] Slice E - bounded Analysis-/Recovery-Pfade
-- `92b3279` Task [8] Slice F - Projection/API-Konvergenz
-- `7eb95cb` Task [9] Slice G - Conditional FUSE/Landlock Runtime Restore
-- `90792a5` Task [10] Out-of-scope Follow-up - Haiku-Policy
-- `441ff3c` Task [11] Phase 3 - Tests, Clippy, Builds
-- `aa4ee20` Task [12] Phase 4 - Deploy auf die VM
-- `e53cb5c` Task [13] Phase 5 - AC-Matrix
-- `f752ffc` Task [14] Benchmarks
-- `TBD` Task [15] PR- und Close-Sequenz
-- `TBD` Task [16] Plan-Verifikation
+- `TBD` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
+- `TBD` Task [2] Phase 2 - Gateway Policy-Layer
+- `TBD` Task [3] Phase 3 - Observability und Response Log
+- `TBD` Task [4] Phase 4 - Go-Tests
+- `TBD` Task [5] Phase 5 - Benchmarks
+- `TBD` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
+- `TBD` Task [7] Phase 8 - AC-Matrix und Live-Verifikation
+- `TBD` Task [8] Dokumentation, PR- und Close-Sequenz
+- `TBD` Task [9] Plan-Verifikation
 
 ## Task table
 
 | # | Task | Status | Scope | Evidence |
 |---|------|--------|-------|----------|
-| 1 | Phase 0 - Issue-Repair und Baseline-Reset | DONE | frische VM-Baseline, Issue-Body-Repair, canonical-main-Reset, Post-Reset-Baseline ohne runtime-health | command, system, inspect |
-| 2 | Phase 1 - Donor-Audit und Clean Port | DONE | alte #279-Donor-Commits pruefen, nur scope-konforme Teile uebernehmen, Haiku ausschliessen | inspect, command |
-| 3 | Slice A - Runtime-Health-Read-Model | DONE | `/operator/runtime-health`, Snapshot-Modell, Auth/Loopback, Tests | inspect, command, system |
-| 4 | Slice B - Runtime-Control / Reconcile | DONE | `/operator/runtime/reconcile`, stale/orphan/zombie cleanup, bounded retries | inspect, command, system |
-| 5 | Slice C - Fast Stall Recovery | DONE | deterministischer Stall-Testhook, same-tick Fast-Respawn, Runtime/Security/Sandbox-Recreate | inspect, command, system |
-| 6 | Slice D - Worker-Supervision | DONE | catch_unwind + in-process worker respawn, panic-test Hook | inspect, command, system |
-| 7 | Slice E - bounded Analysis-/Recovery-Pfade | DONE | bounded trigger queues, coalescing/drop counters, flood-test | inspect, command, system |
-| 8 | Slice F - Projection/API-Konvergenz | DONE | read-only Projection-Reads, Rebuild-Request, drift-heal, no restart storm | inspect, command, system |
-| 9 | Slice G - Conditional FUSE/Landlock Runtime Restore | DONE | FUSE-Aktivierungs-Gate, `/ram/agents` Fallback, Landlock-ELF-Loader-Allowlist, eigene Build-/Deploy-Gates | inspect, command, system |
-| 10 | Out-of-scope Follow-up - Haiku-Policy | DONE | separates Gateway-/Policy-Issue #314 erstellt und in #279 verlinkt, nicht #279-Close-Bedingung | command, inspect |
-| 11 | Phase 3 - Tests, Clippy, Builds | DONE | cargo remote only, relevant packages, conditional FUSE/Landlock matrix | command |
-| 12 | Phase 4 - Deploy auf die VM | DONE | ExecStart pruefen, scp/install, restart, post-restart smoke, Projection-/Cgroup-Drift reparieren | command, system |
-| 13 | Phase 5 - AC-Matrix | DONE | alle ACs mit Command, Output, PASS auf VM | command, system |
-| 14 | Benchmarks | DONE | Recovery, Queue, Soak, Sidecar-Monitoring | command, system |
-| 15 | PR- und Close-Sequenz | PENDING | PR mit Pflichtsektionen, labels, merge, branch delete, issue close erst nach verified | command |
-| 16 | Plan-Verifikation | PENDING | Plan Zeile fuer Zeile gegen Ergebnis pruefen, Abweichungen fixen | inspect, command |
+| 1 | Phase 1 - Issue-Body-Repair, Branch und Preflight | DONE | Branch von main, GitHub-Body reparieren, `quality:ready`, Haiku-String fuer claude-code pruefen, Platform-Controlplane out-of-scope bestaetigen | command, inspect, system |
+| 2 | Phase 2 - Gateway Policy-Layer | PENDING | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
+| 3 | Phase 3 - Observability und Response Log | PENDING | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, ggf. bounded circular buffer | inspect, command |
+| 4 | Phase 4 - Go-Tests | PENDING | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
+| 5 | Phase 5 - Benchmarks | PENDING | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
+| 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | PENDING | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
+| 7 | Phase 8 - AC-Matrix und Live-Verifikation | PENDING | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
+| 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
+| 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
 
-## Task 1 - Phase 0: Issue-Repair und Baseline-Reset
+## Task 1 - Phase 1: Issue-Body-Repair, Branch und Preflight
 
 ### Pre-task self-check
 
-- Was muss getan werden: frische Runtime-Wahrheit erfassen, GitHub-Issue korrigieren, canonical `main` auf der VM deployen, danach Baseline ohne `/operator/runtime-health` belegen.
+- Was muss getan werden:
+  - frischen Branch von synchronem `main` verwenden
+  - GitHub-Issue `#314` mit dem Plan-Body reparieren
+  - `quality:needs-spec` entfernen und `quality:ready` setzen
+  - kanonischen Haiku-String fuer den aktuellen `claude-code` Provider pruefen
+  - Platform-Controlplane fuer #314 explizit out-of-scope halten
 - Welche ACs muessen hier passen:
-  - AC-1: frische experimentelle VM-Baseline ist dokumentiert.
-  - AC-2: `#279` Issue-Body ist truth-repaired und enthaelt keine stale Blocked-by-/Zahlen-Behauptung.
-  - AC-3: canonical `main` Binaries fuer Daemon und Projection sind remote gebaut, Deploy-Pfad inklusive ExecStart ist belegt.
-  - AC-4: Post-Reset-Baseline ohne `/operator/runtime-health` ist belegt.
-- Wie wird bewiesen: `gh`, `ssh ubuntu@10.0.0.240`, `cargo remote -c --`, `scp`, `systemctl`, `curl`, `sqlite3`, `journalctl`.
-- Erwartete Dateien: `PROGRESS.md`, `docs/issue-279-phase0-baseline.md`, optional temporaere Issue-Body-Datei.
+  - AC-1: Branch basiert sauber auf `origin/main`.
+  - AC-2: GitHub-Issue-Body enthaelt `Scope`, `Out of Scope`, `Benchmarks` und die 6 ACs.
+  - AC-3: Labels zeigen nicht mehr `quality:needs-spec`, sondern `quality:ready`.
+  - AC-4: Haiku-Provider-String ist per Live-Preflight geprueft oder als Blocker dokumentiert.
+  - AC-5: Keine Daemon-Code-Aenderung in Task 1.
+- Wie wird bewiesen:
+  - `git status`, `git rev-list`, `gh issue view/edit`, `ssh ubuntu@10.0.0.240 "/usr/bin/claude -p --model haiku ..."`
+- Erwartete Dateien:
+  - `PROGRESS.md`
+  - optional `issue-314-body.md`
+  - optional `test-314-verification.md`
 - Risiken:
-  - VM laeuft aktuell moeglicherweise mit experimentellen #279-Binaries; Phase 0 ersetzt diese bewusst durch canonical `main`.
-  - Nach Main-Reset ist `/operator/runtime-health` erwartbar nicht vorhanden.
-  - Deployment darf nicht gegen falsche systemd `ExecStart`-Pfade kopieren.
+  - `claude -p --model haiku` kann wegen Quota/Auth scheitern; dann Task 1 blockiert nicht den Issue-Body-Repair, aber der kanonische Modellstring muss spaeter vor Deploy final belegt werden.
+  - Issue-Body-Repair ist GitHub-Schreibaktion; Ergebnis muss direkt per `gh issue view` gegengeprueft werden.
 
 ### Outcome
 
-- Fresh pre-reset VM baseline captured:
-  - services active
-  - API agents `57`
-  - Projection agents `57`
-  - experimental runtime-health expected active agents `26`
-  - experimental runtime-health runtime agents `26`
-  - experimental runtime-health orphan cgroups `33`
-  - experimental runtime-health projection drift `true`
-- GitHub issue `#279` body repaired at `2026-04-23T09:47:19Z`:
-  - removed stale `Blocked by #278`
-  - removed old 2026-04-21 numbers as current truth
-  - removed #264-stacked branch assumption
-  - kept Haiku/model policy out-of-scope
-  - kept strict `status:verified` close rule
-- Canonical `main` artifacts built through `cargo remote -c --`:
-  - `sentinel-daemon --features fuse`: `Finished release profile [optimized] target(s) in 12m 04s`
-  - `sentinel-projection-service`: `Finished release profile [optimized] target(s) in 1m 37s`
-- Main artifacts deployed to exact VM `ExecStart` paths:
-  - `/opt/sentinel/bin/sentinel-daemon`
-  - `/opt/sentinel/bin/sentinel-projection`
-  - timestamp backup created with `20260423T100300Z`
-- Post-reset baseline without runtime-health captured:
-  - services active
-  - API agents `57`
-  - Projection agents `57`
-  - cgroup dirs `59`
-  - live cgroup process dirs `29`
-  - `/operator/runtime-health` returns `404`, expected on current `main`
-- Conclusion:
-  - canonical `main` does not self-heal the runtime/projection/cgroup drift
-  - full #279 recovery scope remains required
+- Branch `feat/issue-314-agent-model-policy` wurde von synchronem `main` erstellt.
+- `issue-314-body.md` enthaelt den reparierten GitHub-Issue-Body.
+- `gh issue edit 314` hat den Body aktualisiert, `quality:needs-spec`, `status:triage` und `status:backlog` entfernt sowie `quality:ready` und `status:in-progress` gesetzt.
+- `gh issue view 314` bestaetigt die reparierten Labels und Body-Sektionen.
+- VM-Preflight bestaetigt `haiku` als akzeptierten `claude-code` Modellalias mit Output `PONG`.
 
 ### Evidence
 
-- `test-279-verification.md` contains Phase-0 command/output evidence.
-- AC-1 PASS: Pre-reset VM baseline captured on `10.0.0.240`.
-- AC-2 PASS: `gh issue edit 279 --repo silentspike/project-sentinel --body-file docs/issue-279-body.md`; follow-up `gh issue view` confirmed repaired body.
-- AC-3 PASS: remote release builds succeeded and deployed SHA256 values match installed VM binaries:
-  - `2b31820c751c6f3dd0eb8e1282e827d64c5b2d9b016bf56fcede4c765ee86883  /opt/sentinel/bin/sentinel-daemon`
-  - `10b845881d24ed0c661ba5a18de4ebddad44d404d15f0231ef1ce83a83855ce3  /opt/sentinel/bin/sentinel-projection`
-- AC-4 PASS: Post-reset baseline uses only main-compatible checks and confirms `runtime_health_http=404`.
+- `test-314-verification.md` enthaelt Task-1 Command/Output-Evidence.
+- AC-1 PASS: Branch basiert auf `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`, ahead/behind vor Branch-Erstellung `0/0`.
+- AC-2 PASS: Issue-Body enthaelt `Kontext`, `Scope`, `Out of Scope`, `Acceptance Criteria`, `Benchmarks`, `Verify-Ideen`.
+- AC-3 PASS: Labels enthalten `quality:ready` und `status:in-progress`; alte Spec-/Triage-/Backlog-Labels sind entfernt.
+- AC-4 PASS: VM-Befehl `/usr/bin/claude -p --model haiku ...` lieferte `PONG`.
+- AC-5 PASS: Task 1 aenderte nur `PROGRESS.md`, `docs/issue-314-body.md` und `test-314-verification.md`.
 
-## Task 2 - Phase 1: Donor-Audit und Clean Port
+## Task 2 - Phase 2: Gateway Policy-Layer
 
 ### Pre-task self-check
 
-- Was muss getan werden: alten Donor-Branch lesen, Commit-/Diff-Scope klassifizieren, Haiku- und #264-fremde Arbeit ausschliessen, eine saubere Port-Reihenfolge fuer die Code-Slices herstellen.
+- Was muss getan werden:
+  - bestehende Gateway-Pipeline, Provider-Konfig und Control-Plane-Strukturen lesen
+  - `request_class` zentral einfuehren
+  - `agent_runtime_model_policy` als Gateway-Konfiguration einfuehren
+  - Resolver-Reihenfolge implementieren: explizites Modell, Agent-Runtime-Policy, Provider-Fallback
+  - Validation fuer unaufloesbare Policy/Provider-Kombinationen fail-closed einbauen
 - Welche ACs muessen hier passen:
-  - AC-1: Donor-Commits sind gegen `main` sichtbar und klassifiziert.
-  - AC-2: Out-of-scope Commits/Dateien sind explizit ausgeschlossen.
-  - AC-3: Clean-port Reihenfolge fuer Slice A-F und conditional Slice G ist dokumentiert.
-- Wie wird bewiesen: `git log`, `git diff --name-status`, gezielte Code-Inspection, Abgleich gegen `codex-plan279.md`.
-- Erwartete Dateien: `PROGRESS.md`, ggf. `test-279-verification.md`; noch kein Produktionscode, solange nur Audit laeuft.
+  - AC-1: `external_compat`, `agent_runtime`, `platform_controlplane`, `service_internal`, `internal_other` sind als klare Klassen modelliert.
+  - AC-2: `agent_runtime` erfordert positive numerische `agent_id` und schliesst `platform_analysis`, `request_type`, `sentinel-judge`, `PLATFORM-CONTROLPLANE` aus.
+  - AC-3: Leeres Modell wird nur fuer `agent_runtime` zu Haiku resolved.
+  - AC-4: Explizites Request-Modell gewinnt.
+  - AC-5: `/v1/messages` bleibt bei `PreferredProvider=anthropic-direct` und bekommt keine Agent-Policy.
+  - AC-6: Ungueltige Policy/Provider-Kombination wird nicht still auf Opus zurueckfallen.
+- Wie wird bewiesen:
+  - gezielte Go-Tests in Task 4
+  - fuer Task 2 zusaetzlich strukturelle Inspection und `go test` fuer betroffene Packages, sobald Code geaendert ist
+- Erwartete Dateien:
+  - `cmd/cortex-gateway/internal/proxy/policy.go`
+  - `cmd/cortex-gateway/internal/proxy/provider.go`
+  - `cmd/cortex-gateway/internal/proxy/pipeline.go`
+  - `cmd/cortex-gateway/main.go`
+  - ggf. `cmd/cortex-gateway/internal/control/plane.go`
 - Risiken:
-  - Der alte Donor-Branch ist auf #264 gestackt und darf nicht direkt gemergt werden.
-  - Haiku-Pinning ist bewusst out-of-scope fuer #279.
-
-### Outcome
-
-- Donor sources inspected:
-  - old donor: `/work/company/project-sentinel-issue279`, branch `feat/issue-279-daemon-hardening`
-  - safer stack donor: `/work/company/project-sentinel-issue279-stack`, branch `feat/issue-279-daemon-hardening-stack`
-- The old donor contains `dbb1b8e` which pins agent LLM requests to `haiku`; this is rejected for #279.
-- The stack donor removed the Haiku commit, but still spans a broad stacked diff and is not mergeable as a branch.
-- Clean-port source of truth:
-  - use stack donor commits as code references
-  - path-limit each slice
-  - do not port stale donor evidence or donor `PROGRESS.md`
-- Port order is fixed:
-  - Slice A from `29a0fb5`
-  - Slice B from `146ef43`
-  - Slice C from `fdc40c7`
-  - Slice D from `6919e66`
-  - Slice E from `389b5e6`
-  - Slice F from `14560c4` plus relevant stabilization from `b1e376b`
-  - Slice G from `6c31975` only if needed
-  - Benchmarks from `ffca58b` with fresh current evidence
-
-### Evidence
-
-- `test-279-verification.md` contains Phase-1 command/output evidence.
-- AC-1 PASS:
-  - `git log --oneline --decorate --reverse origin/main..HEAD` run on both donor worktrees.
-  - `git range-diff origin/main...feat/issue-279-daemon-hardening-stack` shows the old #264 lineage and the #279 commit sequence.
-- AC-2 PASS:
-  - old donor `dbb1b8e` / `services/sentinel-daemon/src/llm_bridge.rs` is explicitly rejected.
-  - stale donor `PROGRESS.md`, old evidence and branch-wide #264 paths are excluded.
-- AC-3 PASS:
-  - clean port order and path-limited rules are documented in `test-279-verification.md`.
-
-## Task 3 - Slice A: Runtime-Health-Read-Model
-
-### Pre-task self-check
-
-- Was muss getan werden: Runtime-Health-Snapshot aus dem Donor path-limited portieren und `GET /operator/runtime-health` als loopback/auth-konformen Read-Pfad verfuegbar machen.
-- Welche ACs muessen hier passen:
-  - AC-1: `runtime_health.rs` existiert und berechnet runtime/cgroup/projection/worker truth ohne Seiteneffekte.
-  - AC-2: Operator-Endpoint ist verdrahtet und nutzt die bestehende Operator-Auth-/Loopback-Struktur.
-  - AC-3: relevante Remote-Rust-Tests oder mindestens package build fuer Slice A sind gruen.
-- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- test/build`.
-- Erwartete Dateien: `services/sentinel-daemon/src/runtime_health.rs`, `lib.rs`, `operator_api.rs`, `orchestrator.rs`, `service_health.rs`, ggf. `Cargo.toml/Cargo.lock`.
-- Risiken:
-  - Donor-Patch darf keine Reconcile-/Stall-/Queue-Semantik vorziehen.
-  - `runtime-health` muss read-only bleiben.
-
-### Outcome
-
-- Path-limited donor Slice A was applied from stack donor `29a0fb5`.
-- Merge conflict in `services/sentinel-daemon/src/operator_api.rs` was resolved by keeping current `main`'s `open_fs_layer` security/FUSE helper and adding only the new `is_protected_read_path()` read-auth helper.
-- Added `services/sentinel-daemon/src/runtime_health.rs`.
-- Added `sentinel-projection` as `sentinel-daemon` dependency so the daemon can read Projection truth without mutating Projection state.
-- Wired `SharedRuntimeHealthState` through `orchestrator.rs` into the ECS tick loop and Operator API.
-- Added `GET /operator/runtime-health` as a protected read path; it returns the current snapshot and respects the existing operator shared-secret auth rule.
-- Extended `ServiceHealthChecker` with a read-only worker snapshot for runtime-health reporting.
-- Fixed the initial `unused import RuntimeHealthSnapshot` warning by moving the import into the test module.
-
-### Evidence
-
-- `cargo remote -c -- test -p sentinel-daemon runtime_health -- --nocapture`
-  - PASS: `3 passed; 0 failed; 173 filtered out; finished in 10.28s`
-  - Covered tests:
-    - `runtime_health::tests::build_snapshot_marks_missing_projection_and_security_as_stale`
-    - `operator_api::tests::runtime_health_endpoint_returns_snapshot`
-    - `operator_api::tests::runtime_health_endpoint_requires_auth_when_secret_is_set`
-- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
-  - PASS: `Finished release profile [optimized] target(s) in 1m 07s`
-  - artifact hash: `7b5145a77da0a55a3e9e9da00b2d9036ce943df748d327b4095f87955b0034d2  target/release/sentinel-daemon`
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-
-## Task 4 - Slice B: Runtime-Control / Reconcile
-
-### Pre-task self-check
-
-- Was muss getan werden: Runtime-Control aus dem Donor path-limited portieren und `POST /operator/runtime/reconcile` als kontrollierten Reparaturpfad in den ECS-Thread verdrahten.
-- Welche ACs muessen hier passen:
-  - AC-1: `runtime_control.rs` definiert Request/Response, Command und bounded Respawn-Backoff.
-  - AC-2: Operator-Endpoint dispatcht in den ECS-Thread und wartet bounded auf Response.
-  - AC-3: Orchestrator kann stale Runtime-Fragmente, Security-Snapshots und orphan Cgroups bereinigen.
-  - AC-4: Missing expected Agents koennen mit Backoff respawned oder als `repair_blocked` dokumentiert werden.
-  - AC-5: Projection-Rebuild wird entkoppelt per Request-Datei angefordert.
-  - AC-6: relevante Remote-Rust-Tests und Release-Build sind gruen.
-- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- test/build`.
-- Erwartete Dateien: `services/sentinel-daemon/src/runtime_control.rs`, `lib.rs`, `operator_api.rs`, `orchestrator.rs`.
-- Risiken:
-  - Donor-Patch darf keine alte #264-SIGSTOP-Abschwaechung einschleppen.
-  - Reconcile darf nicht inline Projection mutieren.
-  - Respawn-Fehler muessen bounded bleiben und duerfen keinen Endlos-Loop erzeugen.
-
-### Outcome
-
-- Path-limited donor Slice B was applied from stack donor `146ef43`.
-- Added `services/sentinel-daemon/src/runtime_control.rs` with:
-  - `RuntimeReconcileRequest`
-  - `RuntimeReconcileResponse`
-  - `RuntimeControlCommand`
-  - `RespawnBackoffTracker::new(3)` semantics
-  - `write_projection_rebuild_request()`
-- Added `POST /operator/runtime/reconcile` and a bounded `recv_timeout(10s)` response path.
-- Wired `runtime_tx/runtime_rx` through Operator API and ECS loop.
-- Added `run_runtime_reconcile()` in the orchestrator:
-  - removes unexpected active runtime fragments
-  - removes stale security runtime snapshots
-  - tears down orphan cgroups without live PIDs
-  - restores missing security runtime snapshots when core runtime is healthy
-  - respawns expected active Agents when requested
-  - records `repair_blocked` via `PlatformIntervention`
-  - updates `SharedRuntimeHealthState` with counters and per-agent repair status
-- Conflict resolution:
-  - kept current `suspend_pids()` implementation with 2s multi-PID verification from #264/main lineage
-  - rejected donor's narrower 250ms tracked-PID-only check
-
-### Evidence
-
-- `cargo remote -c -- test -p sentinel-daemon runtime_control -- --nocapture`
-  - PASS: `2 passed; 0 failed; 177 filtered out`
-  - Covered tests:
-    - `runtime_control::tests::respawn_backoff_tracker_applies_exponential_backoff_until_blocked`
-    - `runtime_control::tests::write_projection_rebuild_request_persists_request_file`
-- `cargo remote -c -- test -p sentinel-daemon runtime_reconcile -- --nocapture`
-  - PASS: `1 passed; 0 failed; 178 filtered out; finished in 0.61s`
-  - Covered test:
-    - `operator_api::tests::runtime_reconcile_is_forwarded_and_returns_response`
-- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
-  - PASS: `Finished release profile [optimized] target(s) in 1m 00s`
-  - artifact hash: `19ce8b228b5588142399a4f712afd4cd89b1caca2be43c1273355a3ad30fe724  target/release/sentinel-daemon`
-
-## Task 5 - Slice C: Fast Stall Recovery
-
-### Pre-task self-check
-
-- Was muss getan werden: Fast-Stall-Recovery aus dem Donor path-limited portieren, einen deterministischen Operator-Testhook bereitstellen und `PlatformSideEffect::RestartAgent` vom verzögerten Despawn auf same-tick Fast-Respawn umstellen.
-- Welche ACs muessen hier passen:
-  - AC-1: Operator-Testhook nimmt `agent_id`, `mode` und `stall_secs` an, validiert Eingaben und dispatcht in den ECS-Thread.
-  - AC-2: Fast-Restart entfernt alte Runtime-, Sandbox-, eBPF- und Security-Fragmente und erzeugt danach Runtime- und Security-State neu.
-  - AC-3: `PlatformSideEffect::RestartAgent` nutzt den Fast-Restart-Pfad statt nur zu despawnen.
-  - AC-4: relevante Remote-Tests, FUSE-Release-Build und `git diff --check` sind gruen.
-- Wie wird bewiesen: Donor-Diff-Inspection, Code-Diff, `cargo remote -c -- fmt/test/build`, `sha256sum`, `git diff --check`.
-- Erwartete Dateien: `services/sentinel-daemon/src/runtime_control.rs`, `operator_api.rs`, `orchestrator.rs`, `runtime_health.rs`, `CHANGELOG.md`.
-- Risiken:
-  - Testhook darf kein Auth-Bypass sein; er laeuft ueber die bestehende Operator-API-Schutzschicht.
-  - Stall-Test darf den ECS-Thread nicht kuenstlich schlafen lassen.
-  - Fast-Restart darf keine alten cgroups oder Security-Snapshots zuruecklassen.
-
-### Outcome
-
-- Path-limited donor Slice C was applied from stack donor `fdc40c7`.
-- Added `RuntimeControlCommand::StallRestartTest` plus typed request/response structs.
-- Added `POST /operator/runtime/stall-restart-test`:
-  - rejects `agent_id=0`
-  - allows only `mode=sigstop` or `mode=direct`
-  - rejects `stall_secs=0`
-  - dispatches to the ECS owner thread and waits with `recv_timeout(10s)`
-- Added `restart_agent_fast_path()` in the orchestrator:
-  - captures `pid_before`
-  - tears down sandbox handle and unregisters eBPF cgroup id
-  - removes and terminates the old tracked process
-  - removes stale security runtime state
-  - despawns ECS/runtime state
-  - respawns the same configured agent immediately
-  - captures `pid_after` and runtime/security presence
-- Replaced `PlatformSideEffect::RestartAgent` with the same fast-path restart.
-- No Haiku/model-policy changes were introduced.
-
-### Evidence
-
-- `cargo remote -c -- fmt --check`
-  - PASS after applying remote rustfmt diffs locally.
-- `cargo remote -c -- test -p sentinel-daemon runtime_stall_restart -- --nocapture`
-  - PASS: `2 passed; 0 failed; 180 filtered out; finished in 1.49s`
-  - Covered tests:
-    - `operator_api::tests::runtime_stall_restart_test_is_forwarded_and_returns_response`
-    - `operator_api::tests::runtime_stall_restart_test_rejects_invalid_mode`
-- `cargo remote -c -- test -p sentinel-daemon restart_agent_fast_path -- --nocapture`
-  - PASS: `1 passed; 0 failed; 181 filtered out; finished in 0.14s`
-  - Covered test:
-    - `orchestrator::tests::test_restart_agent_fast_path_recreates_runtime_and_security_state`
-  - Note: build-server test sandbox logged `bwrap: Can't find source path /work/company`; this did not fail the test and is limited to the remote test fixture path.
-- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
-  - PASS: `Finished release profile [optimized] target(s) in 56.20s`
-  - artifact hash: `3470152e8b897217e2d2e547549b8f6759b3e733ec53d8a3ea8e00745da8d2bd  target/release/sentinel-daemon`
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-
-## Task 6 - Slice D: Worker-Supervision
-
-### Pre-task self-check
-
-- Was muss getan werden: Worker-Supervision aus Donor `6919e66` path-limited portieren, `service_health` per `catch_unwind` im selben Daemon-Prozess neu starten und einen deterministischen Panic-Testhook bereitstellen.
-- Welche ACs muessen hier passen:
-  - AC-1: `service_health`-Worker-Panics werden gefangen und erhoehen `restart_count`, ohne den Daemon-Prozess zu beenden.
-  - AC-2: `POST /operator/runtime/panic-test` akzeptiert nur den erlaubten Worker `service_health`, dispatcht in den ECS-Thread und liefert eine bounded Response.
-  - AC-3: Runtime-Health-Worker-State bleibt beobachtbar: `running`, `restart_count`, `last_error`, `thread_name`.
-  - AC-4: Remote-Tests, FUSE-Release-Build, Artefakt-Hash und `git diff --check` sind gruen.
-- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/build`, `sha256sum`, `git diff --check`.
-- Erwartete Dateien: `services/sentinel-daemon/src/service_health.rs`, `runtime_control.rs`, `operator_api.rs`, `orchestrator.rs`, `CHANGELOG.md`.
-- Risiken:
-  - Der Panic-Test muss ein kontrollierter Testpfad bleiben und darf keinen Daemon-Crash als PASS werten.
-  - Die bestehende Operator-Auth-/Loopback-Schutzschicht darf nicht umgangen werden.
-
-### Outcome
-
-- Path-limited donor Slice D was applied from stack donor `6919e66`.
-- `ServiceHealthChecker::spawn()` supervisiert den Worker jetzt in einer Schleife mit `panic::catch_unwind(AssertUnwindSafe(...))`.
-- Ein kontrollierter Panic erhoeht `restart_count`, schreibt `last_error` und startet `service-health-checker` im selben Daemon-Prozess erneut.
-- `ServiceHealthControl::{PanicTest, Shutdown}` steuert Test und sauberen Drop des Workers.
-- `POST /operator/runtime/panic-test` ist verdrahtet:
-  - rejects empty worker
-  - allows only `worker=service_health`
-  - dispatches via `RuntimeControlCommand::PanicTest`
-  - waits with `recv_timeout(10s)`
-- Der Orchestrator behandelt den Panic-Test im ECS-Owner-Thread und ruft `service_health_checker.trigger_panic_test()`.
-- No Haiku/model-policy changes were introduced.
-
-### Evidence
-
-- `cargo remote -c -- fmt --check`
-  - PASS: no remaining rustfmt diff.
-- `cargo remote -c -- test -p sentinel-daemon runtime_panic_test -- --nocapture`
-  - PASS: `2 passed; 0 failed; 183 filtered out; finished in 0.07s`
-  - Covered tests:
-    - `operator_api::tests::runtime_panic_test_is_forwarded_and_returns_response`
-    - `operator_api::tests::runtime_panic_test_rejects_invalid_worker`
-- `cargo remote -c -- test -p sentinel-daemon panic_test_restarts_worker_in_process -- --nocapture`
-  - PASS: `1 passed; 0 failed; 184 filtered out; finished in 0.25s`
-  - Note: the printed panic/backtrace is expected evidence from the intentional panic-test path; `catch_unwind` catches it and the test passes.
-- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
-  - PASS: `Finished release profile [optimized] target(s) in 57.79s`
-  - artifact hash: `4400fcb9162fe242f3cbebda550f25175976abc8f444475ab201d0570e43c3d2  target/release/sentinel-daemon`
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-
-## Task 7 - Slice E: bounded Analysis-/Recovery-Pfade
-
-### Pre-task self-check
-
-- Was muss getan werden: Slice E aus Donor `389b5e6` path-limited portieren, unbounded Analyse-Vorstufen begrenzen, Coalescing-/Drop-Counter sichtbar machen und einen deterministischen Flood-Testhook bereitstellen.
-- Welche ACs muessen hier passen:
-  - AC-1: Platform-Controlplane-Triggerqueue ist bounded, coalesced Duplikate und droppt aelteste Eintraege bei Ueberlauf.
-  - AC-2: LLM-Analyzer-Channel ist bounded und zaehlt Dropped-Requests statt unbounded Memory-Wachstum zuzulassen.
-  - AC-3: Runtime-Health enthaelt `analysis_queue_depth`, `analysis_queue_dropped_total` und `analysis_queue_coalesced_total`.
-  - AC-4: `POST /operator/runtime/analysis-flood-test` erzeugt kontrollierte Queue-Pressure fuer Live-Verifikation.
-  - AC-5: Remote-Tests, FUSE-Release-Build, Clippy, Artefakt-Hash, Scope-Guard und `git diff --check` sind gruen.
-- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
-- Erwartete Dateien: `config/daemon.toml`, `services/sentinel-daemon/src/config.rs`, `operator_api.rs`, `orchestrator.rs`, `platform_controlplane/*`, `runtime_control.rs`, `runtime_health.rs`, `CHANGELOG.md`.
-- Risiken:
-  - Nur den #279-Queue-Scope portieren, keine Gateway-/Model-Policy.
-  - Analyzer- und Controlplane-Stats muessen zusammengefuehrt werden, damit Runtime-Health nicht nur eine Queue sieht.
-  - Flood-Test muss ueber Operator-API/Runtime-Control laufen und darf kein ungeschuetzter Produktionspfad werden.
-
-### Outcome
-
-- Path-limited donor Slice E was applied from stack donor `389b5e6`.
-- Added `[daemon.platform_controlplane]` settings:
-  - `llm_trigger_queue_capacity = 16`
-  - `llm_analysis_channel_capacity = 16`
-- `PlatformControlplane` now uses a bounded `VecDeque` trigger queue.
-- Duplicate queued triggers are coalesced and counted via `analysis_queue_coalesced_total`.
-- Overflow drops the oldest trigger and increments `analysis_queue_dropped_total`.
-- `PlatformLlmAnalyzerHandle` now uses a bounded channel sized from config and tracks depth/drop counters.
-- Runtime-Health now publishes merged controlplane/analyzer queue stats.
-- Added `POST /operator/runtime/analysis-flood-test`:
-  - rejects `count=0`
-  - dispatches through `RuntimeControlCommand::AnalysisFloodTest`
-  - injects bounded/coalesced queue pressure in the ECS owner thread
-  - returns `requested`, `queue_depth`, `dropped_total` and `coalesced_total`
-- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
-
-### Evidence
-
-- `cargo remote -c -- fmt --check`
-  - PASS: no remaining rustfmt diff.
-- `cargo remote -c -- test -p sentinel-daemon test_parse_config -- --nocapture`
-  - PASS: `2 passed; 0 failed; 188 filtered out`
-- `cargo remote -c -- test -p sentinel-daemon trigger_queue -- --nocapture`
-  - PASS: `2 passed; 0 failed; 188 filtered out`
-- `cargo remote -c -- test -p sentinel-daemon enqueue_drops_when_bounded_queue_is_full -- --nocapture`
-  - PASS: `1 passed; 0 failed; 189 filtered out`
-- `cargo remote -c -- test -p sentinel-daemon runtime_analysis_flood_test -- --nocapture`
-  - PASS: `2 passed; 0 failed; 188 filtered out; finished in 0.06s`
-- `cargo remote -c -- clippy -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - PASS: `Finished dev profile [unoptimized + debuginfo] target(s) in 2m 59s`
-- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
-  - PASS: `Finished release profile [optimized] target(s) in 56.44s`
-  - artifact hash: `39bf79442190541ec03f11a66c4e8be437f6a8bd1f2e2366611a0d9ad0366cb2  target/release/sentinel-daemon`
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-- Scope guard:
-  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates || true`
-  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`
-
-## Task 8 - Slice F: Projection/API-Konvergenz
-
-### Pre-task self-check
-
-- Was muss getan werden: Slice F aus Donor `14560c4` plus relevante Stabilisierung aus `b1e376b` path-limited portieren, Projection-Drift erkennbar machen, Projection-Rebuilds per Request-Datei ausloesen und Restart-Storms vermeiden.
-- Welche ACs muessen hier passen:
-  - AC-1: Projection-Worker konsumiert eine Rebuild-Request-Datei und entfernt sie nach erfolgreichem Full-Rebuild.
-  - AC-2: Projection-Read-Model kann read-only geoeffnet werden, ohne Migrations-/Cleanup-Writes auf Runtime-Health-Reads auszufuehren.
-  - AC-3: Handlerfehler rollen Projection-Batches zurueck statt teilweise fortzuschreiben.
-  - AC-4: Runtime-Health erkennt Projection-Drift gegen Runtime-/Security-/Cgroup-Truth.
-  - AC-5: Runtime-Reconcile fordert bei Drift einen Rebuild an und startet `sentinel-projection` nicht neu, solange der Service aktiv ist und in-place rebuilden kann.
-  - AC-6: Remote-Tests, Clippy, Release-Builds, Artefakt-Hashes und Scope-Guard sind gruen.
-- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
-- Erwartete Dateien: `crates/sentinel-projection/*`, `services/sentinel-projection/src/main.rs`, `services/sentinel-daemon/src/runtime_health.rs`, `runtime_control.rs`, `orchestrator.rs`, `service_health.rs`, `operator_api.rs`, `CHANGELOG.md`.
-- Risiken:
-  - Projection-Recovery darf keine Restart-Schleife erzeugen.
-  - Runtime-Health darf keine Projection-Migrationen oder Startup-Cleanup nebenbei ausfuehren.
-  - Slice F darf keine FUSE/Landlock- oder Gateway-/Model-Policy-Arbeit einschleppen.
-
-### Outcome
-
-- Path-limited Slice F was applied from stack donor `14560c4` plus relevant stabilization from `b1e376b`.
-- `ProjectionConfig` now carries `rebuild_request_path` and a `1s` poll interval.
-- `ProjectionWorker` now polls `.projection-rebuild-request`, runs a full rebuild in-place, and removes the request file after success.
-- Projection batch handler failures now rollback the transaction and return an error instead of silently skipping failed events.
-- `ReadModelStore::open_readonly()` opens Projection DB read-only with a busy timeout and does not run migrations or startup cleanup.
-- Runtime-Health uses read-only Projection access and reports:
-  - `projection_drift_detected`
-  - `projection_drift_agents`
-- Runtime-Reconcile writes rebuild request payloads with a reason and reports:
-  - `projection_drift_before`
-  - `projection_drift_after`
-  - `projection_restart_attempted`
-  - `projection_restart_succeeded`
-- Runtime-Reconcile deliberately skips `systemctl restart sentinel-projection` when Projection is already active and a request-file rebuild can run in-place.
-- `service_health::restart_service()` now calls `systemctl reset-failed` before restart when a restart is actually required.
-- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
-
-### Evidence
-
-- `cargo remote -c -- fmt --check`
-  - PASS: no remaining rustfmt diff.
-- `cargo remote -c -- test -p sentinel-projection rebuild_request -- --nocapture`
-  - PASS: `1 passed; 0 failed`
-- `cargo remote -c -- test -q -p sentinel-projection -- --nocapture`
-  - PASS: `7 unit + 6 acceptance tests passed`
-- `cargo remote -c -- test -q -p sentinel-daemon runtime_control -- --nocapture`
-  - PASS: `2 passed`
-- `cargo remote -c -- test -q -p sentinel-daemon runtime_health -- --nocapture`
-  - PASS: `4 passed`
-- `cargo remote -c -- test -q -p sentinel-daemon test_runtime_reconcile_skips_projection_restart_when_rebuild_can_run_in_place -- --nocapture`
-  - PASS: `1 passed`
-- `cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings`
-  - PASS: exit `0`
-- `cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings`
-  - PASS: exit `0`
-- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - PASS: exit `0`
-- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
-  - PASS: exit `0`
-  - artifact hash: `3a05fc872c061ae973e3d820e0a1aaa2d0a909b201d61e9b0c8c84b080c08425  target/release/sentinel-daemon`
-- `cargo remote -c -- build -q -p sentinel-projection-service --release`
-  - PASS: exit `0`
-  - artifact hash: `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`
-
-## Task 9 - Slice G: Conditional FUSE/Landlock Runtime Restore
-
-### Pre-task self-check
-
-- Was muss getan werden: Slice G nur soweit umsetzen, wie der canonical-main-Reset es fuer Runtime-Konsistenz rechtfertigt: kein #264-Port, kein Gateway-/Model-Scope, sondern FUSE-Aktivierung fail-closed und Landlock-Exec-Pfade runtime-faehig halten.
-- Welche ACs muessen hier passen:
-  - AC-1: `fs_mount` wird nur an Sandbox, Operator-API und ECS weitergegeben, wenn `sentinel-fs` wirklich als FUSE-Mount aktiv ist.
-  - AC-2: Wenn der FUSE-Mount nicht aktiv wird, laeuft die Runtime explizit ueber `/ram/agents` weiter statt auf einen leeren Mountpoint zu zeigen.
-  - AC-3: Landlock bleibt eng und erlaubt Execute nicht wieder pauschal fuer `/usr` oder `/lib`.
-  - AC-4: Dynamische ELF-Binaries koennen weiter starten, weil die notwendigen Loader explizit erlaubt sind.
-  - AC-5: Remote-Tests, Clippy, FUSE-Builds, Sandbox-Binary-Build, Scope-Guard und `git diff --check` sind gruen.
-- Wie wird bewiesen: Code-Diff, `cargo remote -c -- fmt/test/clippy/build`, `sha256sum`, `git diff --check`, Scope-Guard gegen Haiku-/Model-Pinning.
-- Erwartete Dateien: `services/sentinel-daemon/src/orchestrator.rs`, `crates/sentinel-sandbox/src/landlock.rs`, `CHANGELOG.md`.
-- Risiken:
-  - FUSE darf nicht blind als aktiv gelten, nur weil `fs_mount` konfiguriert ist.
-  - Landlock darf nicht durch breite `/usr`-/`/lib`-Exec-Allowlists verwässert werden.
-  - Slice G darf keine #264-Security-ACs oder Haiku-/Gateway-Policy einschleppen.
-
-### Outcome
-
-- `mountinfo_contains_mountpoint()` prueft jetzt exakt auf Mountpoint, FUSE-Filesystem und `sentinel-fs` als Mount-Source.
-- `wait_for_fuse_mount()` wartet bounded bis zu 2s auf den FUSE-Mount und prueft danach final erneut.
-- Der Daemon berechnet `active_fs_mount` und gibt nur diesen aktiven Mount an Sandbox, Operator-API und ECS weiter.
-- Wenn `config.fs_mount` gesetzt ist, aber kein tragfaehiger FUSE-Mount aktiv wird, loggt der Daemon eine Warnung und nutzt weiter `/ram/agents`.
-- Landlock `default_exec_paths()` bleibt eng:
-  - `/usr/bin/agent-runtime`
-  - `/breakout-helper`
-  - `/lib64/ld-linux-x86-64.so.2`
-  - `/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2`
-- Tests sichern ab, dass `/usr` nicht als pauschaler Exec-Pfad zurueckkommt.
-- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
-
-### Evidence
-
-- `cargo remote -c -- test -q -p sentinel-daemon mountinfo_contains_mountpoint_matches_exact_sentinel_fuse_mount --features fuse -- --nocapture`
-  - PASS: targeted FUSE-mountinfo test passed.
-- `cargo remote -c -- test -q -p sentinel-sandbox ruleset_for_agent_paths -- --nocapture`
-  - PASS: Landlock-Agent-Ruleset-Test passed and confirms no `/usr` exec path.
-- `cargo remote -c -- fmt --check`
-  - PASS: no remaining rustfmt diff.
-- `cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture`
-  - PASS: `44 tests: 41 passed, 3 ignored`; `16 tests: 14 passed, 2 ignored`; `12 tests: 3 passed, 9 ignored`.
-- `cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-sandbox --release --bins`
-  - PASS: exit `0`.
-- `cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture`
-  - PASS: `93 passed`; `19 passed`; `2 ignored`.
-- `cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings`
-  - PASS: exit `0`.
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-- Scope guard:
-  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates`
-  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`.
-- Artifact hashes:
-  - `517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon`
-  - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
-  - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`
-
-## Task 10 - Out-of-scope Follow-up: Haiku-Policy
-
-### Pre-task self-check
-
-- Was muss getan werden: Haiku-/Agent-Model-Policy nicht in #279 implementieren, sondern als separates Gateway-/Inference-Follow-up sichern.
-- Welche ACs muessen hier passen:
-  - AC-1: Es gibt keine Haiku-/Model-Pinning-Aenderung im #279-Branch.
-  - AC-2: Bestehende Issues wurden geprueft, damit kein Duplikat erzeugt wird.
-  - AC-3: Wenn kein passendes Issue existiert, wird ein eigenes Follow-up erstellt.
-  - AC-4: #279 dokumentiert die Scope-Entscheidung.
-- Wie wird bewiesen: GitHub-Issue-Suche, neues Issue, Kommentar auf #279, Scope-Guard aus Task 9.
-- Erwartete Dateien: `PROGRESS.md`.
-- Risiken:
-  - Die fachliche Entscheidung "Agents sollen Haiku nutzen" darf nicht durch Daemon-Hardcoding umgesetzt werden.
-  - #279 darf dadurch keine neue Close-Bedingung bekommen.
-
-### Outcome
-
-- GitHub-Suche nach Haiku-/Model-Policy-Themen fand kein passendes offenes Follow-up.
-- Neues Issue erstellt: `#314 Policy: Agent LLM model defaults via Gateway/Inference layer`.
-- `#314` definiert Haiku als Agent-Runtime-Default in Gateway/Inference, nicht im Daemon.
-- #279 kommentiert mit Scope-Entscheidung und Link auf #314.
-- No Haiku/model-policy changes were introduced; runtime still leaves model selection to the Gateway default.
-
-### Evidence
-
-- `gh issue list --repo silentspike/project-sentinel --state all --search "Haiku in:title" --limit 20 --json number,title,state,labels,url`
-  - PASS: no matching existing Haiku policy issue.
-- `gh issue list --repo silentspike/project-sentinel --state all --search "model in:title" --limit 20 --json number,title,state,labels,url`
-  - PASS: only unrelated/closed historical model issues found.
-- `gh issue create ...`
-  - PASS: created `https://github.com/silentspike/project-sentinel/issues/314`.
-- `gh issue comment 279 ...`
-  - PASS: created `https://github.com/silentspike/project-sentinel/issues/279#issuecomment-4304109979`.
-- Scope guard inherited from Task 9:
-  - `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`
-
-## Task 11 - Phase 3: Tests, Clippy, Builds
-
-### Pre-task self-check
-
-- Was muss getan werden: die komplette Remote-Qualitaetsmatrix fuer #279 ausfuehren, inklusive conditional FUSE/Landlock-Gates, Release-Artefakte erzeugen und Scope-/Whitespace-Guards belegen.
-- Welche ACs muessen hier passen:
-  - AC-1: Daemon-, Projection- und Projection-Service-Tests laufen auf dem Remote-Builder gruen.
-  - AC-2: Clippy ist fuer alle beruehrten Rust-Crates gruen.
-  - AC-3: Release-Artefakte fuer Daemon, Projection und Sandbox-Helper existieren lokal nach Remote-Build.
-  - AC-4: conditional FUSE/Landlock-Gates bleiben nach allen Slices gruen.
-  - AC-5: `git diff --check` und Haiku-/Model-Scope-Guard sind gruen.
-- Wie wird bewiesen: ausschliesslich `cargo remote -c --` fuer Rust, danach lokale `git diff --check`, `rg` Scope-Guard und `sha256sum`.
-- Erwartete Dateien: `PROGRESS.md`, `test-279-verification.md`; keine Code-Aenderungen.
-- Risiken:
-  - Der Daemon-Test enthaelt einen erwarteten kontrollierten Panic-Test; PASS ist nur gueltig, wenn `catch_unwind` den Test abfaengt und der Testprozess erfolgreich endet.
-  - Release-Hashes muessen die finalen Artefakte fuer Task 12 sein.
-
-### Outcome
-
-- Full daemon test suite passed on the remote builder:
-  - `193 passed; 0 failed; 0 ignored; finished in 10.29s`
-  - expected controlled `panic-test requested for service_health` output was caught by the worker-supervision test.
-- Projection tests passed on the remote builder:
-  - `sentinel-projection`: `7 passed` and `6 passed`
-  - `sentinel-projection-service`: `0 tests`, exit `0`
-- Clippy passed for:
-  - `sentinel-daemon --all-targets --features fuse`
-  - `sentinel-projection --all-targets`
-  - `sentinel-projection-service --all-targets`
-  - `sentinel-fs --all-targets --features fuse-tests`
-  - `sentinel-sandbox --all-targets`
-- Release builds passed for:
-  - `sentinel-daemon --release --features fuse`
-  - `sentinel-projection-service --release`
-  - `sentinel-sandbox --release --bins`
-- Conditional FUSE/Landlock tests were repeated and remained green:
-  - `sentinel-fs --features fuse-tests`: `93 passed`, `19 passed`, `2 ignored`
-  - `sentinel-sandbox`: `41 passed, 3 ignored`; `14 passed, 2 ignored`; `3 passed, 9 ignored`
-- No Haiku/model-policy change was introduced; runtime still leaves model selection to the Gateway default.
-
-### Evidence
-
-- `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`
-  - PASS: `193 passed; 0 failed; 0 ignored; finished in 10.29s`.
-- `cargo remote -c -- test -q -p sentinel-projection -- --nocapture`
-  - PASS: `7 passed`; `6 passed`; no failures.
-- `cargo remote -c -- test -q -p sentinel-projection-service -- --nocapture`
-  - PASS: `0 tests`, exit `0`.
-- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- clippy -q -p sentinel-projection --all-targets -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- clippy -q -p sentinel-projection-service --all-targets -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-projection-service --release`
-  - PASS: exit `0`.
-- `cargo remote -c -- test -q -p sentinel-fs --features fuse-tests -- --nocapture`
-  - PASS: `93 passed; 19 passed; 2 ignored`.
-- `cargo remote -c -- test -q -p sentinel-sandbox -- --nocapture`
-  - PASS: `44 tests: 41 passed, 3 ignored`; `16 tests: 14 passed, 2 ignored`; `12 tests: 3 passed, 9 ignored`.
-- `cargo remote -c -- clippy -q -p sentinel-fs --all-targets --features fuse-tests -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- clippy -q -p sentinel-sandbox --all-targets -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-sandbox --release --bins`
-  - PASS: exit `0`.
-- `git diff --check`
-  - PASS: no whitespace/conflict errors.
-- Scope guard:
-  - `rg -n "AGENT_MODEL_HAIKU|model: AGENT|model: String::new\\(\\).*Gateway" services/sentinel-daemon/src cmd crates`
-  - PASS: only `services/sentinel-daemon/src/llm_bridge.rs:612: model: String::new(), // Gateway waehlt default`.
-- Artifact hashes:
-  - `517a9c6a14da0a4d4cd761b74cd7e37d1e2aaa9f24ec4329a7585f0c45638338  target/release/sentinel-daemon`
-  - `d0da3c42b11397e1c954777397c4b3622cfeeb4365fff2adebbded9adacb13b4  target/release/sentinel-projection`
-  - `a3d35bdf5261a617546a19a380f731dba89dc6f24327f4dca1eff4783a05a31d  target/release/landlock-wrapper`
-  - `03abe24e93222b540bf36bbedf0d5c259780bea0f53c79386086c44d22e40be8  target/release/breakout-helper`
-
-## Task 14 - Benchmarks
-
-### Pre-task self-check
-
-- Was muss getan werden: issue-spezifische Benchmarks fuer Runtime-Reconcile, Projection-Drift-Detection, bounded Analysis-Flood und Stall-Recovery-Bookkeeping auf der Deploy-VM messen.
-- Welche ACs muessen hier passen:
-  - AC-1: Benchmarks messen serverseitige Runtime-Pfade, nicht HTTP-Wallclock mit 1-Hz-Tick-Wartezeit.
-  - AC-2: Sidecar-Monitoring fuer RAM, CPU, IOPS und Prozesszustand liegt pro Lauf vor.
-  - AC-3: finaler VM-Zustand bleibt healthy: `expected/runtime/projection/cgroups = 26/26/26/26`, keine stale/orphan/zombie/drift-Treffer.
-  - AC-4: `journalctl` seit Benchmark-Start zeigt keine Panic-/Drift-Regressionsmarker.
-- Wie wird bewiesen: `cargo remote -c --`, Deploy-Hash, `/opt/sentinel/scripts/vm-issue-279-bench.sh`, Sidecar-Artefakte unter `/tmp/issue279-bench-20260423T132030Z`.
-- Erwartete Dateien: `scripts/vm-issue-279-bench.sh`, `PROGRESS.md`, `test-279-verification.md`, `CHANGELOG.md`.
-- Risiken:
-  - HTTP-End-to-End-Zeit ist fuer diese Benchmarks nicht geeignet, weil Runtime-Control-Befehle im ECS-Tick abgearbeitet werden; deshalb wurden serverseitige Timing-Felder ergaenzt.
-
-### Outcome
-
-- Runtime-Control und Runtime-Health liefern benchmarkfaehige serverseitige Timing-Felder:
-  - `RuntimeReconcileResponse.elapsed_us`
-  - `RuntimeHealthSnapshot.snapshot_build_elapsed_us`
-  - `RuntimeAnalysisFloodTestResponse.enqueue_per_request_ns`
-  - `RuntimeStallRestartTestResponse.bookkeeping_elapsed_ns`
-- Remote-Qualitaetsmatrix nach Instrumentierung ist gruen:
-  - `cargo remote -c -- fmt --all`
-  - `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`: `194 passed`
-  - `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
-- VM-Deploy erfolgte am systemd-`ExecStart`-Pfad `/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`.
-- VM-Binary-Hash: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`.
-- Benchmark PASS:
-  - `runtime_reconcile_26_agents`: `2134us < 5000us`
-  - `projection_divergence_detection`: `817us < 5000us`
-  - `analysis_flood_cap`: `148ns/request < 250000ns/request`
-  - `stall_recovery_bookkeeping`: `700ns < 50000ns`
-- Finaler VM-Gate blieb healthy: `expected/runtime/projection/cgroups = 26/26/26/26`, `stale=0`, `orphans=0`, `zombies=0`, `drift=false`.
-
-### Evidence
-
-- `cargo remote -c -- fmt --all`
-  - PASS: exit `0`.
-- `cargo remote -c -- test -q -p sentinel-daemon -- --nocapture`
-  - PASS: `194 passed; 0 failed`.
-- `cargo remote -c -- clippy -q -p sentinel-daemon --all-targets --features fuse -- -D warnings`
-  - PASS: exit `0`.
-- `cargo remote -c -- build -q -p sentinel-daemon --release --features fuse`
-  - PASS: exit `0`.
-- `sha256sum target/release/sentinel-daemon`
-  - PASS: `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d  target/release/sentinel-daemon`.
-- Deploy:
-  - `ssh ubuntu@10.0.0.240 "grep ExecStart /etc/systemd/system/sentinel-daemon.service"`
-  - PASS: `ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml`.
-  - `scp target/release/sentinel-daemon ubuntu@10.0.0.240:/tmp/sentinel-daemon.issue279-bench`
-  - `ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/sentinel-daemon.issue279-bench /opt/sentinel/bin/sentinel-daemon && sudo systemctl restart sentinel-daemon"`
-  - PASS: service active, VM hash matches `7d105283937f92a98bbf2dbd89fc44f8f86128b92a935042c328dac3e8c2756d`.
-- Benchmark:
-  - `scp scripts/vm-issue-279-bench.sh ubuntu@10.0.0.240:/tmp/vm-issue-279-bench.sh`
-  - `ssh ubuntu@10.0.0.240 "sudo install -m 755 /tmp/vm-issue-279-bench.sh /opt/sentinel/scripts/vm-issue-279-bench.sh && /opt/sentinel/scripts/vm-issue-279-bench.sh"`
-  - PASS: `BENCH_PASS out_dir=/tmp/issue279-bench-20260423T132030Z`.
-- Sidecars:
-  - `/tmp/issue279-bench-20260423T132030Z/free-before.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/free-after.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/vmstat-before.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/vmstat-after.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/iostat-before.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/iostat-after.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/ps-before.txt`
-  - `/tmp/issue279-bench-20260423T132030Z/ps-after.txt`
-- Final service gate:
-  - `sentinel-daemon`, `sentinel-projection`, `sentinel-gateway`, `sentinel-nats-bridge`: all `active`.
-  - `journalctl -u sentinel-daemon --since <benchmark-start>` panic/drift marker scan: empty.
+  - aktuelle Config-Strukturen koennen in `control` statt `proxy` liegen; keine neue Parallel-Konfig bauen, sondern bestehende Patterns nutzen.
+  - Response-Observability gehoert erst in Task 3; Task 2 soll Policy-Entscheidung und Request-Klassen sauber schneiden.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_3_DONE_TASK_4_PENDING`
-- Current task: `Task 4 - Phase 4: Go-Tests`
+- Overall status: `TASK_4_DONE_TASK_5_PENDING`
+- Current task: `Task 5 - Phase 5: Benchmarks`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -46,6 +46,14 @@
   - `ResponseLogBuffer` ist jetzt ein bounded circular buffer und vermeidet steady-state O(n)-Kopie beim Append.
   - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
   - `go build ./cmd/cortex-gateway` ist gruen.
+- Task 4 ist erledigt:
+  - Policy-Unit-Tests pruefen strikte Request-Klassifikation und Resolver-Reihenfolge.
+  - Pipeline-Test prueft, dass Agent-Runtime-Requests auf `haiku` gesetzt werden.
+  - Anthropic-Compat-Test prueft, dass `/v1/messages` `external_compat` bleibt und die Request-Override-Policy nutzt.
+  - Control-Tests pruefen Default, erlaubte Werte und Rejects fuer `agent_runtime_model_policy`.
+  - Response-Log-Test prueft Ring-Overwrite, chronologische Ausgabe und `LastByClass`.
+  - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
+  - `go build ./cmd/cortex-gateway` ist gruen.
 
 ## Blocked items
 
@@ -56,7 +64,7 @@
 
 - `a42ef76` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
 - `b953e4a` Task [2] Phase 2 - Gateway Policy-Layer
-- `TBD` Task [3] Phase 3 - Observability und Response Log
+- `114732d` Task [3] Phase 3 - Observability und Response Log
 - `TBD` Task [4] Phase 4 - Go-Tests
 - `TBD` Task [5] Phase 5 - Benchmarks
 - `TBD` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
@@ -71,12 +79,58 @@
 | 1 | Phase 1 - Issue-Body-Repair, Branch und Preflight | DONE | Branch von main, GitHub-Body reparieren, `quality:ready`, Haiku-String fuer claude-code pruefen, Platform-Controlplane out-of-scope bestaetigen | command, inspect, system |
 | 2 | Phase 2 - Gateway Policy-Layer | DONE | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
 | 3 | Phase 3 - Observability und Response Log | DONE | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, bounded circular buffer | inspect, command |
-| 4 | Phase 4 - Go-Tests | PENDING | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
+| 4 | Phase 4 - Go-Tests | DONE | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
 | 5 | Phase 5 - Benchmarks | PENDING | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | PENDING | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
 | 7 | Phase 8 - AC-Matrix und Live-Verifikation | PENDING | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
 | 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
 | 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
+
+## Task 4 - Phase 4: Go-Tests
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - gezielte Unit-/Regressionstests fuer Request-Klassifikation und Policy-Resolver ergaenzen
+  - Tests fuer `/v1/messages` als externe Compatibility-Klasse absichern
+  - Tests fuer Control-Config-Default und Validation von `agent_runtime_model_policy` ergaenzen
+  - Tests fuer Response-Log-Felder und Ringbuffer-Chronologie ergaenzen
+  - komplette betroffene Gateway-Testpakete laufen lassen
+- Welche ACs muessen hier passen:
+  - AC-1: Agent-Runtime wird nur fuer positive numerische Agent-ID nach Ausschluss von Platform-/Service-Pfaden klassifiziert.
+  - AC-2: `/v1/messages` bleibt `external_compat` und bekommt keine Agent-Policy.
+  - AC-3: leeres Modell wird fuer Agent-Runtime zu `haiku`, explizites Modell gewinnt.
+  - AC-4: ungueltige Provider-/Policy-Kombination failt deterministisch.
+  - AC-5: Control-Config defaultet auf `haiku` und akzeptiert nur erlaubte Werte.
+  - AC-6: ResponseLogBuffer liefert chronologische Eintraege nach Ring-Overwrite und `LastByClass` findet den letzten Runtime-Eintrag.
+- Wie wird bewiesen:
+  - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`
+  - `go build ./cmd/cortex-gateway`
+- Erwartete Dateien:
+  - `cmd/cortex-gateway/internal/proxy/policy_test.go`
+  - `cmd/cortex-gateway/internal/proxy/response_log_test.go`
+  - vorhandene Tests in `cmd/cortex-gateway/internal/control`
+- Risiken:
+  - bestehende Tests koennen alte ResponseLogBuffer-Signatur erwarten; nicht per Compatibility-Wrapper kaschieren, sondern Tests auf neue Struktur aktualisieren.
+
+### Outcome
+
+- `policy_test.go` deckt strikte Klassifikation und Resolver-Reihenfolge ab.
+- `pipeline_test.go` deckt Agent-Runtime-Haiku-Anwendung und externe `/v1/messages`-Trennung ab.
+- `plane_test.go` deckt Default, erlaubte Werte und invaliden `agent_runtime_model_policy` ab.
+- `response_log_test.go` deckt Ringbuffer-Overwrite, chronologische Ausgabe und `LastByClass` ab.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-4 Command/Output-Evidence.
+- AC-1 PASS: Tests fuer numerische Agent-ID und Ausschluss von Platform-/Service-Pfaden.
+- AC-2 PASS: Pipeline-Test bestaetigt `/v1/messages` als `external_compat`.
+- AC-3 PASS: Policy- und Pipeline-Tests bestaetigen Haiku fuer Agent-Runtime und explizites Modell als Override.
+- AC-4 PASS: Policy-Test prueft unsupported Provider und unknown Policy als Fehler.
+- AC-5 PASS: Control-Test prueft Default `haiku`, leeres Disable und Rejects.
+- AC-6 PASS: ResponseLogBuffer-Test prueft Ring-Overwrite und `LastByClass`.
+- Command PASS: `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`.
+- Command PASS: `go build ./cmd/cortex-gateway`.
 
 ## Task 1 - Phase 1: Issue-Body-Repair, Branch und Preflight
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_6_DONE_TASK_7_PENDING`
-- Current task: `Task 7 - Phase 8: AC-Matrix und Live-Verifikation`
+- Overall status: `TASK_7_DONE_TASK_8_PENDING`
+- Current task: `Task 8 - Dokumentation, PR- und Close-Sequenz`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -71,6 +71,14 @@
   - `curl -s localhost:8080/health` liefert `status=ok`.
   - `curl -s localhost:8081/control/traffic-stats` enthaelt `agent_runtime_model_policy: haiku`.
   - PID-basiertes Gateway-Journal seit Restart zeigt Startup-Logs ohne Panic/Fatal.
+- Task 7 ist erledigt:
+  - AC-1 PASS: Interner `/internal/llm` Agent-Runtime-Forward setzt `model=haiku`.
+  - AC-2 PASS: Daemon enthaelt kein `AGENT_MODEL_HAIKU`; Agent-Runtime sendet `model: String::new()`.
+  - AC-3 PASS: VM-Forward `request_id=49c25b39-466d-4c48-9bc0-04fac9e9b360` lief als `agent_runtime`, Provider `claude-code`, Model `haiku`.
+  - AC-4 PASS: `/v1/messages` mit Dummy-Key ging gegen `anthropic-direct`, `request_class=external_compat`, `effective_model=claude-opus-4-6`, `policy_source=request_override`, HTTP `401` wegen absichtlich falschem Key.
+  - AC-5 PASS: `traffic-stats`, `traffic-responses` und Journal zeigen redigierte Felder; Secret-Grep fand keine Token/API-Key-Werte.
+  - AC-6 PASS: Go-Tests plus VM-Smoke belegen interne Runtime-Default-Policy getrennt vom externen Compatibility-Pfad.
+  - Panic/Drift-Grep fuer Gateway/Daemon seit Live-Verifikation ist leer.
 
 ## Blocked items
 
@@ -84,7 +92,7 @@
 - `114732d` Task [3] Phase 3 - Observability und Response Log
 - `b326a2f` Task [4] Phase 4 - Go-Tests
 - `9d2adf5` Task [5] Phase 5 - Benchmarks
-- `TBD` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
+- `9495871` Task [6] Phase 6 - Gateway Deploy auf 10.0.0.240
 - `TBD` Task [7] Phase 8 - AC-Matrix und Live-Verifikation
 - `TBD` Task [8] Dokumentation, PR- und Close-Sequenz
 - `TBD` Task [9] Plan-Verifikation
@@ -99,7 +107,7 @@
 | 4 | Phase 4 - Go-Tests | DONE | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
 | 5 | Phase 5 - Benchmarks | DONE | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | DONE | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
-| 7 | Phase 8 - AC-Matrix und Live-Verifikation | PENDING | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
+| 7 | Phase 8 - AC-Matrix und Live-Verifikation | DONE | AC-1 bis AC-6 einzeln auf VM belegen, Config restore, Panic/Error/Secret-Grep | command, system |
 | 8 | Dokumentation, PR- und Close-Sequenz | PENDING | CHANGELOG, Evidence-Doku, PR mit Pflichtsektionen, Labels, Issue-Close erst nach verified | command, inspect |
 | 9 | Plan-Verifikation | PENDING | Plan komplett gegen Ergebnis pruefen, Abweichungen fixen oder blocken | inspect, command, system |
 
@@ -150,6 +158,56 @@
 - AC-3 PASS: `/health` liefert `{"status":"ok",...}`.
 - AC-4 PASS: `/control/traffic-stats` enthaelt `"agent_runtime_model_policy": "haiku"`.
 - AC-5 PASS: PID-basiertes Journal seit Restart zeigt Startup ohne Panic/Fatal.
+
+## Task 7 - Phase 8: AC-Matrix und Live-Verifikation
+
+### Pre-task self-check
+
+- Was muss getan werden:
+  - alle 6 GitHub-ACs einzeln mit VM- oder Repo-Evidence belegen
+  - kontrollierten `agent_runtime`-Forward ueber `/internal/llm` provozieren
+  - externe `/v1/messages`-Compatibility gegen interne Policy trennen
+  - `/control/traffic-stats`, `/control/traffic-responses` und PID-Journal fuer Observability pruefen
+  - Daemon-Code auf fehlendes hartes `AGENT_MODEL_HAIKU`-Pinning pruefen
+  - Panic/Drift/Secret-Grep ausfuehren
+- Welche ACs muessen hier passen:
+  - AC-1: Interne Agent-Runtime-Requests bekommen effektiv `haiku`.
+  - AC-2: Der Daemon pinnt kein Agent-Haiku-Modell.
+  - AC-3: VM zeigt mindestens einen echten Agent-Runtime-Forward mit `effective_model=haiku`.
+  - AC-4: `/v1/messages` bleibt externer MITM-/Anthropic-Compatibility-Pfad und wird nicht von Agent-Default-Policy erfasst.
+  - AC-5: Observability zeigt Request-Klasse, Provider, Policy-Source und effektives Modell ohne Secrets.
+  - AC-6: Tests und VM-Smoke belegen die Trennung von internem Runtime-Default und externem Compatibility-Pfad.
+- Wie wird bewiesen:
+  - VM-`curl` gegen `127.0.0.1:8080/internal/llm`
+  - VM-`curl` gegen `127.0.0.1:8080/v1/messages`
+  - VM-`curl` gegen `127.0.0.1:8081/control/traffic-stats` und `/control/traffic-responses`
+  - PID-basiertes Gateway-Journal
+  - `rg` in Daemon-Quellen
+  - Panic/Drift/Secret-Grep
+- Erwartete Dateien:
+  - `test-314-verification.md`
+  - `PROGRESS.md`
+- Risiken:
+  - Claude-Code-Quota/Circuit-Breaker kann den echten Forward blockieren; dann AC-3 bleibt BLOCKED statt durch Tests ersetzt zu werden.
+
+### Outcome
+
+- Alle 6 GitHub-ACs wurden mit Repo- und VM-Evidence belegt.
+- Kontrollierter Agent-Runtime-Forward ueber `/internal/llm` lieferte HTTP `200`, Provider `claude-code`, Model `haiku`.
+- Externer `/v1/messages`-Pfad wurde mit Dummy-Key getestet und blieb `external_compat`/`anthropic-direct` ohne Agent-Runtime-Policy.
+- Observability-Felder sind in `traffic-stats`, `traffic-responses` und Journal sichtbar.
+- Secret-Grep auf Stats/Responses/Journal fand keine Token/API-Key-Werte.
+- Panic/Drift-Grep blieb leer.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-7 Command/Output-Evidence.
+- AC-1 PASS: `/internal/llm` Response enthaelt `"model":"haiku"` und `"provider":"claude-code"`.
+- AC-2 PASS: `rg "AGENT_MODEL_HAIKU"` ohne Treffer; `llm_bridge.rs` zeigt `model: String::new()`.
+- AC-3 PASS: `traffic-responses` fuer `49c25b39-466d-4c48-9bc0-04fac9e9b360` zeigt `request_class=agent_runtime`, `model=haiku`, `policy_source=agent_runtime_policy`.
+- AC-4 PASS: `/v1/messages` Dummy-Key-Test zeigt im Journal `provider=anthropic-direct`, `request_class=external_compat`, `effective_model=claude-opus-4-6`, `policy_source=request_override`.
+- AC-5 PASS: Observability- und Secret-Grep erfolgreich.
+- AC-6 PASS: Go-Tests plus VM-Smoke decken beide Pfade ab.
 
 ## Task 5 - Phase 5: Benchmarks
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Plan source: `/work/company/codex-plan314.md`
-- Overall status: `TASK_2_DONE_TASK_3_PENDING`
-- Current task: `Task 3 - Phase 3: Observability und Response Log`
+- Overall status: `TASK_3_DONE_TASK_4_PENDING`
+- Current task: `Task 4 - Phase 4: Go-Tests`
 - Current branch: `feat/issue-314-agent-model-policy`
 - Worktree: `/work/company/project-sentinel`
 - Base: `origin/main @ 0f1c46c19bfa61d0616b3468834d29b557b3e254`
@@ -39,6 +39,13 @@
   - Zwischenfund: Die Policy wurde nach erstem Testfail aus dem Pre-Synthesis-Pfad in den echten Forward-Pfad verschoben.
   - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
   - `go build ./cmd/cortex-gateway` ist gruen.
+- Task 3 ist erledigt:
+  - `traffic-stats` zeigt jetzt `agent_runtime_model_policy` und den letzten Agent-Runtime-Forward mit effektivem Modell, Policy-Source und Provider.
+  - `ResponseLogEntry` enthaelt `request_class`, `provider`, `model`, `policy_source`, `agent_id`, `agent_name` ohne Header-/Secret-Felder.
+  - Provider-Success, Provider-Error, Stream-Success und Stream-Error loggen Request-Klasse, effektives Modell und Policy-Source.
+  - `ResponseLogBuffer` ist jetzt ein bounded circular buffer und vermeidet steady-state O(n)-Kopie beim Append.
+  - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control` ist gruen.
+  - `go build ./cmd/cortex-gateway` ist gruen.
 
 ## Blocked items
 
@@ -48,7 +55,7 @@
 ## Commit references
 
 - `a42ef76` Task [1] Phase 1 - Issue-Body-Repair, Branch und Preflight
-- `TBD` Task [2] Phase 2 - Gateway Policy-Layer
+- `b953e4a` Task [2] Phase 2 - Gateway Policy-Layer
 - `TBD` Task [3] Phase 3 - Observability und Response Log
 - `TBD` Task [4] Phase 4 - Go-Tests
 - `TBD` Task [5] Phase 5 - Benchmarks
@@ -63,7 +70,7 @@
 |---|------|--------|-------|----------|
 | 1 | Phase 1 - Issue-Body-Repair, Branch und Preflight | DONE | Branch von main, GitHub-Body reparieren, `quality:ready`, Haiku-String fuer claude-code pruefen, Platform-Controlplane out-of-scope bestaetigen | command, inspect, system |
 | 2 | Phase 2 - Gateway Policy-Layer | DONE | Request-Klassifikation, Agent-Runtime-Policy, Resolver-Reihenfolge, fail-closed Validation | inspect, command |
-| 3 | Phase 3 - Observability und Response Log | PENDING | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, ggf. bounded circular buffer | inspect, command |
+| 3 | Phase 3 - Observability und Response Log | DONE | Traffic-Stats, ResponseLogEntry, Journal-Logs fuer Success/Stream/Error, bounded circular buffer | inspect, command |
 | 4 | Phase 4 - Go-Tests | PENDING | Unit-/Regressionstests fuer Klassen, Policy, `/v1/messages`, Response-Logs und Validation | command |
 | 5 | Phase 5 - Benchmarks | PENDING | Classify/Resolve/ResponseLog Benchmarks mit Zielwerten und System-Monitoring | command, system |
 | 6 | Phase 6 - Gateway Deploy auf 10.0.0.240 | PENDING | ExecStart pruefen, Linux-Binary bauen, deployen, Gateway restart, Smoke | command, system |
@@ -193,3 +200,22 @@
 - Risiken:
   - `traffic-stats` lebt in `main.go` und muss ohne zusaetzliche globale State-Duplikation an Gateway-Daten kommen.
   - Error-Logs muessen AC-4 belegen koennen, auch wenn `/v1/messages` mit Dummy-Key fehlschlaegt.
+
+### Outcome
+
+- `traffic-stats` liest die Control-Konfiguration einmal pro Request und exportiert `agent_runtime_model_policy`.
+- Wenn ein Agent-Runtime-Forward im Response-Log existiert, exportiert `traffic-stats` zusaetzlich `last_agent_runtime_effective_model`, `last_agent_runtime_policy_source` und `last_agent_runtime_provider`.
+- `ResponseLogEntry` wurde um `request_class`, `model`, `policy_source`, `agent_id` und `agent_name` erweitert; Header, Tokens und Secrets werden nicht gespeichert.
+- Provider-Success-, Provider-Error-, Stream-Success- und Stream-Error-Logs tragen jetzt Request-Klasse, effektives Modell, Policy-Source und Agent-Metadaten.
+- `ResponseLogBuffer` wurde auf einen bounded circular buffer umgestellt; `Add()` ueberschreibt bei vollem Buffer ohne Slice-Restkopie.
+
+### Evidence
+
+- `test-314-verification.md` enthaelt Task-3 Command/Output-Evidence.
+- AC-1 PASS: `main.go` exportiert `agent_runtime_model_policy` und letzte Agent-Runtime-Policy-Felder.
+- AC-2 PASS: `ResponseLogEntry` enthaelt redigierte Policy-/Agent-Felder.
+- AC-3 PASS: Success-, Stream- und Error-Logs enthalten Request-Klasse, effektives Modell und Policy-Source.
+- AC-4 PASS: Neue Response-Log-/Stats-Felder enthalten keine Header, API-Keys oder Tokenwerte.
+- AC-5 PASS: `ResponseLogBuffer.Add()` bleibt bounded und hat im steady state keine O(n)-Kopie.
+- Command PASS: `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`.
+- Command PASS: `go build ./cmd/cortex-gateway`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -32,7 +32,7 @@
 - Task 2 ist erledigt:
   - `RequestClass` wurde zentral im Gateway eingefuehrt.
   - `agent_runtime` wird nur bei positiver numerischer `agent_id` und nach Ausschluss von Platform-/Service-/Analysepfaden gesetzt.
-  - `agent_runtime_model_policy` defaultet in der Control-Config auf `haiku`.
+  - `agent_runtime_model_policy` setzt in der Control-Config standardmaessig `haiku`.
   - `ResolveModelPolicy` setzt Haiku nur fuer `agent_runtime` ohne explizites Modell.
   - `/v1/messages` bleibt `external_compat` und `PreferredProvider=anthropic-direct`.
   - ungueltige Policy/Provider-Kombinationen failen vor dem Provider-Call mit `model policy rejected`.
@@ -358,7 +358,7 @@
   - AC-2: `/v1/messages` bleibt `external_compat` und bekommt keine Agent-Policy.
   - AC-3: leeres Modell wird fuer Agent-Runtime zu `haiku`, explizites Modell gewinnt.
   - AC-4: ungueltige Provider-/Policy-Kombination failt deterministisch.
-  - AC-5: Control-Config defaultet auf `haiku` und akzeptiert nur erlaubte Werte.
+  - AC-5: Control-Config setzt standardmaessig `haiku` und akzeptiert nur erlaubte Werte.
   - AC-6: ResponseLogBuffer liefert chronologische Eintraege nach Ring-Overwrite und `LastByClass` findet den letzten Runtime-Eintrag.
 - Wie wird bewiesen:
   - `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`

--- a/cmd/cortex-gateway/internal/control/plane.go
+++ b/cmd/cortex-gateway/internal/control/plane.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 )
 
@@ -23,11 +24,12 @@ const (
 
 // ConfigSnapshot is a mutex-free copy of Config for serialization and reads.
 type ConfigSnapshot struct {
-	PrimaryProvider string            `json:"primary_provider"`
-	Temperature     float64           `json:"temperature"`
-	MaxTokens       int               `json:"max_tokens"`
-	RateLimit       float64           `json:"rate_limit_rps"`
-	AgentOverrides  map[string]string `json:"agent_overrides"`
+	PrimaryProvider         string            `json:"primary_provider"`
+	Temperature             float64           `json:"temperature"`
+	MaxTokens               int               `json:"max_tokens"`
+	RateLimit               float64           `json:"rate_limit_rps"`
+	AgentOverrides          map[string]string `json:"agent_overrides"`
+	AgentRuntimeModelPolicy string            `json:"agent_runtime_model_policy"`
 
 	// Traffic Control (#288)
 	SynthesisEnabled      bool   `json:"synthesis_enabled"`
@@ -50,12 +52,13 @@ type ConfigSnapshot struct {
 
 // Config holds the current gateway configuration (mutable at runtime).
 type Config struct {
-	mu              sync.RWMutex
-	primaryProvider string
-	temperature     float64
-	maxTokens       int
-	rateLimit       float64
-	agentOverrides  map[string]string // agent_id -> provider_name
+	mu                      sync.RWMutex
+	primaryProvider         string
+	temperature             float64
+	maxTokens               int
+	rateLimit               float64
+	agentOverrides          map[string]string // agent_id -> provider_name
+	agentRuntimeModelPolicy string
 
 	// Traffic Control (#288)
 	synthesisEnabled      bool
@@ -79,11 +82,12 @@ type Config struct {
 // NewConfig creates a Config with sensible defaults.
 func NewConfig(primaryProvider string) *Config {
 	return &Config{
-		primaryProvider: primaryProvider,
-		temperature:     0.7,
-		maxTokens:       4096,
-		rateLimit:       0,
-		agentOverrides:  make(map[string]string),
+		primaryProvider:         primaryProvider,
+		temperature:             0.7,
+		maxTokens:               4096,
+		rateLimit:               0,
+		agentOverrides:          make(map[string]string),
+		agentRuntimeModelPolicy: "haiku",
 
 		synthesisEnabled:      false,
 		sequencingEnabled:     false,
@@ -135,11 +139,12 @@ func (c *Config) Get() ConfigSnapshot {
 		overrides[k] = v
 	}
 	return ConfigSnapshot{
-		PrimaryProvider: c.primaryProvider,
-		Temperature:     c.temperature,
-		MaxTokens:       c.maxTokens,
-		RateLimit:       c.rateLimit,
-		AgentOverrides:  overrides,
+		PrimaryProvider:         c.primaryProvider,
+		Temperature:             c.temperature,
+		MaxTokens:               c.maxTokens,
+		RateLimit:               c.rateLimit,
+		AgentOverrides:          overrides,
+		AgentRuntimeModelPolicy: c.agentRuntimeModelPolicy,
 
 		SynthesisEnabled:      c.synthesisEnabled,
 		SequencingEnabled:     c.sequencingEnabled,
@@ -207,6 +212,18 @@ var configUpdaters = map[string]configUpdater{
 			return errors.New("primary_provider must not be empty")
 		}
 		c.primaryProvider = v
+		return nil
+	},
+	"agent_runtime_model_policy": func(c *Config, val interface{}) error {
+		v, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("agent_runtime_model_policy must be a string, got %T", val)
+		}
+		v = strings.TrimSpace(v)
+		if v != "" && v != "haiku" {
+			return fmt.Errorf("agent_runtime_model_policy must be empty or %q, got %q", "haiku", v)
+		}
+		c.agentRuntimeModelPolicy = v
 		return nil
 	},
 	"synthesis_enabled": func(c *Config, val interface{}) error {

--- a/cmd/cortex-gateway/internal/control/plane_test.go
+++ b/cmd/cortex-gateway/internal/control/plane_test.go
@@ -56,6 +56,9 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if snapshot.InterceptMode != "auto" {
 		t.Errorf("expected intercept_mode auto, got %q", snapshot.InterceptMode)
 	}
+	if snapshot.AgentRuntimeModelPolicy != "haiku" {
+		t.Errorf("expected agent_runtime_model_policy haiku, got %q", snapshot.AgentRuntimeModelPolicy)
+	}
 }
 
 // TestConfig_GetSnapshot verifies that Get returns a snapshot and is concurrent-safe.
@@ -160,6 +163,31 @@ func TestConfig_Update_UnknownKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown config key") {
 		t.Errorf("error should mention unknown key: %v", err)
+	}
+}
+
+func TestConfig_Update_AgentRuntimeModelPolicy(t *testing.T) {
+	cfg := NewConfig("claude")
+
+	if err := cfg.Update(map[string]interface{}{"agent_runtime_model_policy": "haiku"}); err != nil {
+		t.Fatalf("update haiku policy: %v", err)
+	}
+	if got := cfg.Get().AgentRuntimeModelPolicy; got != "haiku" {
+		t.Fatalf("AgentRuntimeModelPolicy = %q, want haiku", got)
+	}
+
+	if err := cfg.Update(map[string]interface{}{"agent_runtime_model_policy": ""}); err != nil {
+		t.Fatalf("clear policy: %v", err)
+	}
+	if got := cfg.Get().AgentRuntimeModelPolicy; got != "" {
+		t.Fatalf("AgentRuntimeModelPolicy = %q, want empty", got)
+	}
+
+	if err := cfg.Update(map[string]interface{}{"agent_runtime_model_policy": "opus"}); err == nil {
+		t.Fatal("expected invalid policy to be rejected")
+	}
+	if err := cfg.Update(map[string]interface{}{"agent_runtime_model_policy": 42}); err == nil {
+		t.Fatal("expected non-string policy to be rejected")
 	}
 }
 

--- a/cmd/cortex-gateway/internal/proxy/bench_test.go
+++ b/cmd/cortex-gateway/internal/proxy/bench_test.go
@@ -186,3 +186,56 @@ func BenchmarkAnthropicDirectRequestAssembly(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkClassifyRequestAgentRuntime(b *testing.B) {
+	req := &LLMRequest{Metadata: map[string]string{
+		"agent_id":   "12",
+		"agent_name": "Thomas Mueller",
+		"room_id":    "buero-ceo",
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if got := ClassifyRequest("/internal/llm", req); got != RequestClassAgentRuntime {
+			b.Fatalf("ClassifyRequest() = %q, want %q", got, RequestClassAgentRuntime)
+		}
+	}
+}
+
+func BenchmarkResolveModelPolicyAgentRuntime(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		got, err := ResolveModelPolicy("claude-code", RequestClassAgentRuntime, "", AgentRuntimeModelPolicyHaiku)
+		if err != nil {
+			b.Fatalf("ResolveModelPolicy() error: %v", err)
+		}
+		if got.Model != "haiku" || got.Source != PolicySourceAgentRuntime {
+			b.Fatalf("ResolveModelPolicy() = %+v, want haiku/%s", got, PolicySourceAgentRuntime)
+		}
+	}
+}
+
+func BenchmarkResponseLogBufferAdd(b *testing.B) {
+	buffer := NewResponseLogBuffer(128)
+	entry := ResponseLogEntry{
+		RequestID:    "bench-request",
+		RequestClass: RequestClassAgentRuntime,
+		Provider:     "claude-code",
+		Model:        "haiku",
+		PolicySource: PolicySourceAgentRuntime,
+		AgentID:      "12",
+		AgentName:    "Thomas Mueller",
+		Content:      "ok",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buffer.Add(entry)
+	}
+}

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -451,6 +451,9 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 				pipelineLatency.WithLabelValues("synthesis").Observe(duration.Seconds())
 				ph.logger.Info("pipeline request completed",
 					"provider", "synthesis",
+					"request_class", req.RequestClass,
+					"effective_model", "sentinel-synth-v1",
+					"policy_source", req.PolicySource,
 					"duration", duration,
 					"tokens", 0,
 					"actions", len(actions),
@@ -513,6 +516,9 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 					pipelineLatency.WithLabelValues("apicp").Observe(duration.Seconds())
 					ph.logger.Info("pipeline request completed",
 						"provider", "apicp",
+						"request_class", req.RequestClass,
+						"effective_model", "sentinel-apicp-v1",
+						"policy_source", req.PolicySource,
 						"duration", duration,
 						"tokens", 0,
 						"actions", len(actions),
@@ -605,6 +611,11 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 		pipelineLatency.WithLabelValues(providerName).Observe(duration.Seconds())
 		ph.logger.Error("provider request failed",
 			"provider", providerName,
+			"request_class", req.RequestClass,
+			"effective_model", effectiveModelForLog(&req, ""),
+			"policy_source", req.PolicySource,
+			"agent_id", req.Metadata["agent_id"],
+			"agent_name", agentName,
 			"duration", duration,
 			"error", err,
 		)
@@ -719,6 +730,9 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 
 	ph.logger.Info("pipeline request completed",
 		"provider", providerName,
+		"request_class", req.RequestClass,
+		"effective_model", effectiveModelForLog(&req, resp.Model),
+		"policy_source", req.PolicySource,
 		"duration", duration,
 		"tokens", resp.TokensUsed,
 		"actions", len(actions),
@@ -1219,7 +1233,16 @@ func (ph *PipelineHandler) persistActions(actions []extraction.ExtractedAction, 
 
 func (ph *PipelineHandler) writePipelineResponse(_ context.Context, w http.ResponseWriter, req *LLMRequest, resp PipelineResponse) {
 	if ph.responseLogs != nil {
-		ph.responseLogs.Add(resp.RequestID, resp.Provider, resp.Content)
+		ph.responseLogs.Add(ResponseLogEntry{
+			RequestID:    resp.RequestID,
+			RequestClass: req.RequestClass,
+			Provider:     resp.Provider,
+			Model:        effectiveModelForLog(req, resp.Model),
+			PolicySource: req.PolicySource,
+			AgentID:      req.Metadata["agent_id"],
+			AgentName:    req.Metadata["agent_name"],
+			Content:      resp.Content,
+		})
 	}
 
 	payload := responsePayloadForRequest(req, resp)
@@ -1245,6 +1268,19 @@ func (ph *PipelineHandler) writePipelineResponse(_ context.Context, w http.Respo
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		ph.logger.Error("failed to encode response", "error", err)
 	}
+}
+
+func effectiveModelForLog(req *LLMRequest, responseModel string) string {
+	if strings.TrimSpace(responseModel) != "" {
+		return responseModel
+	}
+	if req == nil {
+		return ""
+	}
+	if strings.TrimSpace(req.EffectiveModel) != "" {
+		return req.EffectiveModel
+	}
+	return strings.TrimSpace(req.Model)
 }
 
 func responsePayloadForRequest(req *LLMRequest, resp PipelineResponse) interface{} {
@@ -1349,6 +1385,11 @@ func (ph *PipelineHandler) streamAnthropicResponse(ctx context.Context, w http.R
 		ph.logger.Error("provider stream failed",
 			"provider", providerName,
 			"request_id", requestID,
+			"request_class", req.RequestClass,
+			"effective_model", effectiveModelForLog(req, ""),
+			"policy_source", req.PolicySource,
+			"agent_id", req.Metadata["agent_id"],
+			"agent_name", req.Metadata["agent_name"],
 			"duration", duration,
 			"error", err,
 		)
@@ -1372,6 +1413,9 @@ func (ph *PipelineHandler) streamAnthropicResponse(ctx context.Context, w http.R
 	ph.logger.Info("pipeline stream completed",
 		"provider", providerName,
 		"request_id", requestID,
+		"request_class", req.RequestClass,
+		"effective_model", effectiveModelForLog(req, ""),
+		"policy_source", req.PolicySource,
 		"duration", duration,
 		"agent_id", req.Metadata["agent_id"],
 		"agent_name", req.Metadata["agent_name"],

--- a/cmd/cortex-gateway/internal/proxy/pipeline.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline.go
@@ -204,16 +204,16 @@ func (ph *PipelineHandler) BreakerStates() map[string]string {
 
 // PipelineResponse ist die erweiterte Antwort mit extrahierten Aktionen.
 type PipelineResponse struct {
-	Content      string                       `json:"content"`
-	ContentBlocks []json.RawMessage           `json:"-"`
-	Model        string                       `json:"model"`
-	Provider     string                       `json:"provider"`
-	TokensUsed   int                          `json:"tokens_used"`
-	InputTokens  int                          `json:"input_tokens,omitempty"`
-	OutputTokens int                          `json:"output_tokens,omitempty"`
-	FinishReason string                       `json:"finish_reason"`
-	Actions      []extraction.ExtractedAction `json:"actions,omitempty"`
-	RequestID    string                       `json:"request_id"`
+	Content       string                       `json:"content"`
+	ContentBlocks []json.RawMessage            `json:"-"`
+	Model         string                       `json:"model"`
+	Provider      string                       `json:"provider"`
+	TokensUsed    int                          `json:"tokens_used"`
+	InputTokens   int                          `json:"input_tokens,omitempty"`
+	OutputTokens  int                          `json:"output_tokens,omitempty"`
+	FinishReason  string                       `json:"finish_reason"`
+	Actions       []extraction.ExtractedAction `json:"actions,omitempty"`
+	RequestID     string                       `json:"request_id"`
 }
 
 // NewPipelineHandler erstellt den Pipeline-Handler.
@@ -343,6 +343,7 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 
 	// --- Step 1: Config-Snapshot ---
 	snap := ph.config.Get()
+	req.RequestClass = ClassifyRequest(r.URL.Path, &req)
 
 	// --- Step 2: Provider bestimmen (Runtime-switchable via Control Plane) ---
 	resolvedProviderName := req.PreferredProvider
@@ -558,6 +559,22 @@ func (ph *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { /
 			return
 		}
 	}
+
+	policyResolution, err := ResolveModelPolicy(providerName, req.RequestClass, req.Model, snap.AgentRuntimeModelPolicy)
+	if err != nil {
+		ph.logger.Error("model policy rejected",
+			"request_id", requestID,
+			"request_class", req.RequestClass,
+			"provider", providerName,
+			"policy", snap.AgentRuntimeModelPolicy,
+			"error", err,
+		)
+		ph.writeRequestError(w, &req, "model policy rejected", http.StatusUnprocessableEntity)
+		return
+	}
+	req.Model = policyResolution.Model
+	req.EffectiveModel = policyResolution.Model
+	req.PolicySource = policyResolution.Source
 
 	if isAnthropicStreamingRequest(&req) {
 		ph.streamAnthropicResponse(r.Context(), w, &req, provider, providerName, breaker, requestID, start)
@@ -1411,6 +1428,9 @@ func cloneRegenRequest(base *LLMRequest, messages []Message, temperature float64
 		Format:             base.Format,
 		PreferredProvider:  base.PreferredProvider,
 		PassthroughHeaders: clonePassthroughHeaders(base.PassthroughHeaders),
+		RequestClass:       base.RequestClass,
+		EffectiveModel:     base.EffectiveModel,
+		PolicySource:       base.PolicySource,
 		ProviderTimeout:    base.ProviderTimeout,
 	}
 }

--- a/cmd/cortex-gateway/internal/proxy/pipeline_test.go
+++ b/cmd/cortex-gateway/internal/proxy/pipeline_test.go
@@ -30,16 +30,16 @@ import (
 // pipelineMockProvider implementiert Provider fuer Pipeline-Tests.
 // Kann Requests aufzeichnen und konfigurierbare Responses/Errors liefern.
 type pipelineMockProvider struct {
-	mu        sync.Mutex
-	name      string
-	resp      *LLMResponse
-	err       error
-	statusErr error
-	calls     int
+	mu          sync.Mutex
+	name        string
+	resp        *LLMResponse
+	err         error
+	statusErr   error
+	calls       int
 	streamCalls int
-	lastReq   *LLMRequest
-	sendFunc  func(ctx context.Context, req *LLMRequest) (*LLMResponse, error)
-	streamFunc func(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error
+	lastReq     *LLMRequest
+	sendFunc    func(ctx context.Context, req *LLMRequest) (*LLMResponse, error)
+	streamFunc  func(ctx context.Context, req *LLMRequest, w http.ResponseWriter) error
 }
 
 func (p *pipelineMockProvider) Name() string { return p.name }
@@ -194,6 +194,46 @@ func TestPipelineStructuredSystemBlocksForAnthropicDirect(t *testing.T) {
 	}
 }
 
+func TestPipelineAgentRuntimeAppliesHaikuPolicy(t *testing.T) {
+	reg := NewRegistry()
+	mock := &pipelineMockProvider{
+		name: "mock",
+		resp: &LLMResponse{
+			Content:      "{\"action_type\":\"THINK\",\"target\":\"\",\"content\":\"ok\"}",
+			Model:        "haiku",
+			TokensUsed:   5,
+			FinishReason: "end_turn",
+		},
+	}
+	reg.Register("mock", mock)
+
+	cfg := control.NewConfig("mock")
+	ph := newTestPipelineHandler(reg, cfg)
+
+	body := `{"messages":[{"role":"user","content":"Was machst du?"}],"metadata":{"agent_id":"12","agent_name":"Thomas Mueller","agent_role":"CEO"}}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/llm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	ph.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if mock.lastReq == nil {
+		t.Fatal("expected provider request")
+	}
+	if mock.lastReq.RequestClass != RequestClassAgentRuntime {
+		t.Fatalf("request class = %q, want %q", mock.lastReq.RequestClass, RequestClassAgentRuntime)
+	}
+	if mock.lastReq.Model != "haiku" || mock.lastReq.EffectiveModel != "haiku" {
+		t.Fatalf("model = %q effective = %q, want haiku", mock.lastReq.Model, mock.lastReq.EffectiveModel)
+	}
+	if mock.lastReq.PolicySource != PolicySourceAgentRuntime {
+		t.Fatalf("policy source = %q, want %q", mock.lastReq.PolicySource, PolicySourceAgentRuntime)
+	}
+}
+
 func TestPipelineAnthropicMessagesPassthrough(t *testing.T) {
 	reg := NewRegistry()
 	internal := &pipelineMockProvider{
@@ -260,6 +300,12 @@ func assertAnthropicPassthroughRequest(t *testing.T, internal, direct *pipelineM
 	}
 	if direct.lastReq.PreferredProvider != "anthropic-direct" {
 		t.Fatalf("preferred provider = %q", direct.lastReq.PreferredProvider)
+	}
+	if direct.lastReq.RequestClass != RequestClassExternalCompat {
+		t.Fatalf("request class = %q, want %q", direct.lastReq.RequestClass, RequestClassExternalCompat)
+	}
+	if direct.lastReq.EffectiveModel != "claude-opus-4-6" || direct.lastReq.PolicySource != PolicySourceRequestOverride {
+		t.Fatalf("effective model = %q policy source = %q, want request override", direct.lastReq.EffectiveModel, direct.lastReq.PolicySource)
 	}
 	if got := direct.lastReq.PassthroughHeaders["authorization"]; got != "Bearer passthrough-token" {
 		t.Fatalf("authorization passthrough = %q", got)

--- a/cmd/cortex-gateway/internal/proxy/policy.go
+++ b/cmd/cortex-gateway/internal/proxy/policy.go
@@ -1,0 +1,122 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RequestClass string
+
+const (
+	RequestClassExternalCompat       RequestClass = "external_compat"
+	RequestClassAgentRuntime         RequestClass = "agent_runtime"
+	RequestClassPlatformControlplane RequestClass = "platform_controlplane"
+	RequestClassServiceInternal      RequestClass = "service_internal"
+	RequestClassInternalOther        RequestClass = "internal_other"
+)
+
+const (
+	AgentRuntimeModelPolicyHaiku = "haiku"
+
+	PolicySourceProviderDefault = "provider_default"
+	PolicySourceRequestOverride = "request_override"
+	PolicySourceAgentRuntime    = "agent_runtime_policy"
+)
+
+func ClassifyRequest(path string, req *LLMRequest) RequestClass {
+	if isAnthropicMessagesPath(path) {
+		return RequestClassExternalCompat
+	}
+	if req == nil {
+		return RequestClassInternalOther
+	}
+
+	metadata := req.Metadata
+	agentName := strings.TrimSpace(metadata["agent_name"])
+	if strings.EqualFold(strings.TrimSpace(metadata["platform_analysis"]), "true") ||
+		strings.EqualFold(agentName, "PLATFORM-CONTROLPLANE") {
+		return RequestClassPlatformControlplane
+	}
+
+	if strings.TrimSpace(metadata["request_type"]) != "" || isServiceIdentity(agentName) {
+		return RequestClassServiceInternal
+	}
+
+	if isPositiveNumericAgentID(metadata["agent_id"]) {
+		return RequestClassAgentRuntime
+	}
+
+	return RequestClassInternalOther
+}
+
+type ModelPolicyResolution struct {
+	Model  string
+	Source string
+}
+
+func ResolveModelPolicy(providerName string, class RequestClass, explicitModel, agentRuntimePolicy string) (ModelPolicyResolution, error) {
+	if model := strings.TrimSpace(explicitModel); model != "" {
+		return ModelPolicyResolution{Model: model, Source: PolicySourceRequestOverride}, nil
+	}
+
+	if class != RequestClassAgentRuntime {
+		return ModelPolicyResolution{Source: PolicySourceProviderDefault}, nil
+	}
+
+	policy := strings.TrimSpace(agentRuntimePolicy)
+	if policy == "" {
+		return ModelPolicyResolution{Source: PolicySourceProviderDefault}, nil
+	}
+
+	model, err := resolveAgentRuntimePolicyModel(providerName, policy)
+	if err != nil {
+		return ModelPolicyResolution{}, err
+	}
+	return ModelPolicyResolution{Model: model, Source: PolicySourceAgentRuntime}, nil
+}
+
+func ValidateAgentRuntimeModelPolicy(policy string) error {
+	policy = strings.TrimSpace(policy)
+	switch policy {
+	case "", AgentRuntimeModelPolicyHaiku:
+		return nil
+	default:
+		return fmt.Errorf("agent_runtime_model_policy must be empty or %q, got %q", AgentRuntimeModelPolicyHaiku, policy)
+	}
+}
+
+func resolveAgentRuntimePolicyModel(providerName, policy string) (string, error) {
+	switch strings.TrimSpace(policy) {
+	case AgentRuntimeModelPolicyHaiku:
+		switch strings.TrimSpace(providerName) {
+		case "claude-code", "mock":
+			return "haiku", nil
+		default:
+			return "", fmt.Errorf("agent_runtime_model_policy %q is not supported for provider %q", policy, providerName)
+		}
+	default:
+		return "", fmt.Errorf("unknown agent_runtime_model_policy %q", policy)
+	}
+}
+
+func isServiceIdentity(agentName string) bool {
+	switch strings.ToLower(strings.TrimSpace(agentName)) {
+	case "sentinel-judge":
+		return true
+	default:
+		return false
+	}
+}
+
+func isPositiveNumericAgentID(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || value[0] == '0' {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/cortex-gateway/internal/proxy/policy_test.go
+++ b/cmd/cortex-gateway/internal/proxy/policy_test.go
@@ -1,0 +1,163 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifyRequestStrictAgentRuntime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		meta map[string]string
+		want RequestClass
+	}{
+		{
+			name: "anthropic messages stays external even with agent id",
+			path: "/v1/messages",
+			meta: map[string]string{"agent_id": "12", "agent_name": "Thomas Mueller"},
+			want: RequestClassExternalCompat,
+		},
+		{
+			name: "platform analysis metadata wins over agent id",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "12", "platform_analysis": "true"},
+			want: RequestClassPlatformControlplane,
+		},
+		{
+			name: "platform controlplane identity wins over agent id",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "12", "agent_name": "PLATFORM-CONTROLPLANE"},
+			want: RequestClassPlatformControlplane,
+		},
+		{
+			name: "request type marks service internal",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "12", "request_type": "evolution_analysis"},
+			want: RequestClassServiceInternal,
+		},
+		{
+			name: "sentinel judge identity marks service internal",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "12", "agent_name": "sentinel-judge"},
+			want: RequestClassServiceInternal,
+		},
+		{
+			name: "positive numeric agent id marks runtime",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "12", "agent_name": "Thomas Mueller"},
+			want: RequestClassAgentRuntime,
+		},
+		{
+			name: "zero is not a runtime agent",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "0", "agent_name": "Thomas Mueller"},
+			want: RequestClassInternalOther,
+		},
+		{
+			name: "leading zero is not a runtime agent",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "012", "agent_name": "Thomas Mueller"},
+			want: RequestClassInternalOther,
+		},
+		{
+			name: "non numeric agent id is not a runtime agent",
+			path: "/internal/llm",
+			meta: map[string]string{"agent_id": "agent-12", "agent_name": "Thomas Mueller"},
+			want: RequestClassInternalOther,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyRequest(tt.path, &LLMRequest{Metadata: tt.meta})
+			if got != tt.want {
+				t.Fatalf("ClassifyRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveModelPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		provider      string
+		class         RequestClass
+		explicitModel string
+		policy        string
+		wantModel     string
+		wantSource    string
+		wantErr       string
+	}{
+		{
+			name:          "explicit request model wins",
+			provider:      "claude-code",
+			class:         RequestClassAgentRuntime,
+			explicitModel: "claude-opus-4-6",
+			policy:        AgentRuntimeModelPolicyHaiku,
+			wantModel:     "claude-opus-4-6",
+			wantSource:    PolicySourceRequestOverride,
+		},
+		{
+			name:       "agent runtime defaults to haiku on claude-code",
+			provider:   "claude-code",
+			class:      RequestClassAgentRuntime,
+			policy:     AgentRuntimeModelPolicyHaiku,
+			wantModel:  "haiku",
+			wantSource: PolicySourceAgentRuntime,
+		},
+		{
+			name:       "agent runtime defaults to haiku on mock provider",
+			provider:   "mock",
+			class:      RequestClassAgentRuntime,
+			policy:     AgentRuntimeModelPolicyHaiku,
+			wantModel:  "haiku",
+			wantSource: PolicySourceAgentRuntime,
+		},
+		{
+			name:       "external compat keeps provider default",
+			provider:   "claude-code",
+			class:      RequestClassExternalCompat,
+			policy:     AgentRuntimeModelPolicyHaiku,
+			wantSource: PolicySourceProviderDefault,
+		},
+		{
+			name:     "unsupported provider fails closed",
+			provider: "anthropic-direct",
+			class:    RequestClassAgentRuntime,
+			policy:   AgentRuntimeModelPolicyHaiku,
+			wantErr:  "not supported",
+		},
+		{
+			name:     "unknown policy fails closed",
+			provider: "claude-code",
+			class:    RequestClassAgentRuntime,
+			policy:   "opus",
+			wantErr:  "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveModelPolicy(tt.provider, tt.class, tt.explicitModel, tt.policy)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveModelPolicy() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveModelPolicy() unexpected error: %v", err)
+			}
+			if got.Model != tt.wantModel || got.Source != tt.wantSource {
+				t.Fatalf("ResolveModelPolicy() = %+v, want model=%q source=%q", got, tt.wantModel, tt.wantSource)
+			}
+		})
+	}
+}

--- a/cmd/cortex-gateway/internal/proxy/provider.go
+++ b/cmd/cortex-gateway/internal/proxy/provider.go
@@ -28,6 +28,9 @@ type LLMRequest struct {
 	Format             RequestFormat     `json:"-"`
 	PreferredProvider  string            `json:"-"`
 	PassthroughHeaders map[string]string `json:"-"`
+	RequestClass       RequestClass      `json:"-"`
+	EffectiveModel     string            `json:"-"`
+	PolicySource       string            `json:"-"`
 	// ProviderTimeout applies only to the real provider execution, not queue wait.
 	ProviderTimeout time.Duration `json:"-"`
 }

--- a/cmd/cortex-gateway/internal/proxy/response_log.go
+++ b/cmd/cortex-gateway/internal/proxy/response_log.go
@@ -6,10 +6,15 @@ import (
 )
 
 type ResponseLogEntry struct {
-	RequestID string    `json:"request_id"`
-	Provider  string    `json:"provider"`
-	Content   string    `json:"content"`
-	LoggedAt  time.Time `json:"logged_at"`
+	RequestID    string       `json:"request_id"`
+	RequestClass RequestClass `json:"request_class,omitempty"`
+	Provider     string       `json:"provider"`
+	Model        string       `json:"model,omitempty"`
+	PolicySource string       `json:"policy_source,omitempty"`
+	AgentID      string       `json:"agent_id,omitempty"`
+	AgentName    string       `json:"agent_name,omitempty"`
+	Content      string       `json:"content"`
+	LoggedAt     time.Time    `json:"logged_at"`
 }
 
 // ResponseLogBuffer keeps recent response bodies in memory for control-plane
@@ -18,16 +23,17 @@ type ResponseLogBuffer struct {
 	mu      sync.Mutex
 	limit   int
 	entries []ResponseLogEntry
+	next    int
 }
 
 func NewResponseLogBuffer(limit int) *ResponseLogBuffer {
 	if limit <= 0 {
 		limit = 200
 	}
-	return &ResponseLogBuffer{limit: limit}
+	return &ResponseLogBuffer{limit: limit, entries: make([]ResponseLogEntry, 0, limit)}
 }
 
-func (b *ResponseLogBuffer) Add(requestID, provider, content string) {
+func (b *ResponseLogBuffer) Add(entry ResponseLogEntry) {
 	if b == nil {
 		return
 	}
@@ -35,15 +41,17 @@ func (b *ResponseLogBuffer) Add(requestID, provider, content string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.entries = append(b.entries, ResponseLogEntry{
-		RequestID: requestID,
-		Provider:  provider,
-		Content:   content,
-		LoggedAt:  time.Now(),
-	})
-	if len(b.entries) > b.limit {
-		b.entries = append([]ResponseLogEntry(nil), b.entries[len(b.entries)-b.limit:]...)
+	if entry.LoggedAt.IsZero() {
+		entry.LoggedAt = time.Now()
 	}
+
+	if len(b.entries) < b.limit {
+		b.entries = append(b.entries, entry)
+		return
+	}
+
+	b.entries[b.next] = entry
+	b.next = (b.next + 1) % b.limit
 }
 
 func (b *ResponseLogBuffer) Entries() []ResponseLogEntry {
@@ -54,8 +62,7 @@ func (b *ResponseLogBuffer) Entries() []ResponseLogEntry {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	out := make([]ResponseLogEntry, len(b.entries))
-	copy(out, b.entries)
+	out := b.entriesChronologicalLocked()
 	return out
 }
 
@@ -67,4 +74,37 @@ func (b *ResponseLogBuffer) Len() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return len(b.entries)
+}
+
+func (b *ResponseLogBuffer) LastByClass(class RequestClass) (ResponseLogEntry, bool) {
+	if b == nil {
+		return ResponseLogEntry{}, false
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	entries := b.entriesChronologicalLocked()
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].RequestClass == class {
+			return entries[i], true
+		}
+	}
+	return ResponseLogEntry{}, false
+}
+
+func (b *ResponseLogBuffer) entriesChronologicalLocked() []ResponseLogEntry {
+	if len(b.entries) == 0 {
+		return nil
+	}
+	if len(b.entries) < b.limit || b.next == 0 {
+		out := make([]ResponseLogEntry, len(b.entries))
+		copy(out, b.entries)
+		return out
+	}
+
+	out := make([]ResponseLogEntry, 0, len(b.entries))
+	out = append(out, b.entries[b.next:]...)
+	out = append(out, b.entries[:b.next]...)
+	return out
 }

--- a/cmd/cortex-gateway/internal/proxy/response_log_test.go
+++ b/cmd/cortex-gateway/internal/proxy/response_log_test.go
@@ -1,0 +1,59 @@
+package proxy
+
+import "testing"
+
+func TestResponseLogBufferRingOverwriteAndLastByClass(t *testing.T) {
+	t.Parallel()
+
+	buffer := NewResponseLogBuffer(2)
+	buffer.Add(ResponseLogEntry{
+		RequestID:    "external-1",
+		RequestClass: RequestClassExternalCompat,
+		Provider:     "anthropic-direct",
+		Model:        "claude-opus-4-6",
+		Content:      "external",
+	})
+	buffer.Add(ResponseLogEntry{
+		RequestID:    "agent-1",
+		RequestClass: RequestClassAgentRuntime,
+		Provider:     "claude-code",
+		Model:        "haiku",
+		PolicySource: PolicySourceAgentRuntime,
+		AgentID:      "12",
+		AgentName:    "Thomas Mueller",
+		Content:      "first runtime",
+	})
+	buffer.Add(ResponseLogEntry{
+		RequestID:    "agent-2",
+		RequestClass: RequestClassAgentRuntime,
+		Provider:     "claude-code",
+		Model:        "haiku",
+		PolicySource: PolicySourceAgentRuntime,
+		AgentID:      "13",
+		AgentName:    "Julia Neumann",
+		Content:      "second runtime",
+	})
+
+	entries := buffer.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("Entries() len = %d, want 2", len(entries))
+	}
+	if entries[0].RequestID != "agent-1" || entries[1].RequestID != "agent-2" {
+		t.Fatalf("Entries() order = [%s %s], want [agent-1 agent-2]", entries[0].RequestID, entries[1].RequestID)
+	}
+	if entries[1].LoggedAt.IsZero() {
+		t.Fatal("expected Add() to populate LoggedAt")
+	}
+
+	lastRuntime, ok := buffer.LastByClass(RequestClassAgentRuntime)
+	if !ok {
+		t.Fatal("LastByClass(agent_runtime) not found")
+	}
+	if lastRuntime.RequestID != "agent-2" || lastRuntime.AgentID != "13" || lastRuntime.PolicySource != PolicySourceAgentRuntime {
+		t.Fatalf("LastByClass(agent_runtime) = %+v, want latest runtime entry", lastRuntime)
+	}
+
+	if _, ok := buffer.LastByClass(RequestClassExternalCompat); ok {
+		t.Fatal("LastByClass(external_compat) found overwritten entry")
+	}
+}

--- a/cmd/cortex-gateway/main.go
+++ b/cmd/cortex-gateway/main.go
@@ -287,12 +287,14 @@ func main() {
 		costStats := guardrails.RuntimeCostSnapshot()
 		pendingIntercepts := requestInterceptor.Pending()
 		pendingResponseIntercepts := responseInterceptor.Pending()
+		trafficConfig := controlConfig.Get()
+		lastAgentRuntime, hasLastAgentRuntime := responseLogs.LastByClass(proxy.RequestClassAgentRuntime)
 		stats := map[string]interface{}{
-			"synthesis_enabled":           controlConfig.Get().SynthesisEnabled,
-			"sequencing_enabled":          controlConfig.Get().SequencingEnabled,
-			"tick_sync_enabled":           controlConfig.Get().TickSyncEnabled,
+			"synthesis_enabled":           trafficConfig.SynthesisEnabled,
+			"sequencing_enabled":          trafficConfig.SequencingEnabled,
+			"tick_sync_enabled":           trafficConfig.TickSyncEnabled,
 			"tick_sync_runtime_enabled":   tickSync.Enabled(),
-			"apicp_enabled":               controlConfig.Get().APICPEnabled,
+			"apicp_enabled":               trafficConfig.APICPEnabled,
 			"current_cost_usd":            costStats.TotalCostUSD,
 			"estimated_savings_usd":       costStats.TotalSavingsUSD,
 			"projected_daily_cost_usd":    costStats.ProjectedDailyCostUSD,
@@ -302,19 +304,25 @@ func main() {
 			"synthesis_count":             costStats.SynthesisCount,
 			"synthesis_rate":              costStats.SynthesisRate,
 			"cost_by_provider":            costStats.ByProvider,
-			"primary_provider":            controlConfig.Get().PrimaryProvider,
-			"internal_primary_provider":   controlConfig.Get().PrimaryProvider,
+			"primary_provider":            trafficConfig.PrimaryProvider,
+			"internal_primary_provider":   trafficConfig.PrimaryProvider,
 			"external_mitm_provider":      "anthropic-direct",
-			"intercept_mode":              controlConfig.Get().InterceptMode,
-			"max_forward_concurrency":     controlConfig.Get().MaxForwardConcurrency,
-			"tick_sync_timeout_ms":        controlConfig.Get().TickSyncTimeoutMs,
-			"p3_timeout_ms":               controlConfig.Get().P3TimeoutMs,
+			"agent_runtime_model_policy":  trafficConfig.AgentRuntimeModelPolicy,
+			"intercept_mode":              trafficConfig.InterceptMode,
+			"max_forward_concurrency":     trafficConfig.MaxForwardConcurrency,
+			"tick_sync_timeout_ms":        trafficConfig.TickSyncTimeoutMs,
+			"p3_timeout_ms":               trafficConfig.P3TimeoutMs,
 			"queue_depth":                 forwardQueue.Stats().Depth,
 			"active_forward_calls":        forwardQueue.Stats().Active,
 			"pending_intercepts":          len(pendingIntercepts),
 			"pending_response_intercepts": len(pendingResponseIntercepts),
 			"tick_sync_pending":           tickSync.Stats().Pending,
 			"response_log_entries":        responseLogs.Len(),
+		}
+		if hasLastAgentRuntime {
+			stats["last_agent_runtime_effective_model"] = lastAgentRuntime.Model
+			stats["last_agent_runtime_policy_source"] = lastAgentRuntime.PolicySource
+			stats["last_agent_runtime_provider"] = lastAgentRuntime.Provider
 		}
 		if apicpObserver != nil {
 			apicpStats := apicpObserver.Stats()

--- a/issue-314-body.md
+++ b/issue-314-body.md
@@ -1,0 +1,55 @@
+## Kontext
+
+Aus der #279-Umsetzung wurde die Haiku-/Model-Policy bewusst herausgeschnitten. #279 war Daemon-Resilience-Scope; Modellwahl gehoert in die Gateway-/Inference-Schicht, nicht in den deterministischen ECS-Daemon.
+
+Aktueller Ist-Zustand:
+
+- `sentinel-daemon` sendet fuer Agent-Runtime kein hartes Modell (`model=""`)
+- interne Runtime-Requests laufen ueber `POST /internal/llm`
+- externe MITM-Kompatibilitaet laeuft ueber `POST /v1/messages`
+- der laufende Gateway-Default fuer `claude-code` ist aktuell `claude-opus-4-6`
+- Observability zeigt heute Provider, aber nicht die effektive interne Model-Policy
+
+## Scope
+
+- zentrale Gateway-/Inference-Policy fuer interne `agent_runtime` Requests
+- Haiku als interner Runtime-Default fuer Agent-Traffic
+- strikte Request-Klassifikation: nur positive numerische Agent-IDs, keine Platform-/Service-/Analysepfade
+- keine Daemon-Seiten-Policy
+- redigierte Observability fuer `provider`, `policy`, `effective_model`, `request_class`
+- Regressionstest fuer Trennung von internem Runtime-Pfad und externem MITM-Pfad
+
+## Out of Scope
+
+- kein hartes Modell-Pinning im `sentinel-daemon`
+- keine Aenderung am externen `/v1/messages`-MITM-Contract
+- keine umfassende provider-agnostische Modell-Taxonomie fuer alle Service-Klassen
+- keine Erweiterung auf Platform-Controlplane-Defaults, solange nicht separat spezifiziert
+- keine #279-Daemon-Hardening-Aenderungen
+
+## Acceptance Criteria
+
+- [ ] AC-1: Interne `agent_runtime`-LLM-Requests bekommen ueber Gateway/Inference standardmaessig Haiku als effektive Model-Policy.
+- [ ] AC-2: Der Daemon enthaelt kein hartes `AGENT_MODEL_HAIKU`-Pinning und bleibt bei Gateway-/Policy-Default oder einem expliziten Request-Override.
+- [ ] AC-3: Runtime-Evidence auf `10.0.0.240` zeigt mindestens einen echten `agent_runtime`-Forward mit effektivem Haiku-Modell.
+- [ ] AC-4: Externe MITM-/`/v1/messages`-Pfade werden durch die interne Agent-Default-Policy nicht regressiert.
+- [ ] AC-5: Observability zeigt `request_class`, `provider`, `policy_source` und `effective_model` redigiert und ohne Secrets.
+- [ ] AC-6: Tests und VM-Smoke belegen die Trennung von internem Runtime-Default und externem Compatibility-Pfad.
+
+## Benchmarks
+
+| Feld | Beschreibung |
+|------|--------------|
+| **Neue Metriken** | `gateway.request_classify_and_policy_resolve`, `gateway.response_log_enriched_append` |
+| **Performance-Budget** | Klassifikation+Policy `< 5us/op`, Response-Log-Append `< 10us/op` |
+| **Tier** | Tier 1: Go Bench lokal, Tier 2: VM-Smoke mit System-Monitoring |
+| **Betroffene Sprachen** | Go |
+| **Bestehende Benchmarks betroffen?** | Nein, neue Go-Benchmarks im Gateway |
+
+## Verify-Ideen
+
+- Gateway-Journal mit `request_class`, `provider`, `policy_source`, `effective_model`
+- `GET /control/traffic-stats` zeigt aktive Runtime-Policy
+- `GET /control/traffic-responses` zeigt redigierte Runtime-Eintraege mit Modell
+- Regressionstest fuer `/internal/llm` vs `/v1/messages`
+- Runtime-Nachweis auf `10.0.0.240` mit kontrolliertem Agent-Forward

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -576,3 +576,88 @@ ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	0.0
 ```
 
 `go build ./cmd/cortex-gateway` exited `0`.
+
+## Task 5 - Phase 5: Benchmarks
+
+### AC-1 bis AC-4 - Benchmark-Zielwerte und Allokationen
+
+Command:
+
+```bash
+rm -f /tmp/issue314-vmstat.txt /tmp/issue314-bench.txt
+(vmstat 1 5 > /tmp/issue314-vmstat.txt &)
+/usr/bin/time -v go test ./cmd/cortex-gateway/internal/proxy \
+  -bench 'Benchmark(ClassifyRequest|ResolveModelPolicy|ResponseLogBufferAdd)' \
+  -benchmem \
+  -run '^$' 2>&1 | tee /tmp/issue314-bench.txt
+wait
+cat /tmp/issue314-vmstat.txt
+```
+
+Output:
+
+```text
+goos: linux
+goarch: amd64
+pkg: github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy
+cpu: AMD Ryzen 9 5900HS with Radeon Graphics
+BenchmarkClassifyRequestAgentRuntime-16       	 3408093	       494.9 ns/op	      16 B/op	       1 allocs/op
+BenchmarkResolveModelPolicyAgentRuntime-16    	28704816	        38.43 ns/op	       0 B/op	       0 allocs/op
+BenchmarkResponseLogBufferAdd-16              	  331939	      3831 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	4.537s
+```
+
+PASS:
+
+```text
+ClassifyRequest: 494.9 ns/op < 1us/op
+ResolveModelPolicy: 38.43 ns/op < 1us/op
+ResponseLogBuffer.Add: 3831 ns/op < 10us/op
+benchmem visible: B/op and allocs/op recorded
+```
+
+### AC-5 - System-Monitoring waehrend Benchmarks
+
+Command:
+
+```bash
+/usr/bin/time -v go test ./cmd/cortex-gateway/internal/proxy \
+  -bench 'Benchmark(ClassifyRequest|ResolveModelPolicy|ResponseLogBufferAdd)' \
+  -benchmem \
+  -run '^$'
+vmstat 1 5
+iostat -dx 1 2
+```
+
+Output excerpt:
+
+```text
+User time (seconds): 6.31
+System time (seconds): 2.06
+Percent of CPU this job got: 125%
+Elapsed (wall clock) time: 0:06.66
+Maximum resident set size (kbytes): 245816
+Swaps: 0
+File system inputs: 49904
+File system outputs: 112
+```
+
+`vmstat` excerpt:
+
+```text
+procs -----------memory---------- ---swap-- -----io---- -system-- -------cpu-------
+ r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa st gu
+13  0 7093336 508428  4292 5292392 111  262  7410  7235 14249  20 24  8 67  1  0  0
+ 7  0 7093904 449476  4292 5194228   0  540 203676 91808 44259 36959 34 29 36 1 0 0
+ 9  1 7096252 508796  4292 5326296 452 2792 211448 46760 40951 43288 33 21 46 1 0 0
+```
+
+`iostat` excerpt:
+
+```text
+Device            r/s     rkB/s     w/s     wkB/s  r_await w_await aqu-sz  %util
+nvme0n1        187.00   2984.00 1799.00  24092.00     0.07    2.95   5.35   5.80
+```
+
+PASS: CPU/RAM/IO-Metriken wurden dokumentiert; der Benchmarklauf beendet sauber ohne Swap-Fehler oder IO-Blockade.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -1015,3 +1015,103 @@ gh issue close 314 --repo silentspike/project-sentinel
 ```
 
 PASS: `status:verified` wird erst nach finaler Verifikation/Merge gesetzt und vor dem Issue-Close.
+
+## Task 9 - Plan-Verifikation
+
+### AC-1 - Plan-Slices abgeschlossen
+
+Command:
+
+```bash
+git log --oneline --decorate -10
+```
+
+Output excerpt:
+
+```text
+645553b Task [8]: Dokumentation und PR-Vorbereitung
+00f10ec Task [7]: Phase 8 - AC-Matrix und Live-Verifikation
+9495871 Task [6]: Phase 6 - Gateway Deploy auf VM
+9d2adf5 Task [5]: Phase 5 - Benchmarks
+b326a2f Task [4]: Phase 4 - Go-Tests
+114732d Task [3]: Phase 3 - Observability und Response Log
+b953e4a Task [2]: Phase 2 - Gateway Policy-Layer
+a42ef76 Task [1]: Phase 1 - Issue-Body-Repair, Branch und Preflight
+```
+
+PASS: Plan-Slices 1 bis 8 sind committed; Task 9 ist diese finale Verifikation.
+
+### AC-2 - Tests und Build final gruen
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
+go build ./cmd/cortex-gateway
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	(cached)
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(cached)
+```
+
+`go build ./cmd/cortex-gateway` exited `0`.
+
+PASS: Betroffene Gateway-Packages testen und bauen final.
+
+### AC-3 - VM-Deploy bleibt live und gesund
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s localhost:8080/health; printf '\n--- traffic ---\n'; curl -s localhost:8081/control/traffic-stats | python3 -c 'import sys,json; d=json.load(sys.stdin); print({k:d.get(k) for k in [\"agent_runtime_model_policy\",\"last_agent_runtime_effective_model\",\"last_agent_runtime_policy_source\",\"last_agent_runtime_provider\",\"primary_provider\",\"external_mitm_provider\"]})'"
+```
+
+Output:
+
+```text
+{"status":"ok","version":"0.1.0","circuit_breakers":{"anthropic-direct":"closed","claude-code":"closed"},"guardrails_enabled":false}
+
+--- traffic ---
+{'agent_runtime_model_policy': 'haiku', 'last_agent_runtime_effective_model': 'haiku', 'last_agent_runtime_policy_source': 'agent_runtime_policy', 'last_agent_runtime_provider': 'claude-code', 'primary_provider': 'claude-code', 'external_mitm_provider': 'anthropic-direct'}
+```
+
+PASS: Der deployed Gateway zeigt die #314-Policy weiterhin live.
+
+### AC-4 - GitHub Issue bleibt korrekt offen bis PR/Merge
+
+Command:
+
+```bash
+gh issue view 314 --repo silentspike/project-sentinel --json number,state,labels,title,updatedAt
+```
+
+Output excerpt:
+
+```json
+{
+  "number": 314,
+  "state": "OPEN",
+  "title": "Policy: Agent LLM model defaults via Gateway/Inference layer",
+  "labels": ["quality:ready", "status:in-progress", "type:feature", "comp:cortex", "comp:inference"]
+}
+```
+
+PASS: Issue ist nicht verfrueht geschlossen; `status:verified` kommt erst nach PR/Merge.
+
+### AC-5 - Finale Sequenz
+
+Nach Task-9-Commit:
+
+```bash
+git push -u origin feat/issue-314-agent-model-policy
+gh pr create --repo silentspike/project-sentinel ...
+# CI gruen abwarten
+gh pr merge ...
+gh issue edit 314 --repo silentspike/project-sentinel --add-label "status:verified" --remove-label "status:in-progress"
+gh issue close 314 --repo silentspike/project-sentinel
+```
+
+PASS: Lokaler Stand ist bereit fuer die GitHub-Sequenz.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -661,3 +661,127 @@ nvme0n1        187.00   2984.00 1799.00  24092.00     0.07    2.95   5.35   5.80
 ```
 
 PASS: CPU/RAM/IO-Metriken wurden dokumentiert; der Benchmarklauf beendet sauber ohne Swap-Fehler oder IO-Blockade.
+
+## Task 6 - Phase 6: Gateway Deploy auf 10.0.0.240
+
+### AC-1 - Deploy trifft den systemd-Binary-Pfad
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "systemctl cat sentinel-gateway --no-pager && systemctl is-active sentinel-gateway && ls -l /opt/sentinel/bin/cortex-gateway"
+```
+
+Output excerpt:
+
+```text
+ExecStart=/opt/sentinel/bin/cortex-gateway
+active
+-rwxr-xr-x 1 root root 23269163 Apr  3 22:39 /opt/sentinel/bin/cortex-gateway
+```
+
+PASS: Der Zielpfad ist `/opt/sentinel/bin/cortex-gateway`.
+
+### AC-2 - Linux-Binary wurde deployed und Service ist aktiv
+
+Command:
+
+```bash
+GOOS=linux GOARCH=amd64 go build -o cortex-gateway ./cmd/cortex-gateway/
+scp cortex-gateway ubuntu@10.0.0.240:/tmp/cortex-gateway.issue314
+ssh ubuntu@10.0.0.240 "set -euo pipefail; \
+  sudo systemctl stop sentinel-gateway; \
+  sudo cp /tmp/cortex-gateway.issue314 /opt/sentinel/bin/cortex-gateway; \
+  sudo chmod 0755 /opt/sentinel/bin/cortex-gateway; \
+  sudo chown root:root /opt/sentinel/bin/cortex-gateway; \
+  sudo systemctl start sentinel-gateway; \
+  sleep 2; \
+  systemctl is-active sentinel-gateway; \
+  ls -l /opt/sentinel/bin/cortex-gateway"
+```
+
+Output:
+
+```text
+active
+-rwxr-xr-x 1 root root 23244031 Apr 24 06:24 /opt/sentinel/bin/cortex-gateway
+```
+
+Zwischenfund:
+
+```text
+cp: cannot create regular file '/opt/sentinel/bin/cortex-gateway': Text file busy
+```
+
+Fix: Service wurde vor dem finalen Copy gestoppt und danach wieder gestartet.
+
+Backup:
+
+```text
+/opt/sentinel/bin/cortex-gateway.bak-issue314-20260424062401
+```
+
+PASS: Neues Binary ist live am systemd-Pfad, Gateway-Service ist aktiv.
+
+### AC-3 - Health ist OK
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s localhost:8080/health"
+```
+
+Output:
+
+```json
+{"status":"ok","version":"0.1.0","circuit_breakers":{},"guardrails_enabled":false}
+```
+
+PASS: Gateway-Health liefert `status=ok`.
+
+### AC-4 - Traffic-Stats zeigen neues Policy-Feld live
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-stats | python3 -m json.tool | sed -n '1,120p'"
+```
+
+Output excerpt:
+
+```json
+{
+    "active_forward_calls": 0,
+    "active_patterns": 123,
+    "agent_runtime_model_policy": "haiku",
+    "apicp_enabled": true,
+    "primary_provider": "claude-code",
+    "response_log_entries": 0,
+    "synthesis_enabled": true
+}
+```
+
+PASS: Die neue Gateway-Policy ist auf der VM sichtbar.
+
+### AC-5 - Journal zeigt keinen Startfehler
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "pid=\$(pgrep -n cortex-gate); echo PID=\$pid; journalctl _PID=\$pid --since '2 min ago' --no-pager | tail -80"
+```
+
+Output excerpt:
+
+```text
+PID=1578506
+cortex-gateway starting
+registered provider name=anthropic-direct model=claude-opus-4-6
+registered provider name=claude-code model=claude-opus-4-6
+traffic control defaults applied
+company context loaded
+proxy server starting addr=:8080
+control plane starting addr=:8081
+```
+
+PASS: PID-basiertes Journal zeigt normalen Startup ohne Panic/Fatal.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -965,3 +965,53 @@ ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(ca
 ```
 
 PASS: Unit-/Regressionstests, Gateway-Build, VM-Smoke und Panic/Drift-Grep sind gruen.
+
+## Task 8 - Dokumentation, PR- und Close-Sequenz
+
+### AC-1 - CHANGELOG enthaelt #314
+
+Command:
+
+```bash
+rg -n "#314|Gateway Model Policy|agent_runtime_model_policy|Response-Log-Buffer" CHANGELOG.md
+```
+
+Output:
+
+```text
+12:- **Gateway Model Policy: Agent-Runtime defaultet ueber Inference-Layer auf Haiku** (#314)
+14:  - `agent_runtime_model_policy` defaultet im Gateway-Control-State auf `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
+18:  - Response-Log-Buffer nutzt jetzt einen bounded circular buffer statt steady-state Slice-Kopie
+```
+
+PASS: `CHANGELOG.md` dokumentiert #314 unter `[Unreleased]`.
+
+### AC-2 - PR-Pflichtsektionen vorbereitet
+
+Pflichtsektionen fuer `gh pr create`:
+
+```text
+## Summary
+## Changes
+## Linked Issues
+## Test Plan
+## Benchmarks
+## Evidence (AC Mapping)
+## Checklist
+```
+
+PASS: PR-Body wird mit allen Gate-Sektionen erstellt.
+
+### AC-3 - Close-Sequenz bleibt korrekt
+
+Geplante Reihenfolge:
+
+```bash
+git push -u origin feat/issue-314-agent-model-policy
+gh pr create --repo silentspike/project-sentinel ...
+# CI gruen, PR merge
+gh issue edit 314 --repo silentspike/project-sentinel --add-label "status:verified" --remove-label "status:in-progress"
+gh issue close 314 --repo silentspike/project-sentinel
+```
+
+PASS: `status:verified` wird erst nach finaler Verifikation/Merge gesetzt und vor dem Issue-Close.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -114,3 +114,156 @@ Hinweis: `docs/` ist im Repo ignoriert. Der Issue-Body wurde nach dem GitHub-Upd
 getracktes Root-Artefakt `issue-314-body.md` gesichert.
 
 PASS: Task 1 aendert nur Tracking-/Dokumentationsartefakte fuer #314, keinen Daemon-Code.
+
+## Task 2 - Phase 2: Gateway Policy-Layer
+
+### AC-1 - Request-Klassen sind modelliert
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '1,50p'
+```
+
+Output excerpt:
+
+```text
+RequestClassExternalCompat       RequestClass = "external_compat"
+RequestClassAgentRuntime         RequestClass = "agent_runtime"
+RequestClassPlatformControlplane RequestClass = "platform_controlplane"
+RequestClassServiceInternal      RequestClass = "service_internal"
+RequestClassInternalOther        RequestClass = "internal_other"
+```
+
+PASS: Die fuenf geplanten Request-Klassen sind zentral im Gateway modelliert.
+
+### AC-2 - Agent-Runtime-Klassifikation ist strikt
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '26,49p'
+```
+
+Output excerpt:
+
+```text
+if isAnthropicMessagesPath(path) { return RequestClassExternalCompat }
+if platform_analysis == "true" || agent_name == "PLATFORM-CONTROLPLANE" { return RequestClassPlatformControlplane }
+if request_type != "" || isServiceIdentity(agentName) { return RequestClassServiceInternal }
+if isPositiveNumericAgentID(metadata["agent_id"]) { return RequestClassAgentRuntime }
+return RequestClassInternalOther
+```
+
+PASS: `agent_runtime` wird erst nach Platform-/Service-/Analyse-Ausschluessen und nur bei positiver numerischer `agent_id` gesetzt.
+
+### AC-3 - Leeres Runtime-Modell wird nur fuer agent_runtime zu Haiku
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '57,76p'
+nl -ba cmd/cortex-gateway/internal/proxy/pipeline.go | sed -n '563,577p'
+```
+
+Output excerpt:
+
+```text
+if class != RequestClassAgentRuntime { return ModelPolicyResolution{Source: PolicySourceProviderDefault}, nil }
+...
+return ModelPolicyResolution{Model: model, Source: PolicySourceAgentRuntime}, nil
+...
+req.Model = policyResolution.Model
+req.EffectiveModel = policyResolution.Model
+req.PolicySource = policyResolution.Source
+```
+
+PASS: Die Policy wird nur fuer `agent_runtime` angewandt und vor dem Provider-Forward in den Request geschrieben.
+
+### AC-4 - Explizites Request-Modell gewinnt
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '57,64p'
+```
+
+Output excerpt:
+
+```text
+if model := strings.TrimSpace(explicitModel); model != "" {
+    return ModelPolicyResolution{Model: model, Source: PolicySourceRequestOverride}, nil
+}
+```
+
+PASS: Ein explizites Request-Modell wird nicht von der Agent-Runtime-Policy ueberschrieben.
+
+### AC-5 - /v1/messages bleibt externe Compatibility-Klasse
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/anthropic_api.go | sed -n '86,99p'
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '26,29p'
+```
+
+Output excerpt:
+
+```text
+PreferredProvider: "anthropic-direct"
+...
+if isAnthropicMessagesPath(path) {
+    return RequestClassExternalCompat
+}
+```
+
+PASS: `/v1/messages` bleibt `external_compat` und bevorzugt weiter `anthropic-direct`.
+
+### AC-6 - Ungueltige Policy/Provider-Kombination ist fail-closed
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/policy.go | sed -n '88,99p'
+nl -ba cmd/cortex-gateway/internal/proxy/pipeline.go | sed -n '563,573p'
+```
+
+Output excerpt:
+
+```text
+case "claude-code", "mock":
+    return "haiku", nil
+default:
+    return "", fmt.Errorf("agent_runtime_model_policy %q is not supported for provider %q", policy, providerName)
+...
+ph.writeRequestError(w, &req, "model policy rejected", http.StatusUnprocessableEntity)
+```
+
+PASS: Nicht unterstuetzte Provider fallen nicht still auf Opus zurueck, sondern erzeugen einen Fehler vor dem Provider-Call.
+
+### Compile-/Regression-Check
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
+go build ./cmd/cortex-gateway
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	1.070s
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(cached)
+```
+
+`go build ./cmd/cortex-gateway` exited `0`.
+
+PASS: Betroffene Gateway-Packages testen und bauen nach Task 2.
+
+### Zwischenfund
+
+Der erste `go test`-Lauf zeigte, dass die Policy zu frueh vor dem Synthesis-Pfad lief und Testprovider-Forwards blockierte. Fix:
+
+- Policy-Anwendung wurde hinter Synthesis/API-CP/Sequencing und direkt vor Streaming/Provider.Send verschoben.
+- Testprovider `mock` wird als Testmapping fuer `haiku` akzeptiert; echte unbekannte Provider bleiben fail-closed.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -259,6 +259,148 @@ ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(ca
 
 `go build ./cmd/cortex-gateway` exited `0`.
 
+## Task 3 - Phase 3: Observability und Response Log
+
+### AC-1 - Traffic-Stats zeigen Agent-Runtime-Policy
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/main.go | sed -n '287,328p'
+```
+
+Output excerpt:
+
+```text
+trafficConfig := controlConfig.Get()
+lastAgentRuntime, hasLastAgentRuntime := responseLogs.LastByClass(proxy.RequestClassAgentRuntime)
+...
+"agent_runtime_model_policy":  trafficConfig.AgentRuntimeModelPolicy,
+...
+stats["last_agent_runtime_effective_model"] = lastAgentRuntime.Model
+stats["last_agent_runtime_policy_source"] = lastAgentRuntime.PolicySource
+stats["last_agent_runtime_provider"] = lastAgentRuntime.Provider
+```
+
+PASS: `/control/traffic-stats` kann die aktive Agent-Runtime-Policy und den letzten effektiven Runtime-Forward ausgeben.
+
+### AC-2 - ResponseLogEntry enthaelt redigierte Policy- und Agent-Felder
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/response_log.go | sed -n '8,19p'
+nl -ba cmd/cortex-gateway/internal/proxy/pipeline.go | sed -n '1233,1247p'
+```
+
+Output excerpt:
+
+```text
+RequestClass RequestClass `json:"request_class,omitempty"`
+Provider     string       `json:"provider"`
+Model        string       `json:"model,omitempty"`
+PolicySource string       `json:"policy_source,omitempty"`
+AgentID      string       `json:"agent_id,omitempty"`
+AgentName    string       `json:"agent_name,omitempty"`
+Content      string       `json:"content"`
+```
+
+PASS: Response-Logs enthalten Request-Klasse, Provider, effektives Modell, Policy-Source und Agent-Metadaten, aber keine Header-/Secret-Felder.
+
+### AC-3 - Success-, Stream- und Error-Logs enthalten Policy-Felder
+
+Command:
+
+```bash
+rg -n '"request_class"|"effective_model"|"policy_source"' cmd/cortex-gateway/internal/proxy/pipeline.go
+```
+
+Output excerpt:
+
+```text
+454: "request_class", req.RequestClass,
+455: "effective_model", "sentinel-synth-v1",
+456: "policy_source", req.PolicySource,
+614: "request_class", req.RequestClass,
+615: "effective_model", effectiveModelForLog(&req, ""),
+616: "policy_source", req.PolicySource,
+733: "request_class", req.RequestClass,
+734: "effective_model", effectiveModelForLog(&req, resp.Model),
+735: "policy_source", req.PolicySource,
+1388: "request_class", req.RequestClass,
+1389: "effective_model", effectiveModelForLog(req, ""),
+1390: "policy_source", req.PolicySource,
+1416: "request_class", req.RequestClass,
+1417: "effective_model", effectiveModelForLog(req, ""),
+1418: "policy_source", req.PolicySource,
+```
+
+PASS: Synthesis/APICP, Provider-Error, Provider-Success, Stream-Error und Stream-Success sind observierbar.
+
+### AC-4 - Keine Secrets in Observability-Feldern
+
+Command:
+
+```bash
+rg -n 'ResponseLogEntry|agent_runtime_model_policy|last_agent_runtime|x-api-key|authorization|secret|token' \
+  cmd/cortex-gateway/main.go \
+  cmd/cortex-gateway/internal/proxy/response_log.go \
+  cmd/cortex-gateway/internal/proxy/pipeline.go
+```
+
+Output excerpt:
+
+```text
+cmd/cortex-gateway/main.go:312: "agent_runtime_model_policy": trafficConfig.AgentRuntimeModelPolicy,
+cmd/cortex-gateway/main.go:324: stats["last_agent_runtime_policy_source"] = lastAgentRuntime.PolicySource
+cmd/cortex-gateway/internal/proxy/response_log.go:8:type ResponseLogEntry struct {
+```
+
+PASS: Die neuen Stats-/ResponseLog-Felder speichern keine Authorization-Header, API-Keys oder Secret-Werte.
+
+### AC-5 - Response-Log-Append ist bounded und ohne steady-state Slice-Kopie
+
+Command:
+
+```bash
+nl -ba cmd/cortex-gateway/internal/proxy/response_log.go | sed -n '25,55p'
+```
+
+Output excerpt:
+
+```text
+return &ResponseLogBuffer{limit: limit, entries: make([]ResponseLogEntry, 0, limit)}
+...
+if len(b.entries) < b.limit {
+    b.entries = append(b.entries, entry)
+    return
+}
+
+b.entries[b.next] = entry
+b.next = (b.next + 1) % b.limit
+```
+
+PASS: Der Buffer ist begrenzt und ersetzt nach Erreichen des Limits Eintraege per Ring-Index statt den Restslice zu kopieren.
+
+### Compile-/Regression-Check
+
+Command:
+
+```bash
+gofmt -w cmd/cortex-gateway/main.go cmd/cortex-gateway/internal/proxy/pipeline.go cmd/cortex-gateway/internal/proxy/response_log.go
+go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
+go build ./cmd/cortex-gateway
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	(cached)
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(cached)
+```
+
+`go build ./cmd/cortex-gateway` exited `0`.
+
 PASS: Betroffene Gateway-Packages testen und bauen nach Task 2.
 
 ### Zwischenfund

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -979,8 +979,8 @@ rg -n "#314|Gateway Model Policy|agent_runtime_model_policy|Response-Log-Buffer"
 Output:
 
 ```text
-12:- **Gateway Model Policy: Agent-Runtime defaultet ueber Inference-Layer auf Haiku** (#314)
-14:  - `agent_runtime_model_policy` defaultet im Gateway-Control-State auf `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
+12:- **Gateway Model Policy: Agent-Runtime nutzt ueber Inference-Layer standardmaessig Haiku** (#314)
+14:  - `agent_runtime_model_policy` setzt im Gateway-Control-State standardmaessig `haiku`, ohne den Daemon oder `/v1/messages` hart zu pinnen
 18:  - Response-Log-Buffer nutzt jetzt einen bounded circular buffer statt steady-state Slice-Kopie
 ```
 

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -785,3 +785,183 @@ control plane starting addr=:8081
 ```
 
 PASS: PID-basiertes Journal zeigt normalen Startup ohne Panic/Fatal.
+
+## Task 7 - Phase 8: AC-Matrix und Live-Verifikation
+
+### AC-1 - Interne agent_runtime Requests bekommen effektiv Haiku
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "cat > /tmp/issue314-agent-runtime.json <<'JSON'
+{
+  \"messages\": [{\"role\": \"user\", \"content\": \"Antworte exakt mit PONG314.\"}],
+  \"metadata\": {
+    \"agent_id\": \"314\",
+    \"agent_name\": \"Issue314 Test Agent\",
+    \"agent_role\": \"Testperson\",
+    \"room_id\": \"buero-ceo\",
+    \"is_directly_addressed\": \"true\"
+  }
+}
+JSON
+timeout 90 curl -sS -w '\nHTTP_STATUS=%{http_code}\n' \
+  -X POST http://127.0.0.1:8080/internal/llm \
+  -H 'Content-Type: application/json' \
+  --data-binary @/tmp/issue314-agent-runtime.json"
+```
+
+Output:
+
+```json
+{"content":"PONG314","model":"haiku","provider":"claude-code","tokens_used":19282,"input_tokens":18783,"output_tokens":499,"finish_reason":"success","actions":[{"type":"chat","content":"PONG314","emotion":"neutral"}],"request_id":"49c25b39-466d-4c48-9bc0-04fac9e9b360"}
+```
+
+```text
+HTTP_STATUS=200
+```
+
+PASS: Der interne Agent-Runtime-Forward lief ueber `claude-code` mit effektivem Modell `haiku`.
+
+### AC-2 - Daemon pinnt kein AGENT_MODEL_HAIKU
+
+Command:
+
+```bash
+rg -n "AGENT_MODEL_HAIKU" services/sentinel-daemon/src || true
+rg -n "model:\s*String::new\(\)|model:\s*\"haiku\"|model:\s*AGENT" \
+  services/sentinel-daemon/src/llm_bridge.rs \
+  services/sentinel-daemon/src/orchestrator.rs \
+  services/sentinel-daemon/src/platform_controlplane/llm_analyzer.rs
+nl -ba services/sentinel-daemon/src/llm_bridge.rs | sed -n '600,620p'
+```
+
+Output:
+
+```text
+services/sentinel-daemon/src/platform_controlplane/llm_analyzer.rs:326:        model: String::new(),
+services/sentinel-daemon/src/llm_bridge.rs:612:            model: String::new(), // Gateway waehlt default
+```
+
+```text
+605	        GatewayRequest {
+606	            messages: vec![GatewayMessage {
+607	                role: "user".to_string(),
+608	                content: user_prompt,
+609	            }],
+610	            temperature: 0.7,
+611	            max_tokens: 1024,
+612	            model: String::new(), // Gateway waehlt default
+613	            metadata,
+614	        }
+```
+
+PASS: Kein `AGENT_MODEL_HAIKU`; Agent-Runtime bleibt beim Gateway-/Policy-Default.
+
+### AC-3 - VM-Evidence zeigt echten agent_runtime Forward mit Haiku
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-stats | python3 -m json.tool | sed -n '1,140p'"
+ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-responses | python3 -c 'import sys,json; data=json.load(sys.stdin); [print(json.dumps({k:e.get(k) for k in (\"request_id\",\"request_class\",\"provider\",\"model\",\"policy_source\",\"agent_id\",\"agent_name\")}, ensure_ascii=False)) for e in data if e.get(\"request_id\")==\"49c25b39-466d-4c48-9bc0-04fac9e9b360\"]'"
+```
+
+Output excerpt:
+
+```json
+{
+    "agent_runtime_model_policy": "haiku",
+    "last_agent_runtime_effective_model": "haiku",
+    "last_agent_runtime_policy_source": "agent_runtime_policy",
+    "last_agent_runtime_provider": "claude-code"
+}
+```
+
+```json
+{"request_id": "49c25b39-466d-4c48-9bc0-04fac9e9b360", "request_class": "agent_runtime", "provider": "claude-code", "model": "haiku", "policy_source": "agent_runtime_policy", "agent_id": "314", "agent_name": "Issue314 Test Agent"}
+```
+
+PASS: Live-Observability belegt den echten Forward mit `agent_runtime` + `haiku`.
+
+### AC-4 - /v1/messages bleibt externer Compatibility-Pfad
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "cat > /tmp/issue314-v1messages.json <<'JSON'
+{
+  \"model\": \"claude-opus-4-6\",
+  \"max_tokens\": 16,
+  \"messages\": [{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Sag PONG314\"}]}]
+}
+JSON
+timeout 30 curl -sS -w '\nHTTP_STATUS=%{http_code}\n' \
+  -X POST http://127.0.0.1:8080/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy-issue314' \
+  -H 'anthropic-version: 2023-06-01' \
+  --data-binary @/tmp/issue314-v1messages.json"
+```
+
+Output:
+
+```json
+{"type":"error","error":{"type":"authentication_error","message":"provider request failed"}}
+```
+
+```text
+HTTP_STATUS=401
+```
+
+Journal:
+
+```bash
+ssh ubuntu@10.0.0.240 "pid=\$(pgrep -n cortex-gate); journalctl _PID=\$pid --since '2 min ago' --no-pager | grep -E 'provider request failed|anthropic-direct|external_compat|request_override' | tail -20"
+```
+
+Output:
+
+```text
+provider request failed provider=anthropic-direct request_class=external_compat effective_model=claude-opus-4-6 policy_source=request_override agent_id="" agent_name="" error="provider error: HTTP 401: ... invalid x-api-key ..."
+```
+
+PASS: `/v1/messages` geht weiter an `anthropic-direct` als `external_compat`; die interne Agent-Policy greift dort nicht.
+
+### AC-5 - Observability redigiert und ohne Secrets
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-stats | grep -E 'x-api-key|dummy-issue314|authorization|Bearer|sk-ant|api_key' || true; curl -s localhost:8081/control/traffic-responses | grep -E 'dummy-issue314|Bearer|sk-ant|api_key|authorization' || true"
+ssh ubuntu@10.0.0.240 "pid=\$(pgrep -n cortex-gate); journalctl _PID=\$pid --since '10 min ago' --no-pager | grep -E 'dummy-issue314|Bearer|sk-ant|api_key|authorization' || true"
+```
+
+Output:
+
+```text
+
+```
+
+PASS: Stats, Response-Log und PID-Journal enthalten keine Dummy-Key-/Bearer-/Secret-Werte.
+
+### AC-6 - Tests und VM-Smoke belegen interne/externe Trennung
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
+go build ./cmd/cortex-gateway
+ssh ubuntu@10.0.0.240 "journalctl -u sentinel-gateway --since '10 min ago' --no-pager | grep -iE 'panic|fatal|segfault' || true; printf '\n--- daemon drift/panic ---\n'; journalctl -u sentinel-daemon --since '10 min ago' --no-pager | grep -iE 'panic|drift' || true"
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	(cached)
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(cached)
+
+--- daemon drift/panic ---
+```
+
+PASS: Unit-/Regressionstests, Gateway-Build, VM-Smoke und Panic/Drift-Grep sind gruen.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -1,0 +1,116 @@
+# Issue #314 Verification
+
+Stand: `2026-04-24`
+
+Branch: `feat/issue-314-agent-model-policy`
+
+## Task 1 - Phase 1: Issue-Body-Repair, Branch und Preflight
+
+### AC-1 - Branch basiert sauber auf origin/main
+
+Command:
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+git rev-parse origin/main
+git rev-list --left-right --count HEAD...origin/main
+```
+
+Output:
+
+```text
+## main...origin/main
+0f1c46c19bfa61d0616b3468834d29b557b3e254
+0f1c46c19bfa61d0616b3468834d29b557b3e254
+0	0
+```
+
+Nach Branch-Erstellung:
+
+```text
+Switched to a new branch 'feat/issue-314-agent-model-policy'
+```
+
+PASS: Branch wurde von synchronem `main` bei `0f1c46c19bfa61d0616b3468834d29b557b3e254` erstellt.
+
+### AC-2 - GitHub-Issue-Body ist spec-ready
+
+Command:
+
+```bash
+gh issue edit 314 --repo silentspike/project-sentinel \
+  --body-file docs/issue-314-body.md \
+  --remove-label "quality:needs-spec" \
+  --remove-label "status:triage" \
+  --remove-label "status:backlog" \
+  --add-label "quality:ready" \
+  --add-label "status:in-progress"
+
+gh issue view 314 --repo silentspike/project-sentinel --json number,title,state,labels,body,updatedAt
+```
+
+Output excerpt:
+
+```text
+https://github.com/silentspike/project-sentinel/issues/314
+labels: quality:ready, status:in-progress, type:feature, comp:cortex, comp:inference, ...
+body contains: Kontext, Scope, Out of Scope, Acceptance Criteria, Benchmarks, Verify-Ideen
+updatedAt: 2026-04-24T05:51:12Z
+```
+
+PASS: Issue-Body enthaelt die vom Quality-Gate geforderten Sektionen `Scope`, `Out of Scope` und `Benchmarks`.
+
+### AC-3 - Labels sind repariert
+
+Command:
+
+```bash
+gh issue view 314 --repo silentspike/project-sentinel --json labels
+```
+
+Output excerpt:
+
+```text
+quality:ready
+status:in-progress
+```
+
+PASS: `quality:needs-spec`, `status:triage` und `status:backlog` wurden entfernt; `quality:ready` und `status:in-progress` sind gesetzt.
+
+### AC-4 - Haiku-Provider-String ist live geprueft
+
+Command:
+
+```bash
+ssh ubuntu@10.0.0.240 "/usr/bin/claude -p --model haiku 'Antworte exakt mit PONG.'"
+```
+
+Output:
+
+```text
+PONG
+```
+
+PASS: Der aktuelle `claude-code` Pfad akzeptiert `--model haiku` auf der VM.
+
+### AC-5 - Kein Daemon-Code in Task 1 geaendert
+
+Command:
+
+```bash
+git status --short --branch
+```
+
+Output:
+
+```text
+## feat/issue-314-agent-model-policy
+ M PROGRESS.md
+?? test-314-verification.md
+```
+
+Hinweis: `docs/` ist im Repo ignoriert. Der Issue-Body wurde nach dem GitHub-Update als
+getracktes Root-Artefakt `issue-314-body.md` gesichert.
+
+PASS: Task 1 aendert nur Tracking-/Dokumentationsartefakte fuer #314, keinen Daemon-Code.

--- a/test-314-verification.md
+++ b/test-314-verification.md
@@ -401,7 +401,7 @@ ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	(ca
 
 `go build ./cmd/cortex-gateway` exited `0`.
 
-PASS: Betroffene Gateway-Packages testen und bauen nach Task 2.
+PASS: Betroffene Gateway-Packages testen und bauen nach Task 3.
 
 ### Zwischenfund
 
@@ -409,3 +409,170 @@ Der erste `go test`-Lauf zeigte, dass die Policy zu frueh vor dem Synthesis-Pfad
 
 - Policy-Anwendung wurde hinter Synthesis/API-CP/Sequencing und direkt vor Streaming/Provider.Send verschoben.
 - Testprovider `mock` wird als Testmapping fuer `haiku` akzeptiert; echte unbekannte Provider bleiben fail-closed.
+
+## Task 4 - Phase 4: Go-Tests
+
+### AC-1 - Agent-Runtime-Klassifikation ist getestet
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy -run 'TestClassifyRequestStrictAgentRuntime|TestResolveModelPolicy'
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	0.033s
+```
+
+Covered cases:
+
+```text
+/v1/messages + agent_id -> external_compat
+platform_analysis/request_type/service identity + agent_id -> not agent_runtime
+positive numeric agent_id -> agent_runtime
+0, leading zero, non-numeric agent_id -> internal_other
+```
+
+PASS: `agent_runtime` ist streng positiv-numerisch und wird erst nach Platform-/Service-Ausschluessen gesetzt.
+
+### AC-2 - /v1/messages bleibt externe Compatibility-Klasse
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy -run TestPipelineAnthropicMessagesPassthrough
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	0.019s
+```
+
+Assertions:
+
+```text
+claude-code calls = 0
+anthropic-direct calls = 1
+PreferredProvider = anthropic-direct
+RequestClass = external_compat
+PolicySource = request_override
+```
+
+PASS: `/v1/messages` laeuft nicht in die Agent-Runtime-Haiku-Policy.
+
+### AC-3 - Agent-Runtime-Haiku und Request-Override sind getestet
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy -run 'TestPipelineAgentRuntimeAppliesHaikuPolicy|TestResolveModelPolicy'
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	0.032s
+```
+
+Assertions:
+
+```text
+agent_runtime without model -> model haiku, effective_model haiku, policy_source agent_runtime_policy
+explicit request model -> policy_source request_override
+```
+
+PASS: Der Runtime-Pfad setzt Haiku nur bei leerem Modell; explizite Modelle gewinnen.
+
+### AC-4 - Fail-Closed fuer ungueltige Policy/Provider-Kombination
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy -run TestResolveModelPolicy
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	0.023s
+```
+
+Assertions:
+
+```text
+provider anthropic-direct + agent_runtime_policy haiku -> error contains "not supported"
+policy opus -> error contains "unknown"
+```
+
+PASS: Unaufloesbare Policy-Zustaende fallen nicht still auf Provider-Default/Opus zurueck.
+
+### AC-5 - Control-Config-Default und Validation sind getestet
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/control -run 'TestNewConfig_Defaults|TestConfig_Update_AgentRuntimeModelPolicy'
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	0.010s
+```
+
+Assertions:
+
+```text
+default agent_runtime_model_policy = haiku
+accepted: "haiku", ""
+rejected: "opus", non-string
+```
+
+PASS: Die Runtime-Policy ist im Control-Plane-State deterministisch validiert.
+
+### AC-6 - ResponseLogBuffer-Ring und LastByClass sind getestet
+
+Command:
+
+```bash
+go test ./cmd/cortex-gateway/internal/proxy -run TestResponseLogBufferRingOverwriteAndLastByClass
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	0.017s
+```
+
+Assertions:
+
+```text
+limit 2 -> third Add overwrites oldest entry
+Entries() returns chronological [agent-1, agent-2]
+LastByClass(agent_runtime) returns agent-2
+LastByClass(external_compat) does not return overwritten external entry
+```
+
+PASS: Der bounded Ringbuffer ist regressionsgesichert.
+
+### Compile-/Regression-Check
+
+Command:
+
+```bash
+gofmt -w cmd/cortex-gateway/internal/proxy/policy_test.go cmd/cortex-gateway/internal/proxy/response_log_test.go cmd/cortex-gateway/internal/proxy/pipeline_test.go cmd/cortex-gateway/internal/control/plane_test.go
+go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
+go build ./cmd/cortex-gateway
+```
+
+Output:
+
+```text
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/proxy	1.087s
+ok  	github.com/obtFusi/project-sentinel/cmd/cortex-gateway/internal/control	0.019s
+```
+
+`go build ./cmd/cortex-gateway` exited `0`.


### PR DESCRIPTION
## Summary
Implements #314 as a Gateway/Inference-layer model policy: internal `agent_runtime` requests default to Haiku via the gateway, while daemon code stays model-neutral and `/v1/messages` remains the external Anthropic/MITM compatibility path.

## Changes
- Adds strict gateway request classes: `external_compat`, `agent_runtime`, `platform_controlplane`, `service_internal`, `internal_other`.
- Adds `agent_runtime_model_policy` to gateway control config, defaulting to `haiku`.
- Resolves Haiku only for `agent_runtime` requests without an explicit model; explicit request models still win.
- Keeps `/v1/messages` on `anthropic-direct` and outside agent-runtime policy.
- Enriches traffic stats, response logs, and journal logs with redacted `request_class`, `provider`, `policy_source`, and `effective_model` fields.
- Converts response log storage to a bounded circular buffer.
- Adds targeted Go tests and microbenchmarks.
- Updates CHANGELOG and records VM evidence in `test-314-verification.md`.

## Linked Issues
Closes #314

## Test Plan
- `go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control`
- `go build ./cmd/cortex-gateway`
- VM deploy to `10.0.0.240`: build linux/amd64 gateway, replace `/opt/sentinel/bin/cortex-gateway`, restart `sentinel-gateway`.
- VM smoke: `curl -s localhost:8080/health`.
- VM AC smoke: controlled `/internal/llm` agent-runtime request returns provider `claude-code`, model `haiku`, HTTP 200.
- VM external-compat smoke: `/v1/messages` with dummy key remains `anthropic-direct`/`external_compat` and fails as expected with HTTP 401 auth error, not agent policy.
- Panic/drift/secret greps against gateway/daemon observability.

## Benchmarks
- `BenchmarkClassifyRequestAgentRuntime`: `494.9 ns/op`, `16 B/op`, `1 allocs/op`.
- `BenchmarkResolveModelPolicyAgentRuntime`: `38.43 ns/op`, `0 B/op`, `0 allocs/op`.
- `BenchmarkResponseLogBufferAdd`: `3831 ns/op`, `0 B/op`, `0 allocs/op`.
- Targets met: classify `<1us/op`, resolve `<1us/op`, response-log append `<10us/op`.
- Sidecar metrics captured with `/usr/bin/time -v`, `vmstat`, and `iostat`.

## Evidence (AC Mapping)
| AC | Evidence | Result |
| --- | --- | --- |
| AC-1 | VM `/internal/llm` response returned `model=haiku`, `provider=claude-code`. | PASS |
| AC-2 | `rg AGENT_MODEL_HAIKU services/sentinel-daemon/src` returned no hits; `llm_bridge.rs` keeps `model: String::new()`. | PASS |
| AC-3 | VM response log request `49c25b39-466d-4c48-9bc0-04fac9e9b360` shows `request_class=agent_runtime`, `model=haiku`, `policy_source=agent_runtime_policy`. | PASS |
| AC-4 | `/v1/messages` dummy-key smoke logged `provider=anthropic-direct`, `request_class=external_compat`, `effective_model=claude-opus-4-6`, `policy_source=request_override`. | PASS |
| AC-5 | `traffic-stats`, `traffic-responses`, and PID journal expose redacted policy fields; secret greps found no key/token values. | PASS |
| AC-6 | Go tests plus VM internal/external smokes prove runtime-default and compatibility-path separation. | PASS |

Concrete commands/output excerpts:

```bash
go test ./cmd/cortex-gateway/internal/proxy ./cmd/cortex-gateway/internal/control
go build ./cmd/cortex-gateway
ssh ubuntu@10.0.0.240 "curl -s localhost:8080/health"
ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-stats | python3 -m json.tool"
ssh ubuntu@10.0.0.240 "curl -s localhost:8081/control/traffic-responses | python3 -m json.tool"
ssh ubuntu@10.0.0.240 "pid=\$(pgrep -n cortex-gate); journalctl _PID=\$pid --since '10 min ago' --no-pager"
```

```text
/internal/llm -> HTTP_STATUS=200, provider=claude-code, model=haiku, request_id=49c25b39-466d-4c48-9bc0-04fac9e9b360
traffic-stats -> agent_runtime_model_policy=haiku, last_agent_runtime_effective_model=haiku, last_agent_runtime_policy_source=agent_runtime_policy
/v1/messages dummy-key -> HTTP_STATUS=401, provider=anthropic-direct, request_class=external_compat, policy_source=request_override
panic/drift/secret greps -> no matches
```

Full command/output evidence is in `test-314-verification.md`.

## Checklist
- [x] Issue body is `quality:ready`.
- [x] Code implemented in Gateway/Inference layer, not daemon.
- [x] Relevant Go tests pass.
- [x] Benchmarks pass with target values.
- [x] Gateway deployed and verified on `10.0.0.240`.
- [x] Every AC has command/output evidence.
- [x] CHANGELOG.md updated.
- [x] No panic/drift/secret regression observed in verification window.