### PR TITLE
docs(v6-stage-3): add Development methodology footer to CONTRIBUTING.md (CC-6 cautious)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,3 +94,9 @@ deploy/              VM configuration
 
 - See `docs/private-repo-guardrails.md` for the full private-repo enforcement model
 - Direct push to `main` is blocked locally by pre-push hook and monitored in CI
+
+## Development methodology
+
+Project Sentinel is developed using AI coding agents (Codex, Claude Code,
+Gemini CLI). The runtime governance work in this repo informs how those
+tools should be sandboxed.


### PR DESCRIPTION
## Summary

Plan v6 Stage 3 (Polish). Audit v2 CC-6 places the Built-with hint on sentinel as **vorsichtig** — only in CONTRIBUTING.md, not in README. This commit follows the constraint exactly.

## Changes

- `CONTRIBUTING.md` — new `## Development methodology` section at the end (3 lines), names Codex / Claude Code / Gemini CLI tool-agnostically, frames around runtime sandboxing (no persona-frame amplification)

## Linked Issues

Closes #361

## Test Plan

\`\`\`bash
grep -A 5 "## Development methodology" CONTRIBUTING.md
# expect: section + 3-line wording

grep -cE "AI coding agents|Built with|Codex.*Claude Code" README.md
# expect: 0 (CC-6 prohibits README-prominent)
\`\`\`

## Benchmarks

N/A (docs).

## Evidence (AC Mapping)

| AC | Result | Evidence |
|----|--------|----------|
| AC-1 | PASS | `## Development methodology` section at CONTRIBUTING.md end |
| AC-2 | PASS | grep README returns 0 for built-with patterns |
| AC-3 | PASS | self-review: 3 lines, sandbox context, no persona reference, no codex-tilt |

\`\`\`bash
\$ grep -A 5 "## Development methodology" CONTRIBUTING.md
## Development methodology

Project Sentinel is developed using AI coding agents (Codex, Claude Code,
Gemini CLI). The runtime governance work in this repo informs how those
tools should be sandboxed.

\$ grep -cE "AI coding agents|Built with|Codex.*Claude Code" README.md
0
\`\`\`

## Checklist

- [x] AC-1 to AC-3 verified
- [x] CC-6 compliance (sentinel-vorsichtig, only CONTRIBUTING.md)
- [x] CC-1 Authentizitaet: tool-agnostisch (Codex + Claude Code + Gemini CLI), kein OpenAI-Tilt