### PR TITLE
fix(demo): add sentinel-projection service so dashboard does not crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,13 @@ demo-binaries: ## Build only the Rust binaries the docker demo image needs (remo
 	@if [ -f .cargo-remote.toml ] && command -v cargo-remote >/dev/null 2>&1; then \
 		echo "[demo-binaries] cargo-remote configured -> offloading build"; \
 		cargo remote -c -- build --release --bin sentinel-daemon --bin sentinel-nightrun; \
+		cargo remote -c -- build --release -p sentinel-projection-service; \
 	else \
 		echo "[demo-binaries] cargo-remote not configured -> local cargo build"; \
 		echo "[demo-binaries] note: local build needs ~8 GB free RAM and ~20 min on a laptop;"; \
 		echo "[demo-binaries]       set up cargo-remote (see CONTRIBUTING.md) to offload."; \
 		cargo build --release --bin sentinel-daemon --bin sentinel-nightrun; \
+		cargo build --release -p sentinel-projection-service; \
 	fi
 
 demo-image: demo-binaries ## Build the docker demo image (requires demo-binaries)

--- a/deploy/docker/Dockerfile.demo
+++ b/deploy/docker/Dockerfile.demo
@@ -37,9 +37,10 @@
 # `make demo-binaries` (cargo remote -c -- build --release ...) first.
 FROM debian:bookworm-slim AS rust-binaries
 
-COPY target/release/sentinel-daemon   /out/sentinel-daemon
-COPY target/release/sentinel-nightrun /out/sentinel-nightrun
-RUN chmod +x /out/sentinel-daemon /out/sentinel-nightrun
+COPY target/release/sentinel-daemon     /out/sentinel-daemon
+COPY target/release/sentinel-nightrun   /out/sentinel-nightrun
+COPY target/release/sentinel-projection /out/sentinel-projection
+RUN chmod +x /out/sentinel-daemon /out/sentinel-nightrun /out/sentinel-projection
 
 # ---------------------------------------------------------------------------
 # Stage 2: Go build (gateway + judge + nats-bridge)
@@ -95,6 +96,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.1.30" && \
 # Service binaries
 COPY --from=rust-binaries /out/sentinel-daemon          /usr/local/bin/
 COPY --from=rust-binaries /out/sentinel-nightrun        /usr/local/bin/
+COPY --from=rust-binaries /out/sentinel-projection      /usr/local/bin/
 COPY --from=go-builder    /out/cortex-gateway           /usr/local/bin/
 COPY --from=go-builder    /out/sentinel-judge           /usr/local/bin/
 COPY --from=go-builder    /out/sentinel-nats-bridge     /usr/local/bin/

--- a/deploy/docker/sentinel-demo-entrypoint.sh
+++ b/deploy/docker/sentinel-demo-entrypoint.sh
@@ -6,12 +6,13 @@
 # compose file can drive a multi-process stack from a single image.
 #
 # Roles:
-#   daemon         sentinel-daemon  (ECS world, operator API on :8084)
-#   gateway        cortex-gateway   (LLM proxy on :8080, control on :8081)
-#   judge          sentinel-judge   (quality monitor on :8082)
-#   nats-bridge    sentinel-nats-bridge (event bridge on :8083)
-#   dashboard      sentinel-dashboard (Bun UI on :8000)
-#   nightrun       sentinel-nightrun (one-shot nightly batch)
+#   daemon         sentinel-daemon       (ECS world, operator API on :8084)
+#   gateway        cortex-gateway        (LLM proxy on :8080, control on :8081)
+#   judge          sentinel-judge        (quality monitor on :8082)
+#   nats-bridge    sentinel-nats-bridge  (event bridge on :8083)
+#   projection     sentinel-projection   (CQRS read-model worker, builds projection.db)
+#   dashboard      sentinel-dashboard    (Bun UI on :8000)
+#   nightrun       sentinel-nightrun     (one-shot nightly batch)
 #   help           print this message and exit
 #
 set -euo pipefail
@@ -55,8 +56,24 @@ case "$role" in
         cd "$go_workdir"
         exec /usr/local/bin/sentinel-nats-bridge
         ;;
+    projection)
+        # Long-running CQRS read-model worker. Polls EventStore, builds
+        # projection.db that the dashboard reads from.
+        exec /usr/local/bin/sentinel-projection \
+            --event-store /opt/sentinel/data/events.db \
+            --projection-db /opt/sentinel/data/projection.db
+        ;;
     dashboard)
         cd /opt/sentinel/dashboard
+        export PROJECTION_DB_PATH="${PROJECTION_DB_PATH:-/opt/sentinel/data/projection.db}"
+        export EVENT_STORE_DB_PATH="${EVENT_STORE_DB_PATH:-/opt/sentinel/data/events.db}"
+        # Wait for projection worker to create projection.db before bun starts.
+        # Otherwise the dashboard crashes with SQLITE_CANTOPEN.
+        deadline=$(( $(date +%s) + 60 ))
+        while [ ! -f "$PROJECTION_DB_PATH" ] && [ "$(date +%s)" -lt "$deadline" ]; do
+            echo "[entrypoint] waiting for projection.db ($PROJECTION_DB_PATH) to appear..."
+            sleep 2
+        done
         exec bun run src/index.ts
         ;;
     nightrun)
@@ -69,7 +86,7 @@ Sentinel demo container.
 
 Usage: docker run --rm -e SENTINEL_ROLE=<role> sentinel-demo:local
 
-Available roles: daemon | gateway | judge | nats-bridge | dashboard | nightrun
+Available roles: daemon | gateway | judge | nats-bridge | projection | dashboard | nightrun
 
 The demo stack normally invokes this image once per service via
 docker-compose.demo.yml. To run an individual service ad-hoc, set

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,7 +1,7 @@
 # Sentinel 10-minute demo stack.
 #
 # Brings up: NATS + sentinel-daemon + cortex-gateway + sentinel-judge +
-#            sentinel-nats-bridge + sentinel-dashboard
+#            sentinel-nats-bridge + sentinel-projection + sentinel-dashboard
 #
 # All five Sentinel services share the same image (deploy/docker/Dockerfile.demo)
 # and select their binary via the SENTINEL_ROLE environment variable.
@@ -120,6 +120,22 @@ services:
       - sentinel-data:/opt/sentinel/data
     networks: [sentinel]
 
+  projection:
+    # CQRS read-model worker. Polls the EventStore and builds the
+    # projection.db that the dashboard reads (agent_live_view, room_live_view,
+    # kpi_1m). Without this service running, the dashboard crashes on
+    # startup because projection.db doesn't exist.
+    image: sentinel-demo:local
+    container_name: sentinel-demo-projection
+    environment:
+      SENTINEL_ROLE: projection
+    depends_on:
+      daemon:
+        condition: service_healthy
+    volumes:
+      - sentinel-data:/opt/sentinel/data
+    networks: [sentinel]
+
   dashboard:
     image: sentinel-demo:local
     container_name: sentinel-demo-dashboard
@@ -131,6 +147,8 @@ services:
     depends_on:
       gateway:
         condition: service_healthy
+      projection:
+        condition: service_started
     # host port 18000 (port 8000 commonly used by local nginx/dev servers).
     # Adjust on a host where 8000 is free if you want the canonical mapping.
     ports:


### PR DESCRIPTION
## Summary

Add the missing \`sentinel-projection\` worker as the 7th compose service so the dashboard can start. Without it, dashboard crashes with SQLITE_CANTOPEN on every fresh boot.

## Changes

- Makefile \`demo-binaries\`: also build \`sentinel-projection-service\` (cargo-remote-or-local fallback)
- Dockerfile.demo: package the \`sentinel-projection\` binary
- Entrypoint: add \`projection\` role + dashboard wait-loop on \`PROJECTION_DB_PATH\`
- docker-compose.demo.yml: add the projection service with depends_on:daemon(healthy); dashboard now also depends_on:projection

## Linked Issues

Closes #324

## Test Plan

End-to-end as a public user (anon clone, binaries pre-built to skip 20-min cargo step):

\`\`\`bash
cd /tmp && git clone https://github.com/silentspike/project-sentinel.git pubuser
cd pubuser
# (binaries copied in to skip 20-min build, post-PR fallback would do it locally)
docker build -f deploy/docker/Dockerfile.demo -t sentinel-demo:local .
docker compose -f docker-compose.demo.yml up -d
sleep 35
docker compose -f docker-compose.demo.yml ps
\`\`\`

Output observed (7 services Up):
\`\`\`
sentinel-demo-daemon       Up (healthy)
sentinel-demo-dashboard    Up
sentinel-demo-gateway      Up (healthy)
sentinel-demo-judge        Up
sentinel-demo-nats         Up (healthy)
sentinel-demo-nats-bridge  Up
sentinel-demo-projection   Up
\`\`\`

## Benchmarks

N/A — composition + entrypoint changes.

## Evidence (AC Mapping)

| AC | Verification | Evidence |
|----|--------------|----------|
| AC-1 | Makefile builds 3 binaries | \`make -n demo-binaries\` shows cargo build for daemon + nightrun + sentinel-projection-service |
| AC-2 | Dockerfile copies projection binary | \`grep sentinel-projection deploy/docker/Dockerfile.demo\` shows COPY + chmod |
| AC-3 | Entrypoint has projection role | \`grep -A 5 'projection)' deploy/docker/sentinel-demo-entrypoint.sh\` shows exec sentinel-projection |
| AC-4 | 7 services in compose | \`docker compose -f docker-compose.demo.yml config --services\` lists nats + 6 sentinel |
| AC-5 | Dashboard waits for projection.db | entrypoint \`while [ ! -f \"\$PROJECTION_DB_PATH\" ]\` loop with 60s deadline |
| AC-6 | Dashboard /api/agents returns live data | reproducer below |

\`\`\`bash
curl -s --max-time 3 http://localhost:18000/api/agents | head -c 200
# observed:
# [{\"id\":1,\"name\":\"Thomas Mueller\",\"role\":\"CEO / Geschaeftsfuehrer / Gruender\",
#   \"status\":\"active\",\"current_room\":\"buero-ceo\",\"hunger\":20.83,
#   \"energy\":90.62,\"stress\":0.21,\"bladder\":10.80, ...}, ...]
\`\`\`

\`\`\`bash
docker logs sentinel-demo-projection | tail -3
# observed:
# INFO sentinel_limbo::event_store: EventStore opened at /opt/sentinel/data/events.db
# INFO sentinel_projection::store: ReadModelStore opened path=\"/opt/sentinel/data/projection.db\"
# INFO sentinel_projection::worker: Projection worker starting live mode poll_interval_ms=50
\`\`\`

## Checklist

- [x] Code compiles (Makefile + bash + YAML syntax-validated)
- [x] No new clippy/vet warnings
- [x] CHANGELOG entry deferred (consolidated in next release notes after this fix lands)
- [x] PR body has all 7 required sections