### PR TITLE
fix(make): build-go syntax error + test-dashboard auto-install on fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test: ## Run all tests
 	@echo "=== Go Tests ==="
 	cd cmd/cortex-gateway && go test ./...
 	@echo "=== Dashboard Tests ==="
-	cd dashboard && bun test 2>/dev/null || echo "(no dashboard tests yet)"
+	$(MAKE) test-dashboard
 	@echo "All tests: OK"
 
 test-rust: ## Run Rust tests only
@@ -54,7 +54,11 @@ test-rust: ## Run Rust tests only
 test-go: ## Run Go tests only
 	cd cmd/cortex-gateway && go test ./...
 
-test-dashboard: ## Run Dashboard tests only
+test-dashboard: ## Run Dashboard tests only (auto-installs deps on a fresh clone)
+	@if [ ! -d dashboard/node_modules ]; then \
+		echo "[test-dashboard] dashboard/node_modules missing -> bun install"; \
+		cd dashboard && bun install --frozen-lockfile; \
+	fi
 	cd dashboard && bun test
 
 # ──────────────────────────────────────────────
@@ -98,7 +102,7 @@ demo: demo-image ## Build + run the 10-minute demo stack
 	./scripts/demo.sh
 
 build-go: ## Build Cortex Gateway
-	cd cmd/cortex-gateway && go build -o cortex-gateway ./...
+	cd cmd/cortex-gateway && go build -o cortex-gateway .
 
 build-dashboard: ## Build Dashboard
 	cd dashboard && bun install


### PR DESCRIPTION
## Summary

Two engineer-persona path bugs found by Hardening B2 on a fresh anon clone.

## Changes

- Makefile build-go: '-o cortex-gateway ./...' -> '-o cortex-gateway .' (Go disallows -o with multi-package selector)
- Makefile test-dashboard: precondition checks for dashboard/node_modules, runs 'bun install --frozen-lockfile' if missing
- Makefile test umbrella: dispatches via $(MAKE) test-dashboard so the same auto-install path applies

## Linked Issues

Closes #334

## Test Plan

```bash
PUBUSER=$(mktemp -d)
cd $PUBUSER
git clone --depth 1 https://github.com/silentspike/project-sentinel.git
cd project-sentinel
make build-go
ls -la cmd/cortex-gateway/cortex-gateway
make test-dashboard
```

## Benchmarks

N/A — Makefile fix.

## Evidence (AC Mapping)

| AC | Verification | Evidence |
|----|--------------|----------|
| AC-1 | make build-go produces a binary | ls shows 23 MB cortex-gateway after `go build -o cortex-gateway .` |
| AC-2 | make test-dashboard from clean state pass | 63 pass / 0 fail after auto bun install --frozen-lockfile |

```bash
# observed pre-fix on fresh anon clone:
$ make build-go
cd cmd/cortex-gateway && go build -o cortex-gateway ./...
go: cannot write multiple packages to non-directory cortex-gateway
make: *** [Makefile:101: build-go] Error 1

$ make test-dashboard
cd dashboard && bun test
# Unhandled error between tests
 2 pass, 8 fail, 8 errors

# post-fix:
$ make build-go
cd cmd/cortex-gateway && go build -o cortex-gateway .
$ ls cmd/cortex-gateway/cortex-gateway
-rwxr-xr-x ... 23251027 ... cmd/cortex-gateway/cortex-gateway

$ make test-dashboard
[test-dashboard] dashboard/node_modules missing -> bun install
20 packages installed
63 pass, 0 fail
```

## Checklist

- [x] Code compiles (Makefile syntax-validated)
- [x] No new clippy/vet warnings
- [x] CHANGELOG entry deferred (consolidate post-hardening)
- [x] PR body has all 7 required sections