### PR TITLE
fix(demo): map all sentinel ports +10000 to dodge local dev-server collisions

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -10,18 +10,18 @@
 #   ./scripts/demo.sh                    # build + run + open dashboard + tear down
 #   docker compose -f docker-compose.demo.yml up --build
 #
-# Ports exposed on the host:
+# Ports exposed on the host (every Sentinel-app port uses a +10000 offset
+# to avoid colliding with common local dev services on 8000-8090):
 #   18000  Dashboard UI           (browser)              -> container :8000
-#   8080   Cortex Gateway (proxy) -- also serves /metrics
-#   8081   Cortex Gateway (control plane)
+#   18080  Cortex Gateway (proxy) -- also serves /metrics-> container :8080
+#   18081  Cortex Gateway (control plane)               -> container :8081
 #   18082  sentinel-judge        (health, /metrics)     -> container :8082
 #   18083  sentinel-nats-bridge  (health)               -> container :8083
-#   8084   sentinel-daemon (operator API)
-#   8222   NATS monitoring HTTP
+#   18084  sentinel-daemon (operator API)               -> container :8084
+#    8222  NATS monitoring HTTP                          (no collision risk)
+#    4222  NATS client                                   (no collision risk)
 #
-# Host ports 18000/18082/18083 use a +10000 offset because 8000/8082/8083 are
-# commonly bound on a developer laptop (nginx, dev servers, other compose
-# stacks). Adjust to canonical ports if your machine has them free.
+# Adjust to canonical ports (8000, 8080-8084) if your machine has them free.
 
 name: sentinel-demo
 
@@ -54,7 +54,7 @@ services:
       nats:
         condition: service_healthy
     ports:
-      - "8084:8084"
+      - "18084:8084"
     volumes:
       - sentinel-data:/opt/sentinel/data
     healthcheck:
@@ -76,10 +76,12 @@ services:
       daemon:
         condition: service_healthy
     # gateway exposes the proxy on 8080 (also serves /metrics) and the
-    # control plane on 8081. There is no separate metrics port.
+    # control plane on 8081 inside the container. Host ports 18080/18081
+    # use the +10000 offset to avoid colliding with local dev servers
+    # (gradle, java app servers, custom proxies on 8080/8081).
     ports:
-      - "8080:8080"
-      - "8081:8081"
+      - "18080:8080"
+      - "18081:8081"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "--max-time", "3", "http://localhost:8080/health"]
       interval: 10s

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -34,14 +34,14 @@ note "starting stack..."
 
 note "waiting for daemon TCP (operator API has no /healthz; max 120s)..."
 deadline=$(( $(date +%s) + 120 ))
-until curl -s -o /dev/null --max-time 3 http://127.0.0.1:8084/ >/dev/null 2>&1; do
+until curl -s -o /dev/null --max-time 3 http://127.0.0.1:18084/ >/dev/null 2>&1; do
     [ "$(date +%s)" -lt "$deadline" ] || fail "daemon did not become reachable in 120s"
     sleep 2
 done
 
 note "waiting for gateway /health..."
 deadline=$(( $(date +%s) + 60 ))
-until curl -fsS --max-time 3 http://127.0.0.1:8080/health >/dev/null 2>&1; do
+until curl -fsS --max-time 3 http://127.0.0.1:18080/health >/dev/null 2>&1; do
     [ "$(date +%s)" -lt "$deadline" ] || fail "gateway did not become healthy in 60s"
     sleep 2
 done
@@ -57,11 +57,11 @@ note "stack is up — endpoints:"
 cat <<EOF
 
   Dashboard       http://localhost:18000
-  Gateway proxy   http://localhost:8080         (also exposes /metrics)
-  Gateway ctrl    http://localhost:8081
+  Gateway proxy   http://localhost:18080        (also exposes /metrics)
+  Gateway ctrl    http://localhost:18081
   Judge           http://localhost:18082/health (also /metrics)
   NATS bridge     http://localhost:18083/health
-  Daemon API      http://localhost:8084
+  Daemon API      http://localhost:18084
   NATS monitor    http://localhost:8222
 
 EOF


### PR DESCRIPTION
## Summary

Make demo bring-up survive on a developer machine that already runs something on 8080/8081/8084.

## Changes

- docker-compose.demo.yml: 8080→18080, 8081→18081, 8084→18084 host port mapping (in-container ports unchanged)
- scripts/demo.sh: health-probe + endpoint banner updated to use the new host ports
- compose header comment table updated

## Linked Issues

Closes #332

## Test Plan

```bash
docker compose -f docker-compose.demo.yml up -d
sleep 30
docker compose -f docker-compose.demo.yml ps
```

Observed: 7 containers Up.

```bash
for ep in 18000/health 18080/health 18081/ 18082/health 18083/health 18084/; do
  curl -s -o /dev/null -w "%{http_code}\n" --max-time 3 "http://localhost:$ep"
done
```

Observed: 200, 200, 404, 200, 200, 404 (404 are correct: those endpoints have no / route).

## Benchmarks

N/A — port mapping change only.

## Evidence (AC Mapping)

| AC | Verification | Evidence |
|----|--------------|----------|
| AC-1 | Compose stack starts even with 8080 occupied locally | docker compose up succeeds (this PR was discovered when it failed without the fix) |
| AC-2 | All 7 services UP | `docker compose ps` shows nats + 6 sentinel containers |
| AC-3 | Dashboard /api/agents 200 with real data | curl returns JSON with Thomas Mueller etc. |

```bash
# pre-fix (live observation):
$ docker compose up -d
Error response from daemon: failed to bind host port 0.0.0.0:8080/tcp: address already in use

# post-fix:
$ docker compose up -d
[ all 7 containers Healthy ]
```

## Checklist

- [x] Code compiles (compose syntax-validated)
- [x] No new clippy/vet warnings
- [x] CHANGELOG entry deferred (consolidate post-hardening)
- [x] PR body has all 7 required sections