### PR TITLE
docs(hardening-c+d): README badges, status table, honest CHANGELOG, known-limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ development and public visibility — not the beginning of the project itself.
   what / why / revisit-when for each
 - `docs/glossary.md` — PixelPerfekt narrative and 60-LLM + 5-services agent-layer terminology
 - Run-able 10-minute demo via `docker-compose.demo.yml` (`make demo`) bringing up NATS +
-  sentinel-daemon + cortex-gateway + sentinel-judge + sentinel-nats-bridge + dashboard
+  sentinel-daemon + cortex-gateway + sentinel-judge + sentinel-nats-bridge + sentinel-projection + dashboard
+- 3-tier `make demo-binaries` recipe (release-fetch / cargo-remote / local cargo build) plus
+  `scripts/fetch-demo-binaries.sh` so the demo onboard is ~60 MB instead of a 20-min cargo build
+- Pre-built Linux x86_64 release artifacts: `sentinel-daemon`, `sentinel-nightrun`,
+  `sentinel-projection` attached to the v0.1.0-alpha release
 - Demo dashboard recording in `docs/images/sentinel-demo.gif`
 - 4-tier IP / path configuration strategy: `.env.example`, `.make.local.example`,
   `deploy/systemd/sentinel-env.example` and `Makefile` `-include .make.local`
@@ -42,14 +46,30 @@ development and public visibility — not the beginning of the project itself.
 
 ### Security
 - Pre-release security review:
-  - `gitleaks` scan: 0 leaks across 1055 commits / 12.58 MB
-  - `trufflehog` scan: 0 verified + 0 unverified secrets across 56812 chunks / 521 MB
-  - `cargo audit` and `govulncheck` clean
-  - npm audit clean (dashboard dependencies)
+  - `gitleaks` scan: 0 leaks across 1063 commits / 12.58 MB
+  - `trufflehog` scan: 0 verified + 0 unverified secrets across 56851 chunks / 521.76 MB
+  - `cargo audit`, `govulncheck`, `npm audit`: clean
   - 9/9 sandbox breakout tests passing (bwrap + Landlock + cgroups + netns); see
     [docs/security-test-report.md](docs/security-test-report.md)
-- 16 CI workflows green at release
-  (build, test, CodeQL, OSSF Scorecard, cargo-deny, supply-chain, Renovate, coverage)
+- CI workflow status at release: ci, lint, coverage, supply-chain (cargo-deny, npm-audit,
+  go-vuln, rust-audit), conventional-commits, dependency-freshness — green on main.
+  CodeQL scanning depends on GitHub Advanced Security, which is automatically enabled
+  for public repositories; the workflow files (`.github/codeql/codeql-config.yml`,
+  `.github/workflows/codeql.yml`) ship configured so the SAST pipeline goes green
+  on the first scheduled run after the public-flip.
+
+### Known limitations at this release
+- The docker compose demo intentionally exercises only the deterministic + LLM layers
+  (ECS world, bio-engine, gateway pipeline, dashboard). It does **not** exercise
+  the kernel-bound sandbox primitives (bwrap, Landlock, cgroups v2, netns, eBPF,
+  sentinel-fs FUSE) — those need user namespaces and CAP_BPF / CAP_SYS_ADMIN that
+  a plain unprivileged container does not have. The full stack is documented in
+  `deploy/systemd/*.service` for VM deployment. See README "What the docker demo
+  shows — and what it does not" and [docs/known-limitations.md](docs/known-limitations.md).
+- The signed v0.1.0-alpha tag will display "Unverified" in the GitHub UI until the
+  maintainer's SSH signing key is registered as a Signing Key on GitHub. The tag
+  itself carries a valid Ed25519 signature (verifiable locally with
+  `git tag -v v0.1.0-alpha`).
 
 [Unreleased]: https://github.com/silentspike/project-sentinel/compare/v0.1.0-alpha...HEAD
 [0.1.0-alpha]: https://github.com/silentspike/project-sentinel/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Project Sentinel
 
+[![CI](https://github.com/silentspike/project-sentinel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/ci.yml)
+[![Coverage](https://github.com/silentspike/project-sentinel/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/coverage.yml)
+[![CodeQL](https://github.com/silentspike/project-sentinel/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/codeql.yml)
+[![Supply Chain](https://github.com/silentspike/project-sentinel/actions/workflows/deny.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/deny.yml)
+[![OSSF Scorecard](https://github.com/silentspike/project-sentinel/actions/workflows/scorecard.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/scorecard.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/silentspike/project-sentinel?include_prereleases&label=release)](https://github.com/silentspike/project-sentinel/releases)
+[![Rust 1.93+](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org)
+[![Go 1.26+](https://img.shields.io/badge/go-1.26%2B-blue.svg)](https://go.dev)
+
 **A research testbed for runtime hardening, controlplane design, and LLM agent
 boundary detection.** Sixty LLM-persona agents live inside a fictional web
 design agency under strict sandbox isolation. The simulated office is the
@@ -173,6 +183,31 @@ For the full stack with sandbox enforcement see
 `deploy/systemd/*.service` and the deployment notes in
 [docs/governance.md](docs/governance.md).
 
+## Status — what works in this alpha, what doesn't yet
+
+| Area | Status |
+|------|--------|
+| ECS world (bevy_ecs), bio + physics + room sim                   | ✅ implemented + exercised in demo |
+| Event sourcing (Limbo SQLite, idempotent, replayable)            | ✅ implemented + exercised in demo |
+| Cortex Gateway 7-step pipeline + 10-rule synthesis engine        | ✅ implemented + exercised in demo |
+| Dashboard (Bun + Hono + WebSocket)                               | ✅ implemented + exercised in demo |
+| sentinel-judge quality + drift monitoring (NATS streaming)       | ✅ implemented + exercised in demo |
+| sentinel-projection CQRS read-models                             | ✅ implemented + exercised in demo |
+| sentinel-nightrun batch consolidation, deterministic replay      | ✅ implemented, manual trigger only |
+| 60 LLM-persona agents (`config/agents/AGENT-*.toml`)             | ✅ defined; demo runs a 5-agent subset |
+| **bwrap + Landlock per-agent isolation**                         | ✅ implemented (`crates/sentinel-sandbox/`); 9/9 breakout tests pass on a privileged host; **not exercised in the docker demo** |
+| **cgroups v2 per-agent caps + netns + nftables**                 | ✅ implemented; same caveat |
+| **eBPF probes (aya-rs)** + **sentinel-fs CAS-FUSE**              | ✅ implemented; same caveat |
+| TOGAF v22.1 architecture guide + per-cluster gap report          | ✅ shipped in `docs/architecture/` |
+| Pre-built demo binaries (linux-x86_64) on every release          | ✅ since v0.1.0-alpha |
+| Tag verified-badge on GitHub                                     | ⏳ pending maintainer's SSH signing-key registration; tag itself carries valid Ed25519 signature |
+| CodeQL pipeline live status                                      | ⏳ green only after first scheduled run post-public-flip (GHAS gating) |
+| Demo binaries for arm64 / Apple Silicon                          | ⏳ planned (currently linux-x86_64 only) |
+| Multi-tenant company configs ("Gaia firmen-konfigurator")        | ⏳ tracked as roadmap issue |
+
+See [docs/known-limitations.md](docs/known-limitations.md) for the full
+caveat list.
+
 ## Repository Layout
 
 | Path                         | Contents                                                    |
@@ -205,15 +240,21 @@ For the full stack with sandbox enforcement see
 | [SECURITY.md](SECURITY.md)                                   | Reporting vulnerabilities                     |
 | [CHANGELOG.md](CHANGELOG.md)                                 | Release history                               |
 
-## Status
+## Release status
 
 This is the first **public** release boundary. The project was developed
 privately prior to `v0.1.0-alpha`; the tag marks the boundary between
 private development and public visibility, not the start of the project.
 
-CI: 16 workflows (build, test, CodeQL, OSSF Scorecard, cargo-deny,
-Renovate, coverage). Security review: dependency audit clean, secret scan
-clean, 9/9 sandbox breakout tests passing.
+CI on `main`: ci, lint, coverage, supply-chain (cargo-deny, npm-audit,
+go-vuln, rust-audit), conventional-commits, dependency-freshness — green.
+CodeQL goes green on the first scheduled run after the public flip
+(GHAS gating). Security: dependency audit + `gitleaks` + `trufflehog` clean,
+9/9 sandbox breakout tests passing on a privileged host.
+
+See [docs/known-limitations.md](docs/known-limitations.md) for full caveats
+and the [Status table above](#status--what-works-in-this-alpha-what-doesnt-yet)
+for the per-feature picture.
 
 ## License
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,101 @@
+# Known Limitations — v0.1.0-alpha
+
+This document collects what *does not yet work* in the current release so a
+reader can calibrate expectations before they spend an hour cloning and
+running things.
+
+The companion document [docs/togaf-gap-v22.md](togaf-gap-v22.md) lists what
+*is* implemented per architecture cluster.
+
+---
+
+## What the docker demo does NOT exercise
+
+The `docker-compose.demo.yml` stack is deliberately a behavioural demo:
+ECS world, bio-engine, physics, event-sourcing, gateway pipeline, dashboard.
+
+It does **not** exercise the kernel-bound sandbox primitives, because a plain
+unprivileged container does not have user-namespaces, `CAP_BPF`,
+`CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, or a writable `/dev/fuse`:
+
+| Component                  | Demo container | VM deploy |
+|----------------------------|----------------|-----------|
+| bwrap + Landlock isolation | no             | yes       |
+| cgroups v2 per-agent caps  | no             | yes       |
+| netns + nftables egress    | no             | yes       |
+| eBPF probes (aya-rs)       | no             | yes       |
+| sentinel-fs CAS-FUSE       | no             | yes       |
+| Zenoh SHM transport        | no (TCP only)  | yes       |
+
+The `SandboxEnforcer`
+(`crates/sentinel-sandbox/src/enforcer.rs`) detects the absence of these
+features at boot and degrades gracefully — warnings in the daemon log are
+expected demo signal, not failures.
+
+For the full stack with sandbox enforcement, see
+`deploy/systemd/*.service` and the deployment notes in
+[docs/governance.md](governance.md).
+
+## Demo binaries are Linux x86_64 only
+
+The release ships pre-built binaries for `linux-x86_64` only. Apple Silicon,
+arm64, or other architectures need to use the cargo-remote or local-cargo
+tier (see `make demo-binaries`).
+
+## CodeQL on the v0.1.0-alpha commit
+
+GitHub Advanced Security (which CodeQL needs to upload SARIF results) is
+free on public repositories but a paid feature on private ones. The CodeQL
+workflow files ship pre-configured (`build-mode: manual` for Go,
+`build-mode: none` for the Bun dashboard, with `paths-ignore` for the
+node_modules tree) and will go green on the first scheduled run after the
+public flip.
+
+## Tag verification badge
+
+`v0.1.0-alpha` displays "Unverified" in the GitHub web UI until the
+maintainer's Ed25519 SSH key is registered as a *Signing Key* on GitHub
+(separate from the *Authentication Key* used for `git push`). The tag is
+cryptographically valid — verify locally with `git tag -v v0.1.0-alpha`.
+
+## Demo dashboard does not enable the LLM pipeline by default
+
+The demo `cortex-gateway.toml` selects an `ollama` provider on
+`http://localhost:11434` so the demo does not require Anthropic credentials.
+If you do not have a local ollama serving `qwen3:7b`, agent calls will not
+succeed — the dashboard still shows ECS state, room telemetry, and bio
+events, which is the intent of a behavioural demo.
+
+To wire a real provider, set the corresponding API key in `.env` and edit
+`config/demo/cortex-gateway.toml` to enable `claude-code` or
+`anthropic-direct`.
+
+## 60 LLM-persona agents vs 5 in demo
+
+The architecture defines 60 agents in `config/agents/AGENT-*.toml`. The
+demo `daemon.toml` caps `max_agents = 5` for the 10-minute window so the
+log stays readable and the CPU stays available. To run the full cohort,
+remove or raise the cap, expect higher steady-state CPU and memory.
+
+## Nightrun is one-shot in the demo
+
+`sentinel-nightrun` is included in the image but the demo compose stack
+does not run it — it is a shift-change batch process designed to fire at
+real shift boundaries (06:00 / 14:00 / 22:00). To trigger manually inside
+the running stack:
+
+```bash
+docker exec sentinel-demo-daemon /usr/local/bin/sentinel-nightrun --config /opt/sentinel/config-runtime/nightrun.toml
+```
+
+## Open issues that may matter to a reviewer
+
+Live tracking lives at
+<https://github.com/silentspike/project-sentinel/issues> and includes:
+
+- Performance: tick-loop hot-path, dashboard polling, non-blocking nightrun
+- Resilience: daemon hardening
+- Feature: Gaia firmen-konfigurator (multi-tenant company definitions)
+
+These are intentionally open — they reflect post-v0.1.0-alpha roadmap, not
+regressions.


### PR DESCRIPTION
## Summary

Hardening Block C3 (README badges) + Block D (honesty pass on CHANGELOG + new docs/known-limitations.md). Pre-public polish to calibrate reviewer expectations.

## Changes

- README header: 9 badges (CI, Coverage, CodeQL, Supply Chain, OSSF Scorecard, License, Release, Rust 1.93+, Go 1.26+)
- README new section "Status — what works in this alpha, what doesn't yet" with per-feature ✅/⏳ table
- README "Release status" rewrites the "16 workflows green" overstatement with the actual list + GHAS gating note for CodeQL
- CHANGELOG.md: same honesty pass + new "Known limitations at this release" subsection
- docs/known-limitations.md (new): demo-vs-VM caveats, CodeQL GHAS gating, tag verification status, demo binaries linux-x86_64 only, demo agent count, nightrun trigger, open issues pointer

## Linked Issues

Closes #330

## Test Plan

```bash
# AC-1: badge count
head -15 README.md | grep -c '^\[!\['
# expected: >= 5
```

```bash
# AC-2: status table present
grep -c "Status — what works in this alpha" README.md
```

```bash
# AC-3: known-limitations doc
ls -la docs/known-limitations.md
```

```bash
# AC-4: CHANGELOG no "16 workflows green at release" Marketing-Speak
git diff main feat/hardening-cd-readme-changelog -- CHANGELOG.md
```

```bash
# Live badge URL test (shields.io public)
curl -sI 'https://img.shields.io/badge/License-MIT-blue.svg' | head -3
# observed:
#   HTTP/2 200
#   content-type: image/svg+xml;charset=utf-8
```

## Benchmarks

N/A — docs only.

## Evidence (AC Mapping)

| AC | Verification | Evidence |
|----|--------------|----------|
| AC-1 | 9 badges in README header | head -15 README.md returns 9 lines starting with [![ |
| AC-2 | status table exists | grep returns 1 (1 occurrence of "Status — what works in this alpha") |
| AC-3 | known-limitations.md exists | ls -la shows file with 5+ KB content |
| AC-4 | CHANGELOG honest | git diff zeigt entfernung "16 CI workflows green at release" durch tatsächliche Workflow-Liste + GHAS-Note |
| AC-5 | CHANGELOG known-limitations subsection | grep "Known limitations" CHANGELOG.md |

```bash
# CodeQL note in CHANGELOG demonstrating honesty:
$ grep -A 4 "CodeQL scanning depends" CHANGELOG.md
CodeQL scanning depends on GitHub Advanced Security, which is automatically enabled
for public repositories; the workflow files (`.github/codeql/codeql-config.yml`,
`.github/workflows/codeql.yml`) ship configured so the SAST pipeline goes green
on the first scheduled run after the public-flip.
```

## Checklist

- [x] Code compiles (docs only)
- [x] No new clippy/vet warnings
- [x] CHANGELOG entry IS this PR's purpose
- [x] PR body has all 7 required sections