### PR TITLE
docs(v6-stage-1): customer-tone reframe — Hero + persona-lore in docs/ + status 4-col + badges 9->6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,36 @@
 # Project Sentinel
 
 [![CI](https://github.com/silentspike/project-sentinel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/ci.yml)
-[![Coverage](https://github.com/silentspike/project-sentinel/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/coverage.yml)
 [![CodeQL](https://github.com/silentspike/project-sentinel/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/codeql.yml)
-[![Supply Chain](https://github.com/silentspike/project-sentinel/actions/workflows/deny.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/deny.yml)
 [![OSSF Scorecard](https://github.com/silentspike/project-sentinel/actions/workflows/scorecard.yml/badge.svg?branch=main)](https://github.com/silentspike/project-sentinel/actions/workflows/scorecard.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/silentspike/project-sentinel?include_prereleases&label=release)](https://github.com/silentspike/project-sentinel/releases)
-[![Rust 1.93+](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org)
-[![Go 1.26+](https://img.shields.io/badge/go-1.26%2B-blue.svg)](https://go.dev)
+[![Stack: Rust 1.93+ / Go 1.26+](https://img.shields.io/badge/stack-rust%201.93%2B%20%2F%20go%201.26%2B-orange.svg)](#)
 
-**A research testbed for runtime hardening, controlplane design, and LLM agent
-boundary detection.** Sixty LLM-persona agents run a synthetic office workload
-under strict sandbox isolation. The simulated office is the *evaluation
-context*; the platform underneath is the work.
+A reference testbed for runtime governance of LLM coding agents.
 
-## What It Is
+When teams put LLM agents into real workflows, three operational questions
+come back:
 
-A platform that runs sandboxed agent workloads end-to-end. Two layers:
+- How are they sandboxed?
+- How are their actions audited?
+- What happens when something goes wrong?
 
-**Platform layer — 5 background services** (Rust + Go) that own the runtime:
+Project Sentinel makes those questions concrete. It runs a synthetic
+office workload — sixty personas across three shifts, with real LLM calls —
+and underneath it the runtime layer an organization would actually
+operate: per-agent sandboxing (bwrap + Landlock + cgroups + netns),
+event-sourced audit trails, three independent control planes, and a
+9/9-passing breakout test report.
 
-- `sentinel-daemon` — ECS world, tick loop, persistence, agent runtime
-- `cortex-gateway` — LLM proxy, synthesis engine, controlplane
-- `sentinel-judge` — quality + drift monitoring, NATS streaming
-- `sentinel-nightrun` — nightly batch consolidation, deterministic replay
-- `sentinel-nats-bridge` — eBPF metrics dual-publish
+The full stack is documented as a TOGAF v22.1 architecture and runs on a
+provisioned VM. The included docker demo is a deliberate behavioral
+subset: it shows the workload and dashboard, but not the kernel-bound
+parts (eBPF, Landlock, FUSE) that need a real host.
 
-Each agent process runs inside its own **sandbox stack** (bwrap user
-namespaces + Landlock LSM + cgroups v2 + netns + nftables + Wasmtime tool
-runtime). The sandbox enforcement is the load-bearing primitive — see
-[security test report](docs/security-test-report.md) (9/9 breakout tests
-pass on a privileged host).
-
-**Workload layer — 60 LLM-persona agents** that exercise the platform:
-autonomous entities with distinct personality profiles, role assignments,
-and bio-driven state (hunger, caffeine, fatigue, social need). Staffed as
-**51 on a 3-shift rotation (17 per shift)** + **9 always-on duty staff**.
-Approximately 26 agents are active at any given moment. See
-[Research Context](#research-context) for the personality model and role
-taxonomy.
-
-The simulated office is the evaluation context for stress-testing runtime
-hardening primitives, agent control loops, and boundary detection. The
-platform underneath is the work.
-
-See the [TOGAF Architecture Guide](docs/architecture/togaf-architecture-guide.html)
-(v22.1) for cluster-level detail.
+[Architecture Guide (TOGAF v22.1)](docs/architecture/togaf-architecture-guide.html) ·
+[Sandbox Test Report (9/9)](docs/security-test-report.md) ·
+[Demo](#demo-one-command)
 
 ## Why It Exists
 
@@ -229,25 +213,32 @@ For the full stack with sandbox enforcement see
 
 ## Status — what works in this alpha, what doesn't yet
 
-| Area | Status |
-|------|--------|
-| ECS world (bevy_ecs), bio + physics + room sim                   | ✅ implemented + exercised in demo |
-| Event sourcing (Limbo SQLite, idempotent, replayable)            | ✅ implemented + exercised in demo |
-| Cortex Gateway 7-step pipeline + 10-rule synthesis engine        | ✅ implemented + exercised in demo |
-| Dashboard (Bun + Hono + WebSocket)                               | ✅ implemented + exercised in demo |
-| sentinel-judge quality + drift monitoring (NATS streaming)       | ✅ implemented + exercised in demo |
-| sentinel-projection CQRS read-models                             | ✅ implemented + exercised in demo |
-| sentinel-nightrun batch consolidation, deterministic replay      | ✅ implemented, manual trigger only |
-| 60 LLM-persona agents (`config/agents/AGENT-*.toml`)             | ✅ defined; demo runs a 5-agent subset |
-| **bwrap + Landlock per-agent isolation**                         | ✅ implemented (`crates/sentinel-sandbox/`); 9/9 breakout tests pass on a privileged host; **not exercised in the docker demo** |
-| **cgroups v2 per-agent caps + netns + nftables**                 | ✅ implemented; same caveat |
-| **eBPF probes (aya-rs)** + **sentinel-fs CAS-FUSE**              | ✅ implemented; same caveat |
-| TOGAF v22.1 architecture guide + per-cluster gap report          | ✅ shipped in `docs/architecture/` |
-| Pre-built demo binaries (linux-x86_64) on every release          | ✅ since v0.1.0-alpha |
-| Tag verified-badge on GitHub                                     | ⏳ pending maintainer's SSH signing-key registration; tag itself carries valid Ed25519 signature |
-| CodeQL pipeline live status                                      | ⏳ green only after first scheduled run post-public-flip (GHAS gating) |
-| Demo binaries for arm64 / Apple Silicon                          | ⏳ planned (currently linux-x86_64 only) |
-| Multi-tenant company configs ("Gaia firmen-konfigurator")        | ⏳ tracked as roadmap issue |
+Kernel-bound features are **not missing** — they are *implemented + tested
+but not deploy-able in the docker demo*. The VM deploy is the production
+target; the docker demo is a deliberate behavioral subset.
+
+| Area | Status | Demo-Container | VM-Deploy |
+|------|--------|----------------|-----------|
+| ECS world (bevy_ecs), bio + physics + room sim | ✅ implemented + exercised | yes | yes |
+| Event sourcing (Limbo SQLite, idempotent, replayable) | ✅ implemented + exercised | yes | yes |
+| Cortex Gateway 7-step pipeline + 10-rule synthesis engine | ✅ implemented + exercised | yes | yes |
+| Dashboard (Bun + Hono + WebSocket) | ✅ implemented + exercised | yes | yes |
+| sentinel-judge quality + drift monitoring (NATS streaming) | ✅ implemented + exercised | yes | yes |
+| sentinel-projection CQRS read-models | ✅ implemented + exercised | yes | yes |
+| sentinel-nightrun batch consolidation, deterministic replay | ✅ implemented, manual trigger | yes | yes |
+| **bwrap + Landlock per-agent isolation** | ✅ implemented + 9/9 breakout-tested (`crates/sentinel-sandbox/`) | **no (kernel-caps)** | **yes** |
+| **cgroups v2 per-agent caps** | ✅ implemented | **no (kernel-caps)** | **yes** |
+| **netns + nftables agent network** | ✅ implemented | **no (kernel-caps)** | **yes** |
+| **eBPF probes (aya-rs)** | ✅ implemented | **no (kernel-caps)** | **yes** |
+| **sentinel-fs CAS-FUSE** | ✅ implemented | **no (FUSE)** | **yes** |
+| TOGAF v22.1 architecture guide + per-cluster gap report | ✅ shipped in `docs/architecture/` | n/a | n/a |
+| 60 LLM-persona agents (`config/agents/AGENT-*.toml`) | ✅ defined; demo runs a 5-agent subset | partial (5/60) | yes (full 60) |
+| Pre-built demo binaries (linux-x86_64) on every release | ✅ since v0.1.0-alpha | yes | yes |
+| CodeQL pipeline | ✅ green on main | n/a | n/a |
+| Tag verified-badge on GitHub | ✅ verified=true (Ed25519) | n/a | n/a |
+| OpenGraph social-preview image | ⏳ image in repo (`docs/images/opengraph-preview.png`); upload via repo Settings → Social preview pending (#351) | n/a | n/a |
+| Demo binaries for arm64 / Apple Silicon | ⏳ planned (currently linux-x86_64 only) | n/a | n/a |
+| Multi-tenant company configs ("Gaia firmen-konfigurator") | ⏳ tracked as roadmap issue (#266) | n/a | n/a |
 
 See [docs/known-limitations.md](docs/known-limitations.md) for the full
 caveat list.
@@ -327,25 +318,10 @@ for the per-feature picture.
 
 ## Research Context
 
-The simulated workload draws on a fictional employer named **PixelPerfekt
-GmbH** — a synthetic web design agency that exists only inside the
-simulation. The narrative framing (industry, organizational structure,
-location, roster) is a Truman-Show-style agent-belief experiment: agents are
-evaluated against a coherent, believable reality rather than a stub
-environment. This is a research convention, not a product claim. **The
-company does not exist outside the configs**; any resemblance to real
-organizations is coincidental.
-
-| Aspect | Implementation |
-|--------|----------------|
-| Personality model      | Big Five (OCEAN) per agent (`config/agents/AGENT-*.toml`) |
-| Role taxonomy          | developer, designer, management, works council, occupational psychologist, occupational physician, medical, ops |
-| Schedule               | 3-shift rotation (17 per shift) + 9 always-on duty staff (works council, occupational psychologist, occupational physician) |
-| Narrative anchor       | `config/company-context.md` |
-| Boundary research aim  | when does an agent surface awareness markers, and can a synthesis layer intercept routine perceptions before a real LLM call? |
-
-For detailed agent rosters, role definitions, and the narrative convention
-see [docs/glossary.md](docs/glossary.md).
+The synthetic office workload is a deliberate stress-test for the runtime
+layer. The personality model, role taxonomy, and bio-state mechanism are
+documented in [docs/research-context.md](docs/research-context.md). The
+platform underneath is the work; the workload is the evaluation.
 
 ## License
 

--- a/docs/research-context.md
+++ b/docs/research-context.md
@@ -1,0 +1,131 @@
+# Research Context
+
+> The synthetic office workload that runs on top of Project Sentinel is a
+> deliberate stress-test for the runtime layer. This document collects the
+> personality model, role taxonomy, bio-state mechanism, and the
+> ethical/research framing.
+>
+> **The platform underneath is the work; the workload is the evaluation.**
+> If you are evaluating Sentinel as a runtime, the
+> [Architecture Guide](architecture/togaf-architecture-guide.html) and the
+> [Sandbox Test Report](security-test-report.md) are the primary documents.
+
+---
+
+## Why this workload was chosen as the stress-test
+
+Three properties make a 60-agent persona simulation a useful stress test
+for an agent runtime:
+
+1. **Concurrent sandbox lifetimes.** ~26 agents tick simultaneously per
+   shift (17 shift-bound + 9 always-on duty staff). That exercises the
+   per-agent sandbox stack at realistic concurrency, not at toy scale.
+2. **Heterogeneous workloads.** Different roles produce different I/O,
+   memory and CPU patterns. The runtime sees a real distribution of
+   behaviors instead of one synthetic benchmark.
+3. **Long-lived state.** Bio-state (hunger, caffeine, fatigue, social
+   need) accumulates across ticks, which forces the event store, the
+   projection layer, and the night-run consolidation pipeline to handle
+   real append-only volume rather than a flat dataset.
+
+The persona narrative (industry, location, employer name) is a research
+convention to keep agent prompts coherent across many ticks. It is **not**
+a product claim about the runtime.
+
+---
+
+## Personality model — Big Five (OCEAN)
+
+Each agent carries a five-dimensional OCEAN vector
+(Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism)
+in `config/agents/AGENT-*.toml`. The vector is fed to the prompt compiler
+as an `agent-identity` system block at every LLM call, so role-consistent
+behavior is a property of the persona, not of the prompt template.
+
+## Role taxonomy
+
+Eight role categories cover the persona pool:
+
+| Role | Count |
+|------|-------|
+| developer       | majority of shift-bound staff |
+| designer        | a smaller per-shift contingent |
+| management      | head-of-X roles, one per shift |
+| works council   | always-on duty (3, one per shift handover) |
+| occupational psychologist | always-on duty (3) |
+| occupational physician    | always-on duty (3) |
+| medical         | shift-rotated nurse-equivalent |
+| ops             | platform operator role |
+
+Counts per role are derived from `config/agents/AGENT-*.toml`.
+
+## Schedule — three shifts plus always-on duty
+
+| Set | Hours | Count | Notes |
+|-----|-------|-------|-------|
+| Set 1 (early) | 06:00 – 13:59 | 17 | full role mix |
+| Set 2 (mid)   | 14:00 – 21:59 | 17 | same role distribution as Set 1 |
+| Set 3 (late)  | 22:00 – 05:59 | 17 | same role distribution as Set 1 |
+| Set 0 (24/7)  | always-on | 9 | 3 works council + 3 occupational psychologist + 3 occupational physician |
+
+Approximately 26 personas are active at any given moment (one shift + the
+always-on duty pool).
+
+## Bio-state mechanism
+
+Six differential equations in `crates/sentinel-bio/` track per-agent
+state across ticks: `hunger`, `energy`, `caffeine`, `bladder`, `stress`,
+`social need`. The values feed into the perception block of the next LLM
+call, so an agent that has not eaten for many ticks reports hunger as a
+real internal sensation rather than as out-of-band metadata.
+
+This matters for the runtime evaluation because it produces realistic
+churn in event-store volume, projection lag, and synthesis-engine
+intercept rate — all things a runtime operator would care about.
+
+## Self-Recognition Pattern Detection
+
+The Cortex Gateway includes a 15-pattern regex set plus a two-stage LLM
+judge in `cmd/cortex-gateway/internal/detection/`. It fires when an agent
+response surfaces awareness of being a simulation (e.g., "I am an AI", "as
+an LLM"). On a hit, the response is regenerated. The detector is
+documented (with the legacy "Fourth-Wall Detection" anchor preserved) in
+[docs/glossary.md](glossary.md#fourth-wall-detection).
+
+The synthesis engine sits in front of the detector and intercepts ~70% of
+routine perceptions before they reach a real LLM call, which is what
+keeps the per-tick LLM cost of a 60-persona simulation tractable.
+
+---
+
+## What this workload models
+
+- Concurrent agent lifetimes under a real per-agent sandbox
+- Long-lived event sourcing under realistic state churn
+- Cross-role interaction patterns (hierarchy, role-conflict, hand-over)
+- The cost of synthesis vs real LLM calls at scale
+
+## What this workload does NOT model
+
+- Real customer environments — the persona narrative is fiction by design
+- Real coding tasks — agents do not write production code
+- Performance against an SLA — no latency or throughput guarantees
+- Multi-tenant company configs — single-tenant for this release
+
+## Ethical and research framing
+
+The persona narrative — including the fictional employer name
+(**PixelPerfekt GmbH**), the industry framing, and the synthetic role
+roster — is a research convention used to keep agent prompts coherent
+across many ticks. **The company does not exist outside the configs.**
+Any resemblance to real organizations is coincidental.
+
+The narrative framing has been described as Truman-Show-style elsewhere:
+agents are evaluated against a coherent, believable reality rather than
+a stub environment. This is a research convention, not a product claim.
+
+For detailed agent rosters and role definitions see
+[docs/glossary.md](glossary.md). For the architecture context that this
+workload exercises see the
+[TOGAF v22.1 Architecture Guide](architecture/togaf-architecture-guide.html)
+and the [per-cluster gap report](togaf-gap-v22.md).


### PR DESCRIPTION
## Summary

Plan v6 Stage 1 (Quick Wins). Audit v2 Sprint Page-4 "Runtime"-Pfeiler. User-Direktive D-4: 60 personas bleiben (real), TOGAF v22.1 als Production-Truth, Docker-Demo als ehrlich-eingeschraenktes Behavioral-Subset, Customer-Tone NICHT Engineer-Tone.

Vier Stage-1-Subtasks in einem PR (statt 4 separate):

- **S1.1** README-Hero auf Customer-Question-First (3 operationale Fragen)
- **S1.2** Persona-Lore in `docs/research-context.md` verbannt (README-Section auf 5-Zeilen-Verweis)
- **S1.4** Status-Tabelle 4-Spalten (Area/Status/Demo-Container/VM-Deploy) + Drift-Fix (CodeQL ✅, Tag-verified ✅)
- **S1.5** Badges 9 -> 6 (CI/CodeQL/OSSF/License/Release/Stack)

## Changes

- `README.md` — hero replaced (-37 / +24 Zeilen), Status-Tabelle umstrukturiert, Research Context auf Verweis, Badges reduziert
- `docs/research-context.md` (NEU, 131 Zeilen) — Personality, Roles, Schedule, Bio-State, Self-Recognition Pattern, "what models / does NOT model", Ethik

## Linked Issues

Closes #355

## Test Plan

\`\`\`bash
# AC-1.1.1
head -40 README.md
# expect: 3 questions + 3 links (TOGAF, Sandbox-Test-Report, Demo)

# AC-1.1.2 multi-line
sed -z 's/\n/ /g' README.md | grep -oE "deliberate behavioral subset"
# expect: 1 hit

# AC-1.1.3
grep -c "research testbed for runtime hardening" README.md
# expect: 0

# AC-1.2.1
wc -l docs/research-context.md
# expect: 131 (>= 80)

# AC-1.2.3 (most important)
git grep -nE "hunger|caffeine|fatigue|social need|works council|occupational physician|Big Five|OCEAN|17 per shift" README.md
# expect: 0 hits

# AC-1.4.1
grep "^| Area | Status | Demo-Container | VM-Deploy |" README.md
# expect: 1 hit

# AC-1.4.3 drift fix
grep "CodeQL pipeline\\|Tag verified-badge" README.md
# expect: both rows show ✅

# AC-1.5.1
head -20 README.md | grep -cE "img.shields.io|badge.svg"
# expect: 6
\`\`\`

## Benchmarks

N/A (docs-only).

## Evidence (AC Mapping)

| AC | Result | Evidence |
|----|--------|----------|
| AC-1 (S1.1.1) | PASS | head -40 zeigt 3 Fragen + Architecture/Sandbox/Demo Links |
| AC-2 (S1.1.2) | PASS | sixty personas (1x), TOGAF v22.1 (4x), deliberate behavioral subset (1x multi-line via sed -z) |
| AC-3 (S1.1.3) | PASS | grep "research testbed for runtime hardening" returns 0 |
| AC-4 (S1.2.1) | PASS | wc -l docs/research-context.md -> 131 |
| AC-5 (S1.2.2) | PASS | section auf 5 Zeilen mit Verweis auf docs/research-context.md |
| AC-6 (S1.2.3) | PASS | git grep returns 0 fuer alle 9 Persona-Patterns |
| AC-7 (S1.4.1) | PASS | header `\| Area \| Status \| Demo-Container \| VM-Deploy \|` |
| AC-8 (S1.4.2) | PASS | 5 Kernel-Bound-Rows mit "no (kernel-caps)" / "yes" Bold |
| AC-9 (S1.4.3) | PASS | CodeQL ✅ + Tag-verified ✅ in Tabelle |
| AC-10 (S1.4.4) | PASS | Vorrede "Kernel-bound features are not missing" vorhanden |
| AC-11 (S1.5.1) | PASS | head -20 grep returns 6 (war 9) |
| AC-12 (S1.5.2) | PASS | exakte Reihenfolge CI/CodeQL/OSSF/License/Release/Stack |
| AC-13 (S1.5.3) | PASS | gh workflow list zeigt Coverage + Supply Chain = active |

\`\`\`bash
\$ head -40 README.md | tail -25
A reference testbed for runtime governance of LLM coding agents.

When teams put LLM agents into real workflows, three operational questions
come back:

- How are they sandboxed?
- How are their actions audited?
- What happens when something goes wrong?
...
[Architecture Guide (TOGAF v22.1)](docs/architecture/togaf-architecture-guide.html) ·
[Sandbox Test Report (9/9)](docs/security-test-report.md) ·
[Demo](#demo-one-command)

\$ git grep -nE "hunger|caffeine|fatigue|social need|works council|occupational physician|Big Five|OCEAN|17 per shift" README.md
(empty)

\$ wc -l docs/research-context.md
131 docs/research-context.md

\$ head -20 README.md | grep -cE "img.shields.io|badge.svg"
6
\`\`\`

## Checklist

- [x] AC-1 to AC-13 verified
- [x] D-4 compliance: 60 personas bleiben, TOGAF Production-Truth, Demo eingeschraenkt-ehrlich, Customer-Tone
- [x] CC-1 Authentizitaet: kein OpenAI-Tilt, tool-agnostisch
- [x] Coverage + Supply-Chain Workflows weiter aktiv (nur Header-Badges entfernt)
- [x] Anchor backward-compat: kein Anchor auf #what-it-is gefunden vor Loeschung
- [x] Demo-Anchor #demo-one-command verifiziert (### Demo (one command) an L176)