### PR TITLE
ci(v5-t6): add workflow_dispatch to CodeQL for manual re-trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
       - '.github/workflows/codeql.yml'
   schedule:
     - cron: '0 4 * * 3'  # Wednesday 04:00 UTC
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Plan v5 Task 6 (P2-8/P2-10). One-line CodeQL workflow change: add `workflow_dispatch: {}` so post-public-flip the badge can be greened without waiting for the Wednesday cron, and so security-ops have a manual re-trigger path going forward.

## Changes

- `.github/workflows/codeql.yml`: append `workflow_dispatch: {}` to the `on:` block

## Linked Issues

Closes #349

## Test Plan

```bash
gh workflow view codeql.yml | head -10
# expected: workflow_dispatch trigger listed

gh run list --workflow codeql.yml --branch main --limit 1
# expected: triggered automatically by this merge (paths-filter includes
# .github/workflows/codeql.yml); conclusion=success after completion
```

## Benchmarks

N/A (CI change).

## Evidence (AC Mapping)

| AC | Result | Evidence |
|----|--------|----------|
| AC-1 | PASS-after-merge | `workflow_dispatch: {}` present at line ~24 of codeql.yml |
| AC-2 | TBD | first post-merge run will be visible via `gh run list --workflow codeql.yml --branch main --limit 1` |

```bash
$ git diff .github/workflows/codeql.yml
+  workflow_dispatch: {}
```

## Checklist

- [x] One-line change, scoped to `on:` block
- [x] No CodeQL configuration semantics changed (build-mode, queries, paths-filter unchanged)
- [x] Self-triggers a CodeQL run on merge via paths-filter (no extra dummy commit needed)