### PR TITLE
docs(v5-t2): Mermaid architecture diagram + plain-text fallback section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,52 @@ environment:
 
 ## Architecture at a Glance
 
-```
-Deterministic (ECS)            Probabilistic (LLM)
-┌───────────────────┐          ┌────────────────────┐
-│ bevy_ecs World    │          │ Cortex Gateway     │
-│ Bio / Physics     │ ───────> │ 7-step pipeline    │
-│ 60 agent slots    │ <─────── │ Synthesis engine   │
-│ Event Store       │          │ Self-recognition   │
-└───────────────────┘          └────────────────────┘
-         │                              │
-         └────── Event Sourcing ────────┘
-            (sentinel-limbo, append-only)
+```mermaid
+flowchart TB
+  subgraph AGENTS["Agent Layer · 60 LLM personas"]
+    A1["51 shift-bound (3 shifts × 17)"]
+    A2["9 always-on duty staff"]
+  end
+
+  subgraph SANDBOX["Sandbox Stack (per agent)"]
+    S1["bwrap (user-namespaces)"]
+    S2["Landlock LSM"]
+    S3["cgroups v2"]
+    S4["netns + nftables"]
+    S5["Wasmtime (tool runtime)"]
+  end
+
+  subgraph CP["Three Controlplanes — Observe → Decide → Act → Verify"]
+    direction LR
+    AGCP["Agent CP<br/>(bio · perception)"]
+    PLCP["Platform CP<br/>(infra · health)"]
+    APCP["API CP<br/>(cost · routing)"]
+  end
+
+  STORE["Event Store<br/>Limbo SQLite · append-only<br/>Lamport ordering · hash-chain"]
+
+  subgraph GATEWAY["Cortex Gateway (Go)"]
+    G1["7-step proxy + guardrails"]
+    G2["10-rule synthesis engine"]
+  end
+
+  subgraph BRIDGE["Quality + Memory Plane"]
+    J1["Sentinel Judge<br/>(NATS · drift · quality)"]
+    J2["NATS Bridge<br/>(Limbo → JetStream)"]
+    J3["Hippocampus<br/>(NMDA night-run)"]
+  end
+
+  DASH["Dashboard<br/>Bun + Hono + WebSocket"]
+
+  AGENTS -.->|"sandboxed in"| SANDBOX
+  AGENTS -->|prompts| GATEWAY
+  GATEWAY -->|emit events| STORE
+  STORE -->|projections| DASH
+  STORE -->|stream| BRIDGE
+  CP -.->|govern| AGENTS
+  CP -.->|govern| GATEWAY
+  CP -.->|govern| STORE
+  BRIDGE -->|alerts + metrics| DASH
 ```
 
 | Layer            | Tech                                      |
@@ -85,6 +120,9 @@ Deterministic (ECS)            Probabilistic (LLM)
 | Dashboard        | Bun + Hono + vanilla-JS (`dashboard/`)    |
 | Pub/Sub          | Zenoh (Rust SHM <10 µs) + NATS JetStream  |
 | Storage          | redb (state) + Limbo SQLite (events)      |
+
+For a terminal-friendly plain-text view of the same data flow see
+[Architecture Details](#architecture-details) further down.
 
 For per-cluster implementation status see
 [docs/togaf-gap-v22.md](docs/togaf-gap-v22.md).
@@ -238,6 +276,30 @@ caveat list.
 | [CONTRIBUTING.md](CONTRIBUTING.md)                           | How to contribute                             |
 | [SECURITY.md](SECURITY.md)                                   | Reporting vulnerabilities                     |
 | [CHANGELOG.md](CHANGELOG.md)                                 | Release history                               |
+
+## Architecture Details
+
+Plain-text alternative to the [Mermaid diagram above](#architecture-at-a-glance),
+useful for terminal-only viewers and screen-readers. Same data flow, lower
+fidelity:
+
+```
+Deterministic (ECS)            Probabilistic (LLM)
+┌───────────────────┐          ┌────────────────────┐
+│ bevy_ecs World    │          │ Cortex Gateway     │
+│ Bio / Physics     │ ───────> │ 7-step pipeline    │
+│ 60 agent slots    │ <─────── │ Synthesis engine   │
+│ Event Store       │          │ Self-recognition   │
+└───────────────────┘          └────────────────────┘
+         │                              │
+         └────── Event Sourcing ────────┘
+            (sentinel-limbo, append-only)
+```
+
+For full architectural depth (clusters, controlplane internals, deviation
+register) see the
+[TOGAF v22.1 architecture guide](docs/architecture/togaf-architecture-guide.html)
+and the gap report in [docs/togaf-gap-v22.md](docs/togaf-gap-v22.md).
 
 ## Release status
 


### PR DESCRIPTION
## Summary

Plan v5 Task 2 (P1.6). Replaces the small ASCII box-sketch in `## Architecture at a Glance` with a Mermaid flowchart that renders natively on GitHub web. The previous ASCII view is preserved verbatim under a new `## Architecture Details` section as a terminal-friendly fallback.

## Changes

- README.md: Mermaid `flowchart TB` block covering 7 component classes — Agent Layer, Sandbox Stack, three Controlplanes (Agent CP / Platform CP / API CP, each Observe → Decide → Act → Verify), Event Store, Cortex Gateway, Quality + Memory Plane (Judge / NATS Bridge / Hippocampus), Dashboard
- README.md: NEW `## Architecture Details` section with the verbatim ASCII box-sketch and a forward link from the Mermaid section
- Tech-stack table below the Mermaid diagram is unchanged

## Linked Issues

Closes #341

## Test Plan

```bash
# AC-2.1
grep -n '^```mermaid$' README.md
# expected: README.md:67

# AC-2.2: extract block + count component classes
awk '/^```mermaid$/{flag=1; next} /^```$/{if(flag){flag=0}} flag' README.md \
  | grep -oE 'subgraph [A-Z]+|^  [A-Z]+\["' | sort -u
# expected: 5 subgraphs (AGENTS, SANDBOX, CP, GATEWAY, BRIDGE) + 2 plain
# nodes (STORE, DASH) = 7 component classes

# AC-2.3: parse via mmdc
awk '/^```mermaid$/{flag=1; next} /^```$/{flag=0} flag' README.md > /tmp/mermaid-validate/diagram.mmd
cd /tmp/mermaid-validate && npx -y -p @mermaid-js/mermaid-cli mmdc -i diagram.mmd -o diagram.svg
ls -la /tmp/mermaid-validate/diagram.svg
```

## Benchmarks

N/A (docs-only).

## Evidence (AC Mapping)

| AC | Result | Evidence |
|----|--------|----------|
| AC-2.1 | PASS | `grep -n '^\`\`\`mermaid$' README.md` -> `README.md:67` |
| AC-2.2 | PASS | 5 subgraphs + 2 plain nodes = 7 component classes (see commands above) |
| AC-2.3 | PASS | `mmdc -i diagram.mmd -o diagram.svg` produces a 30 KB SVG with no parse error |

```bash
$ npx -y -p @mermaid-js/mermaid-cli mmdc -i /tmp/mermaid-validate/diagram.mmd -o /tmp/mermaid-validate/diagram.svg
Generating single mermaid chart

$ ls -la /tmp/mermaid-validate/diagram.svg
-rw-r--r-- 1 jan jan 30958 Apr 27 13:16 /tmp/mermaid-validate/diagram.svg

$ head -c 200 /tmp/mermaid-validate/diagram.svg
<svg id="my-svg" width="100%" xmlns="http://www.w3.org/2000/svg" ...
```

## Checklist

- [x] AC-2.1 verified
- [x] AC-2.2 verified
- [x] AC-2.3 verified
- [x] No PNG asset committed (audit asks for in-README rendering, no extra binaries; image asset is v5-T5 territory)
- [x] ASCII fallback preserved for terminal viewers / screen-readers