### PR TITLE
perf: optimize issue 276 ECS tick-loop hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Optimized Issue #276 ECS tick-loop hot paths: reusable room-physics and persist workspaces, perception buffer reuse, and batched Limbo event/outbox writes. Deploy-VM benchmarks on Intel i7-3930K show relative improvements of 26.86% physics, 26.34% perception, 52.57% persist e2e, 86.95% persist write-only, and 17.23% full tick.
 - Excluded `sentinel-gateway` from daemon platform-controlplane `monitored_services` in the deployment config so benchmark and smoke runs can keep the gateway stopped without self-heal restarts.
+- Updated optional `sentinel-wasm` Wasmtime dependencies to 44.0.2 to clear current RustSec advisories.
 
 ### Added
 - Added dashboard exposure for Issue #276 benchmark evidence at `/api/metrics/benchmarks`, including hardware scope, relative-only comparison notes, and system-metric log labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Optimized Issue #276 ECS tick-loop hot paths: reusable room-physics and persist workspaces, perception buffer reuse, and batched Limbo event/outbox writes. Deploy-VM benchmarks on Intel i7-3930K show relative improvements of 26.86% physics, 26.34% perception, 52.57% persist e2e, 86.95% persist write-only, and 17.23% full tick.
+- Excluded `sentinel-gateway` from daemon platform-controlplane `monitored_services` in the deployment config so benchmark and smoke runs can keep the gateway stopped without self-heal restarts.
+
+### Added
+- Added dashboard exposure for Issue #276 benchmark evidence at `/api/metrics/benchmarks`, including hardware scope, relative-only comparison notes, and system-metric log labels.
+
 ## [0.1.0-alpha] - 2026-04-26
 
 First public release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "concurrent-queue",
  "derive_more",
  "fixedbitset 0.5.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "nonmax",
  "serde",
@@ -495,7 +495,7 @@ dependencies = [
  "erased-serde",
  "foldhash 0.2.0",
  "glam",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "smallvec",
  "smol_str",
@@ -512,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "067af30072b1611fda1a577f1cb678b8ea2c9226133068be808dd49aac30cef0"
 dependencies = [
  "bevy_macro_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -578,15 +578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +637,7 @@ dependencies = [
  "lazy_static",
  "pretty-hex",
  "rand 0.9.4",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
 ]
 
 [[package]]
@@ -659,7 +650,7 @@ dependencies = [
  "either",
  "getrandom 0.3.4",
  "rand_core 0.9.5",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
 ]
 
 [[package]]
@@ -755,7 +746,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -784,7 +775,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -1075,36 +1066,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b242b4c3675139f52f0b55624fb92571551a344305c5998f55ad20fa527bc55"
+checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499715f19799219f32641b14f2a162f91e50bc1b61c2d2184c2be971716f5c56"
+checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebca2ea7c62c56feb88a5b23ec380460fe6d7c18134520f6ddf4bfa35cbea68"
+checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe11f154b62d7421d909503a746e89995393b1b71926e6f12b08a2076396d7fb"
+checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1113,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2d0da3d51979dc0183fac3076a535477eab794716b063143ecb16632408664"
+checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1127,7 +1119,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "libm",
  "log",
  "pulley-interpreter",
@@ -1141,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b2c94a1b7f6fba0714387ba34ca56d114b2214a80be018acbb2ed40e09a1e"
+checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1154,24 +1146,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4aae718c336a52d90d4ebe9a2d8c3cf0906a4bee78f0e6867e777eebbe554fe"
+checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
 
 [[package]]
 name = "cranelift-control"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18e94519070dc56cddb71906a08cea6a28a1d7c58ed501b88f273fa6b45fa07"
+checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ab4e0eff1045ff2f5ddd8195bf3c97d7b5ef9b780cb044e0cce76e4d352057"
+checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1181,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7645a236e1ec49e660f09ec9fa979a1c5d0b612c419db7610573d4d58a03b7c"
+checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1193,15 +1185,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e0b4a1a0ea01cc19084ff01aaeb640dfe22905d47d83037a419b81ba587ed0"
+checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdec40b396eb630ecfb0e7a81766d7287f464a7631b9eb5862f7711f1020012"
+checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1210,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.129.2"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a001a9dc4557d9e2be324bc932621c0aa9bf33b74dfefa2338f0bf8913329"
+checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
 
 [[package]]
 name = "crc32fast"
@@ -1690,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1752,7 +1744,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1846,7 +1838,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2042,7 +2034,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -2118,7 +2110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -2132,6 +2123,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2435,20 +2435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro 0.6.0",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,12 +2447,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2500,7 +2486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2553,7 +2539,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3078,25 +3064,25 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -3249,7 +3235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3260,7 +3246,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3523,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59a11b64c166a6e1e990303f46a255a52fb4e84d175dbd5e5ca0428e8c02ce"
+checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3535,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823a9d8da391be21a5f4d5e11c39d15f45b011076c6825fc2323f7e4753f09ce"
+checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3598,7 +3584,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3673,15 +3659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3775,13 +3752,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
  "smallvec",
@@ -3979,7 +3956,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3992,7 +3969,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4069,7 +4046,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4627,7 +4604,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4654,7 +4631,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4772,16 +4749,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"
@@ -4983,7 +4950,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -5003,7 +4970,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5256,7 +5223,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5271,7 +5238,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -5310,7 +5277,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -5321,7 +5288,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -5798,22 +5765,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.244.0"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cda9c76ca8dcac01a8b497860c2cb15cd6f216dc07060517df5abbe82512ac"
+checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
 dependencies = [
  "anyhow",
  "heck",
- "im-rc",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph 0.6.5",
- "serde",
- "serde_derive",
- "serde_yaml",
  "smallvec",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wat",
 ]
 
@@ -5829,12 +5792,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.250.0",
 ]
 
 [[package]]
@@ -5844,7 +5817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -5857,38 +5830,50 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.250.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
 dependencies = [
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.244.0"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66806cf6094768e227f74d209eb017cc967276c94fea478e62a0dffede2b3d0d"
+checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -5905,7 +5890,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.37.3",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -5919,8 +5904,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -5939,28 +5924,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d3611be7991cba09f14dbb99fe7a0fbaca9eb995ab5c548456eeda44afe20e"
+checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "log",
- "object 0.37.3",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -5968,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2407af12566ff8d537b1a978eccaa087cc4c6d1f13fa57d21114a8def8bfe8a3"
+checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
 dependencies = [
  "base64",
  "directories-next",
@@ -5988,9 +5975,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3616cebe594e6c4b573ddb908d2703d13b53b2abdaeb73acd1ca8b5a911bc256"
+checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5998,30 +5985,32 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61571112f9cbf9798e48f3bd6ba5161588a08b99158585153784e3f46f955053"
+checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7c68311d6220c20cefdf334e0c8021e16a050383c67edc5be42e5661ddf265"
+checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
 dependencies = [
  "anyhow",
+ "hashbrown 0.16.1",
  "libm",
+ "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fd90a9113379260508193bab9f4e870d34078fdd181f9fc8dd053b0f7a958c"
+checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6032,12 +6021,12 @@ dependencies = [
  "gimli",
  "itertools 0.14.0",
  "log",
- "object 0.37.3",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -6046,9 +6035,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd95ecd37e62eaae686256ca9773902b73c0398c2eb8cfbca49fbf950609c22"
+checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
 dependencies = [
  "cc",
  "cfg-if",
@@ -6061,21 +6050,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b875a7727c043a308c81f2de5ce7260b7513cb5baaa2af32937646b8c9019a3f"
+checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
 dependencies = [
  "cc",
- "object 0.37.3",
+ "object 0.39.1",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52c0779e711777b915d017b3f54049e658057a77df99e0e7958406b3c5d7d07"
+checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6085,22 +6074,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb031b1e9700667b3f818235b2846e3babeb30bc340c8233d3fad4c44d80ff"
+checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object 0.37.3",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfbbfdb0cfd638145b0de4d3e309901ccc4e29965a33ca1eb18ab6f37057350"
+checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6109,16 +6098,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4853af4a25f98c039cc27c7238e40df9ec783fc7981b879a813153d1d3211a"
+checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
- "object 0.37.3",
+ "object 0.39.1",
  "target-lexicon",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -6126,22 +6115,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de1c8eaa54b17e3a64b6c0cfabd065bdbdfd06f5d7c685272b7309117377be0"
+checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
- "indexmap 2.13.0",
- "wit-parser",
+ "indexmap 2.14.0",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e144a12c39adabd2ce1f7b52bd12a60286d3010044ed0d1c2ae52e35fd6f5ce"
+checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -6169,9 +6158,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609666ef67a53449ea6c1c529541a8af24f3b109d9f627255c0b848c58b824b0"
+checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6191,24 +6180,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "250.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.250.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.250.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
 dependencies = [
- "wast 245.0.1",
+ "wast 250.0.0",
 ]
 
 [[package]]
@@ -6275,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bbdfe34fac0937e887fd0b3b9266b775c1fff8cd2e3f80ffa5d67b35bfa7cb"
+checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -6289,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7316746ac77a917a33ccc0cee6794bd72e300f2f533c28b8d5738f1f5fa29f"
+checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6303,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f625d05adeddad85c8d5fbcd765a8ecf1b22260840a0a193125dc4ab06ac9d"
+checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6335,7 +6324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6346,9 +6335,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "42.0.2"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1bc7cbb9103e6847042f0514f911126263173f6e9a18e5cfa257d3b5711c09"
+checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -6357,7 +6346,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -6678,7 +6667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6698,7 +6687,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -6709,7 +6698,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6740,7 +6729,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6748,7 +6737,7 @@ dependencies = [
  "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -6759,7 +6748,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6767,6 +6756,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]

--- a/cmd/cortex-gateway/go.mod
+++ b/cmd/cortex-gateway/go.mod
@@ -2,7 +2,7 @@ module github.com/silentspike/project-sentinel/cmd/cortex-gateway
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/config/daemon.toml
+++ b/config/daemon.toml
@@ -75,6 +75,7 @@ memory_pressure_threshold = 0.9  # 90% cgroup Memory
 max_escalation = 3             # Max Eskalationsstufen
 write_anomaly_threshold_bytes_per_sec = 5000000  # 5 MB/s
 write_anomaly_cooldown_ticks = 60
+monitored_services = ["sentinel-judge", "sentinel-projection"]
 service_check_interval_secs = 60
 llm_enabled = true
 llm_analysis_interval_secs = 300

--- a/crates/sentinel-ecs/Cargo.toml
+++ b/crates/sentinel-ecs/Cargo.toml
@@ -33,3 +33,7 @@ toml = { workspace = true }
 [[bench]]
 name = "room_phase2_bench"
 harness = false
+
+[[bench]]
+name = "tick_loop_hotpath_bench"
+harness = false

--- a/crates/sentinel-ecs/benches/room_phase2_bench.rs
+++ b/crates/sentinel-ecs/benches/room_phase2_bench.rs
@@ -102,6 +102,17 @@ const TRANSIT_SPECS: &[TransitSpec] = &[
 ];
 
 fn config_path() -> PathBuf {
+    if let Ok(repo_root) = std::env::var("SENTINEL_REPO_ROOT") {
+        return Path::new(&repo_root).join("config/rooms.toml");
+    }
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        let candidate = current_dir.join("config/rooms.toml");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()

--- a/crates/sentinel-ecs/benches/tick_loop_hotpath_bench.rs
+++ b/crates/sentinel-ecs/benches/tick_loop_hotpath_bench.rs
@@ -1,0 +1,228 @@
+//! Issue #276 hot-path benchmarks for ECS tick-loop allocation work.
+//!
+//! These benchmarks isolate the two ECS-side allocation hotspots:
+//! - `physics_system` room aggregation for 26 active agents
+//! - `generate_perception` text generation for 26 active agents
+//!
+//! Build with `cargo remote -c -- build -p sentinel-ecs --benches`.
+//! Run on the deployment VM or one consistent local machine, never on the
+//! cargo-remote build server.
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use sentinel_common::room::BuildingConfig;
+use sentinel_common::{AgentId, Tick};
+use sentinel_ecs::systems::physics_system;
+use sentinel_ecs::world::ROOM_IDS;
+use sentinel_ecs::{
+    create_simulation_world, generate_perception, spawn_agent, BioState, EventBuffer, Personality,
+    Position, RoomDistanceMap, RoomInfoMap, SimulationTime, SmellEvent,
+};
+
+const BENCH_AGENT_COUNT: u16 = 26;
+
+#[derive(Debug, Clone)]
+struct PerceptionInput {
+    bio: BioState,
+    position: Position,
+    personality: Personality,
+    room_noise_db: f32,
+    room_temp_c: f32,
+    room_co2_ppm: f32,
+    focus_hours: f32,
+}
+
+fn config_path() -> PathBuf {
+    if let Ok(repo_root) = std::env::var("SENTINEL_REPO_ROOT") {
+        return Path::new(&repo_root).join("config/rooms.toml");
+    }
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        let candidate = current_dir.join("config/rooms.toml");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("config/rooms.toml")
+}
+
+fn load_building_config() -> BuildingConfig {
+    BuildingConfig::load(&config_path()).expect("rooms.toml must load for #276 benches")
+}
+
+fn build_room_maps() -> (RoomDistanceMap, RoomInfoMap) {
+    let config = load_building_config();
+    (
+        RoomDistanceMap::from_building_config(&config),
+        RoomInfoMap::from_building_config(&config),
+    )
+}
+
+fn build_physics_world() -> (bevy_ecs::prelude::World, bevy_ecs::prelude::Schedule) {
+    let (mut world, _) = create_simulation_world();
+    let (room_distances, room_info) = build_room_maps();
+    world.insert_resource(room_distances);
+    world.insert_resource(room_info);
+
+    for id in 1..=BENCH_AGENT_COUNT {
+        let room_index = (id as usize).saturating_sub(1) % ROOM_IDS.len();
+        spawn_agent(
+            &mut world,
+            AgentId(id),
+            &format!("Bench-Agent-{id:02}"),
+            "Benchmark",
+            1,
+            ROOM_IDS[room_index],
+        );
+    }
+
+    prepare_physics_tick(&mut world, 1);
+
+    let mut schedule = bevy_ecs::prelude::Schedule::default();
+    schedule.add_systems(physics_system);
+    (world, schedule)
+}
+
+fn prepare_physics_tick(world: &mut bevy_ecs::prelude::World, tick: u64) {
+    world.resource_mut::<EventBuffer>().events.clear();
+
+    let mut time = world.resource_mut::<SimulationTime>();
+    time.tick = Tick(tick);
+    time.tick_count = tick;
+    time.delta_seconds = 1.0;
+    time.sim_hour = 8.0 + (tick as f32 / 3600.0);
+}
+
+fn build_perception_inputs() -> Vec<PerceptionInput> {
+    (1..=BENCH_AGENT_COUNT)
+        .map(|id| {
+            let room_index = (id as usize).saturating_sub(1) % ROOM_IDS.len();
+            PerceptionInput {
+                bio: BioState {
+                    hunger: 20.0 + f32::from(id % 7) * 10.0,
+                    energy: 85.0 - f32::from(id % 6) * 12.0,
+                    caffeine_mg: f32::from(id % 5) * 8.0,
+                    bladder: 15.0 + f32::from(id % 8) * 10.0,
+                    stress: 10.0 + f32::from(id % 9) * 9.0,
+                    social_need: 35.0 + f32::from(id % 6) * 11.0,
+                    comfort: 70.0,
+                },
+                position: Position {
+                    room_id: ROOM_IDS[room_index].to_string(),
+                    in_transit: false,
+                    transit_target: None,
+                    transit_remaining_ms: 0,
+                    transit_correlation_id: None,
+                    transit_route: Vec::new(),
+                    transit_total_ms: 0,
+                    transit_paused: false,
+                    transit_pause_tick: 0,
+                    transit_source: None,
+                },
+                personality: Personality {
+                    openness: 0.5,
+                    conscientiousness: 0.6,
+                    extraversion: if id % 2 == 0 { 0.7 } else { 0.3 },
+                    agreeableness: 0.5,
+                    neuroticism: 0.3,
+                    caffeine_tolerance: if id % 3 == 0 { 0.8 } else { 0.2 },
+                    is_morning_person: id % 2 == 0,
+                },
+                room_noise_db: 35.0 + f32::from(id % 5) * 8.0,
+                room_temp_c: 18.0 + f32::from(id % 9),
+                room_co2_ppm: 700.0 + f32::from(id % 8) * 120.0,
+                focus_hours: 1.0 + f32::from(id % 6),
+            }
+        })
+        .collect()
+}
+
+fn bench_physics_system_26_agents(c: &mut Criterion) {
+    let (mut world, mut schedule) = build_physics_world();
+    let mut tick = 1u64;
+
+    let mut group = c.benchmark_group("issue276.physics_system");
+    group.sample_size(50);
+    group.bench_function("tick_26_agents", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                prepare_physics_tick(&mut world, tick);
+                let start = Instant::now();
+                schedule.run(&mut world);
+                total += start.elapsed();
+                black_box(world.resource::<EventBuffer>().events.len());
+                tick = if tick >= 59 { 1 } else { tick + 1 };
+            }
+            total
+        });
+    });
+    group.finish();
+}
+
+fn bench_generate_perception_26_agents(c: &mut Criterion) {
+    let inputs = build_perception_inputs();
+    let smells = vec![
+        SmellEvent {
+            source_room: "kueche".to_string(),
+            smell_type: "coffee".to_string(),
+            intensity: 0.8,
+            radius_rooms: 2,
+            decay_per_room: 0.2,
+            created_tick: 1,
+            duration_ticks: 120,
+        },
+        SmellEvent {
+            source_room: "buero-it".to_string(),
+            smell_type: "printer_toner".to_string(),
+            intensity: 0.5,
+            radius_rooms: 1,
+            decay_per_room: 0.2,
+            created_tick: 1,
+            duration_ticks: 60,
+        },
+    ];
+    let present_agents = vec![
+        ("Mia".to_string(), "arbeitet konzentriert".to_string()),
+        ("Jonas".to_string(), "telefoniert".to_string()),
+        ("Lea".to_string(), "liest Tickets".to_string()),
+    ];
+
+    let mut group = c.benchmark_group("issue276.generate_perception");
+    group.sample_size(50);
+    group.bench_function("texts_26_agents", |b| {
+        b.iter(|| {
+            for input in &inputs {
+                black_box(generate_perception(
+                    black_box(&input.bio),
+                    black_box(&input.position),
+                    black_box(&input.personality),
+                    black_box(input.room_noise_db),
+                    black_box(input.room_temp_c),
+                    black_box(input.room_co2_ppm),
+                    black_box(&smells),
+                    black_box(&present_agents),
+                    black_box("08:30"),
+                    black_box(input.focus_hours),
+                ));
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    issue276_hotpath_benches,
+    bench_physics_system_26_agents,
+    bench_generate_perception_26_agents
+);
+criterion_main!(issue276_hotpath_benches);

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -24,9 +24,9 @@ pub use world::{
     despawn_agent_from_world, restore_ecs_state, snapshot_ecs_state, spawn_agent, ActionReceiver,
     ActiveAgentsThisTick, ActiveChaos, ActiveChaosEvent, ActiveRoomStimuli, ActiveSmell,
     ActiveSmells, BroadcastBuffer, EventBuffer, GaiaBuffer, LimboEventStore,
-    OperatorCommandReceiver, PerceptionSender, PersistTelemetry, PsiMetrics, RedbStateStore,
-    RoomChatBuffer, RoomDistanceMap, RoomInfoMap, RoomPhysicsSnapshot, RoomPhysicsState,
-    RoomPhysicsWorkspace, SimulationTime, ToolRuntimeResource, ZenohFanoutSender,
+    OperatorCommandReceiver, PerceptionSender, PersistTelemetry, PersistWorkspace, PsiMetrics,
+    RedbStateStore, RoomChatBuffer, RoomDistanceMap, RoomInfoMap, RoomPhysicsSnapshot,
+    RoomPhysicsState, RoomPhysicsWorkspace, SimulationTime, ToolRuntimeResource, ZenohFanoutSender,
 };
 
 #[cfg(test)]

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -24,7 +24,7 @@ pub use world::{
     ActiveSmells, BroadcastBuffer, EventBuffer, GaiaBuffer, LimboEventStore,
     OperatorCommandReceiver, PerceptionSender, PersistTelemetry, PsiMetrics, RedbStateStore,
     RoomChatBuffer, RoomDistanceMap, RoomInfoMap, RoomPhysicsSnapshot, RoomPhysicsState,
-    SimulationTime, ToolRuntimeResource, ZenohFanoutSender,
+    RoomPhysicsWorkspace, SimulationTime, ToolRuntimeResource, ZenohFanoutSender,
 };
 
 #[cfg(test)]

--- a/crates/sentinel-ecs/src/lib.rs
+++ b/crates/sentinel-ecs/src/lib.rs
@@ -15,7 +15,9 @@ pub mod world;
 
 pub use components::*;
 pub use decision::format_impulse_from_queue;
-pub use perception::{format_injection, generate_perception, PerceptionTexts, SmellEvent};
+pub use perception::{
+    format_injection, generate_perception, generate_perception_into, PerceptionTexts, SmellEvent,
+};
 pub use systems::SimulationPhase;
 pub use world::{
     apply_capabilities, apply_personality, attach_redb_store, create_simulation_world,

--- a/crates/sentinel-ecs/src/perception.rs
+++ b/crates/sentinel-ecs/src/perception.rs
@@ -5,6 +5,7 @@
 //! eingefuegt werden.
 
 use sentinel_common::components::{BioState, Personality, Position};
+use std::fmt::Write as _;
 
 /// Geruchsereignis aus der Physics-Engine
 #[derive(Debug, Clone)]
@@ -19,7 +20,7 @@ pub struct SmellEvent {
 }
 
 /// Generierte Wahrnehmungstexte (ohne Metadaten wie agent_id/timestamp)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PerceptionTexts {
     pub circadian_text: String,
     pub body_text: String,
@@ -27,6 +28,17 @@ pub struct PerceptionTexts {
     pub acoustic_text: String,
     pub presence_text: String,
     pub impulse_text: String,
+}
+
+impl PerceptionTexts {
+    pub fn clear(&mut self) {
+        self.circadian_text.clear();
+        self.body_text.clear();
+        self.environment_text.clear();
+        self.acoustic_text.clear();
+        self.presence_text.clear();
+        self.impulse_text.clear();
+    }
 }
 
 /// Generiert Wahrnehmungstexte aus ECS-Zustandsdaten.
@@ -47,194 +59,263 @@ pub fn generate_perception(
     sim_time: &str,
     focus_hours: f32,
 ) -> PerceptionTexts {
+    let mut perception = PerceptionTexts::default();
+    generate_perception_into(
+        &mut perception,
+        bio,
+        _position,
+        personality,
+        room_noise_db,
+        room_temp_c,
+        room_co2_ppm,
+        room_smells,
+        present_agents,
+        sim_time,
+        focus_hours,
+    );
+    perception
+}
+
+/// Generiert Wahrnehmungstexte in wiederverwendete String-Buffer.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_perception_into(
+    perception: &mut PerceptionTexts,
+    bio: &BioState,
+    _position: &Position,
+    personality: &Personality,
+    room_noise_db: f32,
+    room_temp_c: f32,
+    room_co2_ppm: f32,
+    room_smells: &[SmellEvent],
+    present_agents: &[(String, String)],
+    sim_time: &str,
+    focus_hours: f32,
+) {
+    perception.clear();
+
     // Circadian
-    let circadian_text = format!(
+    write!(
+        perception.circadian_text,
         "{} (Du arbeitest seit {:.0}h konzentriert)",
         sim_time, focus_hours
-    );
+    )
+    .expect("writing to String cannot fail");
 
     // Koerperwahrnehmung
-    let body_text = generate_body_text(bio, personality);
+    generate_body_text_into(&mut perception.body_text, bio, personality);
 
     // Umgebung (Temperatur, CO2, Gerueche)
-    let environment_text = generate_environment_text(room_temp_c, room_co2_ppm, room_smells);
+    generate_environment_text_into(
+        &mut perception.environment_text,
+        room_temp_c,
+        room_co2_ppm,
+        room_smells,
+    );
 
     // Akustik
-    let acoustic_text = generate_acoustic_text(room_noise_db);
+    generate_acoustic_text_into(&mut perception.acoustic_text, room_noise_db);
 
     // Anwesende
-    let presence_text = generate_presence_text(present_agents);
+    generate_presence_text_into(&mut perception.presence_text, present_agents);
 
     // Impuls
-    let impulse_text = generate_impulse_text(bio, personality);
-
-    PerceptionTexts {
-        circadian_text,
-        body_text,
-        environment_text,
-        acoustic_text,
-        presence_text,
-        impulse_text,
-    }
+    generate_impulse_text_into(&mut perception.impulse_text, bio, personality);
 }
 
 /// Formatiert Wahrnehmungstexte als `[SYSTEM_INJECTION]` Block fuer LLM-Prompts.
 ///
 /// Nur nicht-leere Felder werden aufgenommen (CIRCADIAN ist immer dabei).
 pub fn format_injection(perception: &PerceptionTexts) -> String {
-    let mut lines = Vec::new();
-    lines.push("[SYSTEM_INJECTION]".to_string());
-
-    // CIRCADIAN ist immer dabei
-    lines.push(format!("CIRCADIAN: {}", perception.circadian_text));
+    let mut injection = String::with_capacity(
+        perception.circadian_text.len()
+            + perception.body_text.len()
+            + perception.environment_text.len()
+            + perception.acoustic_text.len()
+            + perception.presence_text.len()
+            + perception.impulse_text.len()
+            + 96,
+    );
+    injection.push_str("[SYSTEM_INJECTION]\nCIRCADIAN: ");
+    injection.push_str(&perception.circadian_text);
 
     if !perception.body_text.is_empty() {
-        lines.push(format!("KOERPER: {}", perception.body_text));
+        append_injection_field(&mut injection, "KOERPER", &perception.body_text);
     }
     if !perception.environment_text.is_empty() {
-        lines.push(format!("ENVIRONMENT: {}", perception.environment_text));
+        append_injection_field(&mut injection, "ENVIRONMENT", &perception.environment_text);
     }
     if !perception.acoustic_text.is_empty() {
-        lines.push(format!("AKUSTIK: {}", perception.acoustic_text));
+        append_injection_field(&mut injection, "AKUSTIK", &perception.acoustic_text);
     }
     if !perception.presence_text.is_empty() {
-        lines.push(format!("ANWESEND: {}", perception.presence_text));
+        append_injection_field(&mut injection, "ANWESEND", &perception.presence_text);
     }
     if !perception.impulse_text.is_empty() {
-        lines.push(format!("IMPULS: {}", perception.impulse_text));
+        append_injection_field(&mut injection, "IMPULS", &perception.impulse_text);
     }
 
-    lines.push("[/SYSTEM_INJECTION]".to_string());
-    lines.join("\n")
+    injection.push_str("\n[/SYSTEM_INJECTION]");
+    injection
 }
 
-/// Generiert Koerperwahrnehmungstext aus Bio-Zustand
-fn generate_body_text(bio: &BioState, personality: &Personality) -> String {
-    let mut parts: Vec<String> = Vec::new();
+fn generate_body_text_into(output: &mut String, bio: &BioState, personality: &Personality) {
+    output.clear();
 
     // Hunger-Schwellenwerte
     if bio.hunger > 90.0 {
-        parts.push("Dir ist schwindelig vor Hunger.".to_string());
+        append_part(output, "Dir ist schwindelig vor Hunger.");
     } else if bio.hunger > 80.0 {
-        parts.push("Dein Magen krampft.".to_string());
+        append_part(output, "Dein Magen krampft.");
     } else if bio.hunger > 70.0 {
-        parts.push("Du koenntest etwas essen.".to_string());
+        append_part(output, "Du koenntest etwas essen.");
     }
 
     // Blasendrang
     if bio.bladder > 90.0 {
-        parts.push("Du musst JETZT zur Toilette.".to_string());
+        append_part(output, "Du musst JETZT zur Toilette.");
     } else if bio.bladder > 80.0 {
-        parts.push("Dringend: Toilette.".to_string());
+        append_part(output, "Dringend: Toilette.");
     } else if bio.bladder > 60.0 {
-        parts.push("Du solltest bald eine Pause einlegen.".to_string());
+        append_part(output, "Du solltest bald eine Pause einlegen.");
     }
 
     // Energie
     if bio.energy < 20.0 {
-        parts.push("Du kannst kaum die Augen offen halten.".to_string());
+        append_part(output, "Du kannst kaum die Augen offen halten.");
     } else if bio.energy < 40.0 {
-        parts.push("Du bist muede.".to_string());
+        append_part(output, "Du bist muede.");
     }
 
     // Stress
     if bio.stress > 80.0 {
-        parts.push("Dein Herz rast.".to_string());
+        append_part(output, "Dein Herz rast.");
     } else if bio.stress > 60.0 {
-        parts.push("Du stehst unter Druck.".to_string());
+        append_part(output, "Du stehst unter Druck.");
     }
 
     // Koffein-Entzug: caffeine_mg < 20.0 UND caffeine_tolerance > 0.3
     if bio.caffeine_mg < 20.0 && personality.caffeine_tolerance > 0.3 {
-        parts.push("Leichte Kopfschmerzen - du brauchst Kaffee.".to_string());
+        append_part(output, "Leichte Kopfschmerzen - du brauchst Kaffee.");
     }
 
     // Gesund (keine Schwellenwerte ueberschritten)
-    if parts.is_empty() {
-        parts.push("Du fuehlst dich gut.".to_string());
+    if output.is_empty() {
+        output.push_str("Du fuehlst dich gut.");
     }
-
-    parts.join(" ")
 }
 
-/// Generiert Umgebungstext aus Temperatur, CO2 und Geruechen
-fn generate_environment_text(temp_c: f32, co2_ppm: f32, smells: &[SmellEvent]) -> String {
-    let mut parts: Vec<String> = Vec::new();
+fn generate_environment_text_into(
+    output: &mut String,
+    temp_c: f32,
+    co2_ppm: f32,
+    smells: &[SmellEvent],
+) {
+    output.clear();
 
     // Temperatur
+    begin_part(output);
     if temp_c > 26.0 {
-        parts.push(format!("Es ist deutlich zu warm ({temp_c:.1} °C)."));
+        write!(output, "Es ist deutlich zu warm ({temp_c:.1} °C).")
+            .expect("writing to String cannot fail");
     } else if temp_c > 24.0 {
-        parts.push(format!("Es ist warm ({temp_c:.1} °C)."));
+        write!(output, "Es ist warm ({temp_c:.1} °C).").expect("writing to String cannot fail");
     } else if temp_c < 17.0 {
-        parts.push(format!("Es ist unangenehm kuehl ({temp_c:.1} °C)."));
+        write!(output, "Es ist unangenehm kuehl ({temp_c:.1} °C).")
+            .expect("writing to String cannot fail");
     } else if temp_c < 19.0 {
-        parts.push(format!("Es ist kuehl ({temp_c:.1} °C)."));
+        write!(output, "Es ist kuehl ({temp_c:.1} °C).").expect("writing to String cannot fail");
     } else {
-        parts.push(format!("Die Temperatur ist angenehm ({temp_c:.1} °C)."));
+        write!(output, "Die Temperatur ist angenehm ({temp_c:.1} °C).")
+            .expect("writing to String cannot fail");
     }
 
     // CO2
     if co2_ppm > 1400.0 {
-        parts.push(format!("Die Luft ist sehr stickig ({co2_ppm:.0} ppm CO2)."));
+        begin_part(output);
+        write!(output, "Die Luft ist sehr stickig ({co2_ppm:.0} ppm CO2).")
+            .expect("writing to String cannot fail");
     } else if co2_ppm > 1000.0 {
-        parts.push(format!("Die Luft ist stickig ({co2_ppm:.0} ppm CO2)."));
+        begin_part(output);
+        write!(output, "Die Luft ist stickig ({co2_ppm:.0} ppm CO2).")
+            .expect("writing to String cannot fail");
     }
 
     // Gerueche (nur intensity > 0.3)
     for smell in smells {
         if smell.intensity > 0.3 {
-            let smell_text = match smell.smell_type.as_str() {
-                "coffee" => "Kaffeeduft.".to_string(),
-                "food" => "Essensgeruch.".to_string(),
-                "perfume" => "Parfuemduft.".to_string(),
-                "printer_toner" => "Tonergeruch.".to_string(),
-                other => format!("Ein Geruch von {}.", other),
-            };
-            parts.push(smell_text);
+            match smell.smell_type.as_str() {
+                "coffee" => append_part(output, "Kaffeeduft."),
+                "food" => append_part(output, "Essensgeruch."),
+                "perfume" => append_part(output, "Parfuemduft."),
+                "printer_toner" => append_part(output, "Tonergeruch."),
+                other => {
+                    begin_part(output);
+                    write!(output, "Ein Geruch von {}.", other)
+                        .expect("writing to String cannot fail");
+                }
+            }
         }
     }
-
-    parts.join(" ")
 }
 
-/// Generiert Akustiktext aus Laermpegel
-fn generate_acoustic_text(noise_db: f32) -> String {
+fn generate_acoustic_text_into(output: &mut String, noise_db: f32) {
+    output.clear();
     match noise_db as u32 {
-        0..=35 => format!("Stille ({noise_db:.0} dB)."),
-        36..=50 => format!("Normales Buerogeraeusch ({noise_db:.0} dB)."),
-        51..=65 => format!("Lebhafte Unterhaltungen ({noise_db:.0} dB)."),
-        _ => format!("Es ist laut ({noise_db:.0} dB). Konzentration faellt schwer."),
+        0..=35 => write!(output, "Stille ({noise_db:.0} dB)."),
+        36..=50 => write!(output, "Normales Buerogeraeusch ({noise_db:.0} dB)."),
+        51..=65 => write!(output, "Lebhafte Unterhaltungen ({noise_db:.0} dB)."),
+        _ => write!(
+            output,
+            "Es ist laut ({noise_db:.0} dB). Konzentration faellt schwer."
+        ),
     }
+    .expect("writing to String cannot fail");
 }
 
-/// Generiert Anwesenheitstext
-fn generate_presence_text(present_agents: &[(String, String)]) -> String {
+fn generate_presence_text_into(output: &mut String, present_agents: &[(String, String)]) {
+    output.clear();
     if present_agents.is_empty() {
-        "Du bist allein.".to_string()
+        output.push_str("Du bist allein.");
     } else {
-        present_agents
-            .iter()
-            .map(|(name, activity)| format!("{} ({})", name, activity))
-            .collect::<Vec<_>>()
-            .join(", ")
+        for (index, (name, activity)) in present_agents.iter().enumerate() {
+            if index > 0 {
+                output.push_str(", ");
+            }
+            write!(output, "{} ({})", name, activity).expect("writing to String cannot fail");
+        }
     }
 }
 
-/// Generiert Impulstext (Prioritaet: Toilette > Hunger > Muedigkeit > Sozial > Ruhe)
-fn generate_impulse_text(bio: &BioState, personality: &Personality) -> String {
+fn generate_impulse_text_into(output: &mut String, bio: &BioState, personality: &Personality) {
+    output.clear();
     if bio.bladder > 85.0 {
-        "Dringendes Beduerfnis, zur Toilette zu gehen.".to_string()
+        output.push_str("Dringendes Beduerfnis, zur Toilette zu gehen.");
     } else if bio.hunger > 85.0 {
-        "Dringendes Beduerfnis, etwas zu essen.".to_string()
+        output.push_str("Dringendes Beduerfnis, etwas zu essen.");
     } else if bio.energy < 25.0 {
-        "Dringendes Beduerfnis, Pause zu machen.".to_string()
+        output.push_str("Dringendes Beduerfnis, Pause zu machen.");
     } else if bio.social_need > 80.0 && personality.extraversion > 0.5 {
-        "Du moechtest mit jemandem reden.".to_string()
+        output.push_str("Du moechtest mit jemandem reden.");
     } else if bio.social_need < 20.0 && personality.extraversion < 0.5 {
-        "Du geniesst die Ruhe.".to_string()
-    } else {
-        String::new()
+        output.push_str("Du geniesst die Ruhe.");
+    }
+}
+
+fn append_injection_field(output: &mut String, label: &str, text: &str) {
+    output.push('\n');
+    output.push_str(label);
+    output.push_str(": ");
+    output.push_str(text);
+}
+
+fn append_part(output: &mut String, text: &str) {
+    begin_part(output);
+    output.push_str(text);
+}
+
+fn begin_part(output: &mut String) {
+    if !output.is_empty() {
+        output.push(' ');
     }
 }
 
@@ -279,6 +360,92 @@ mod tests {
             transit_pause_tick: 0,
             transit_source: None,
         }
+    }
+
+    #[test]
+    fn test_generate_perception_into_reuses_output_buffers() {
+        let mut bio = default_bio();
+        bio.hunger = 95.0;
+        bio.bladder = 95.0;
+        bio.caffeine_mg = 50.0;
+        bio.social_need = 90.0;
+        let personality = default_personality();
+        let pos = default_position();
+        let smells = vec![SmellEvent {
+            source_room: "kueche".to_string(),
+            smell_type: "coffee".to_string(),
+            intensity: 0.8,
+            radius_rooms: 2,
+            decay_per_room: 0.3,
+            created_tick: 100,
+            duration_ticks: 500,
+        }];
+        let agents = vec![
+            ("Lisa".to_string(), "Telefonat".to_string()),
+            ("Andreas".to_string(), "Coding".to_string()),
+        ];
+        let mut texts = PerceptionTexts {
+            circadian_text: String::with_capacity(128),
+            body_text: String::with_capacity(256),
+            environment_text: String::with_capacity(256),
+            acoustic_text: String::with_capacity(128),
+            presence_text: String::with_capacity(128),
+            impulse_text: String::with_capacity(128),
+        };
+
+        let capacities_before = (
+            texts.circadian_text.capacity(),
+            texts.body_text.capacity(),
+            texts.environment_text.capacity(),
+            texts.acoustic_text.capacity(),
+            texts.presence_text.capacity(),
+            texts.impulse_text.capacity(),
+        );
+
+        generate_perception_into(
+            &mut texts,
+            &bio,
+            &pos,
+            &personality,
+            55.0,
+            25.5,
+            1200.0,
+            &smells,
+            &agents,
+            "12:00",
+            2.0,
+        );
+        assert!(texts.body_text.contains("schwindelig"));
+
+        bio.hunger = 20.0;
+        bio.bladder = 10.0;
+        generate_perception_into(
+            &mut texts,
+            &bio,
+            &pos,
+            &personality,
+            30.0,
+            21.0,
+            600.0,
+            &[],
+            &[],
+            "13:00",
+            3.0,
+        );
+
+        assert_eq!(
+            capacities_before,
+            (
+                texts.circadian_text.capacity(),
+                texts.body_text.capacity(),
+                texts.environment_text.capacity(),
+                texts.acoustic_text.capacity(),
+                texts.presence_text.capacity(),
+                texts.impulse_text.capacity(),
+            )
+        );
+        assert_eq!(texts.body_text, "Du fuehlst dich gut.");
+        assert_eq!(texts.presence_text, "Du bist allein.");
     }
 
     #[test]

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -18,7 +18,7 @@ use super::components::*;
 use super::world::{
     ActionReceiver, ActiveChaos, ActiveChaosEvent, ActiveRoomStimuli, EventBuffer, LimboEventStore,
     OperatorCommandReceiver, PersistTelemetry, PsiMetrics, RedbStateStore, RoomDistanceMap,
-    RoomPhysicsState, ToolRuntimeResource, ZenohFanoutSender,
+    RoomPhysicsState, RoomPhysicsWorkspace, ToolRuntimeResource, ZenohFanoutSender,
 };
 use super::world::{PerceptionSender, SimulationTime};
 use bevy_ecs::prelude::*;
@@ -693,20 +693,20 @@ pub fn physics_system(
     active_chaos: Option<Res<ActiveChaos>>,
     mut active_room_stimuli: ResMut<ActiveRoomStimuli>,
     mut room_physics_state: ResMut<RoomPhysicsState>,
+    mut workspace: ResMut<RoomPhysicsWorkspace>,
     mut event_buffer: ResMut<EventBuffer>,
 ) {
     let tick = time.tick.0;
     active_room_stimuli.cleanup(tick);
 
     // Agenten pro Raum zaehlen und Meeting-Status ermitteln
-    let mut room_agents: std::collections::HashMap<String, (usize, bool)> =
-        std::collections::HashMap::new();
+    workspace.clear();
 
     // Initialisiere alle bekannten Raeume, damit leere Transit-Raeume keine
     // veralteten Physics-Werte im Read Model behalten.
     if let Some(distances) = room_distances.as_ref() {
         for room_id in distances.all_rooms() {
-            room_agents.entry(room_id.clone()).or_insert((0, false));
+            workspace.ensure_room(room_id);
         }
     }
 
@@ -714,28 +714,26 @@ pub fn physics_system(
     // auch wenn aktuell niemand darin sitzt.
     if let Some(chaos) = active_chaos.as_ref() {
         for room_id in chaos.active_rooms(tick) {
-            room_agents.entry(room_id.to_string()).or_insert((0, false));
+            workspace.ensure_room(room_id);
         }
     }
     for room_id in active_room_stimuli.active_rooms(tick) {
-        room_agents.entry(room_id.to_string()).or_insert((0, false));
+        workspace.ensure_room(room_id);
     }
 
     for (pos, work) in &query {
         if !pos.in_transit {
-            let entry = room_agents.entry(pos.room_id.clone()).or_insert((0, false));
-            entry.0 += 1;
-            if let Some(w) = work {
-                if w.in_meeting {
-                    entry.1 = true;
-                }
-            }
+            workspace.add_occupant(
+                &pos.room_id,
+                work.map(|work_context| work_context.in_meeting)
+                    .unwrap_or(false),
+            );
         }
     }
 
     // Seed-Laerm ohne Nachbarraum-Einfluesse vorberechnen.
-    let mut seed_noise: std::collections::HashMap<&str, f32> = std::collections::HashMap::new();
-    for (room_id, (agent_count, has_meeting)) in &room_agents {
+    for room_index in 0..workspace.len() {
+        let (room_id, agent_count, has_meeting) = workspace.room_stats(room_index);
         let chaos_bonus = active_chaos
             .as_ref()
             .and_then(|chaos| chaos.get_active(room_id, tick))
@@ -743,50 +741,49 @@ pub fn physics_system(
             .unwrap_or(0.0);
         let stimulus_noise = active_room_stimuli.delta_for(room_id, RoomStimulusType::Noise, tick);
         let local_noise =
-            sentinel_physics::calculate_noise_level(*agent_count, *has_meeting, false, &[])
+            sentinel_physics::calculate_noise_level(agent_count, has_meeting, false, &[])
                 + chaos_bonus
                 + stimulus_noise;
-        seed_noise.insert(room_id.as_str(), local_noise);
+        workspace.set_seed_noise(room_index, local_noise);
     }
 
     // Physik pro Raum berechnen
-    for (room_id, (agent_count, has_meeting)) in &room_agents {
-        let adjacent_noise = room_distances
-            .as_ref()
-            .map(|distances| {
-                distances
-                    .rooms_within(room_id, 1)
-                    .into_iter()
-                    .filter_map(|(adjacent_room, _)| seed_noise.get(adjacent_room).copied())
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+    for room_index in 0..workspace.len() {
+        let (_, agent_count, has_meeting) = workspace.room_stats(room_index);
 
-        let active_chaos_event = active_chaos
-            .as_ref()
-            .and_then(|chaos| chaos.get_active(room_id, tick));
-        let active_stimulus_delta_temperature =
-            active_room_stimuli.delta_for(room_id, RoomStimulusType::Temperature, tick);
-        let active_stimulus_delta_noise =
-            active_room_stimuli.delta_for(room_id, RoomStimulusType::Noise, tick);
-        let active_stimulus_delta_co2 =
-            active_room_stimuli.delta_for(room_id, RoomStimulusType::Co2, tick);
+        let active_chaos_event = {
+            let (room_id, _, _) = workspace.room_stats(room_index);
+            active_chaos
+                .as_ref()
+                .and_then(|chaos| chaos.get_active(room_id, tick))
+        };
+        let active_stimulus_delta_temperature = {
+            let (room_id, _, _) = workspace.room_stats(room_index);
+            active_room_stimuli.delta_for(room_id, RoomStimulusType::Temperature, tick)
+        };
+        let active_stimulus_delta_noise = {
+            let (room_id, _, _) = workspace.room_stats(room_index);
+            active_room_stimuli.delta_for(room_id, RoomStimulusType::Noise, tick)
+        };
+        let active_stimulus_delta_co2 = {
+            let (room_id, _, _) = workspace.room_stats(room_index);
+            active_room_stimuli.delta_for(room_id, RoomStimulusType::Co2, tick)
+        };
         let chaos_elapsed_hours = active_chaos_event
             .map(|event| chaos_elapsed_hours(event, &time))
             .unwrap_or(0.0);
 
-        let noise_db = sentinel_physics::calculate_noise_level(
-            *agent_count,
-            *has_meeting,
-            false,
-            &adjacent_noise,
-        ) + active_chaos_event
+        let noise_db = {
+            let adjacent_noise =
+                workspace.collect_adjacent_noise_for(room_index, room_distances.as_deref());
+            sentinel_physics::calculate_noise_level(agent_count, has_meeting, false, adjacent_noise)
+        } + active_chaos_event
             .map(|event| sentinel_physics::chaos_noise_bonus_db(event.event_type))
             .unwrap_or(0.0)
             + active_stimulus_delta_noise;
 
         let temperature =
-            sentinel_physics::calculate_temperature(21.0, *agent_count, false, 15.0, 0.3)
+            sentinel_physics::calculate_temperature(21.0, agent_count, false, 15.0, 0.3)
                 + active_chaos_event
                     .map(|event| {
                         sentinel_physics::chaos_temperature_delta_celsius(
@@ -796,17 +793,18 @@ pub fn physics_system(
                     })
                     .unwrap_or(0.0)
                 + active_stimulus_delta_temperature;
-        let co2 = sentinel_physics::calculate_co2(400.0, *agent_count, 0.5, 1.0)
+        let co2 = sentinel_physics::calculate_co2(400.0, agent_count, 0.5, 1.0)
             + active_stimulus_delta_co2;
         let has_active_stimulus = active_stimulus_delta_temperature.abs() > f32::EPSILON
             || active_stimulus_delta_noise.abs() > f32::EPSILON
             || active_stimulus_delta_co2.abs() > f32::EPSILON;
         let has_active_chaos = active_chaos_event.is_some();
+        let (room_id, _, _) = workspace.room_stats(room_index);
 
         room_physics_state.set(
             room_id,
             tick,
-            *agent_count as u32,
+            agent_count as u32,
             temperature,
             co2,
             noise_db,
@@ -824,7 +822,7 @@ pub fn physics_system(
                 temperature,
                 co2_ppm: co2,
                 noise_db,
-                occupant_count: *agent_count as u32,
+                occupant_count: agent_count as u32,
             };
             let event = DomainEvent::new(
                 payload.event_type_str(),

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -20,7 +20,7 @@ use super::world::{
     OperatorCommandReceiver, PersistTelemetry, PsiMetrics, RedbStateStore, RoomDistanceMap,
     RoomPhysicsState, RoomPhysicsWorkspace, ToolRuntimeResource, ZenohFanoutSender,
 };
-use super::world::{PerceptionSender, SimulationTime};
+use super::world::{PerceptionSender, PersistWorkspace, SimulationTime};
 use bevy_ecs::prelude::*;
 use sentinel_common::{
     ActionType, AgentId, DomainEvent, DomainEventPayload, Emotion, EventType, OperatorCommand,
@@ -2033,6 +2033,7 @@ pub fn persist_system(
     store: Option<Res<RedbStateStore>>,
     event_store: Option<Res<LimboEventStore>>,
     mut event_buffer: ResMut<EventBuffer>,
+    mut persist_workspace: ResMut<PersistWorkspace>,
     mut telemetry: ResMut<PersistTelemetry>,
     fanout_sender: Option<Res<ZenohFanoutSender>>,
 ) {
@@ -2055,30 +2056,30 @@ pub fn persist_system(
 
     // 1. Events aus Buffer nach Limbo schreiben (mit Outbox) + Zenoh Fan-Out
     if let Some(es) = &event_store {
-        let mut batch = Vec::with_capacity(event_buffer.events.len());
+        persist_workspace.clear();
         for event in event_buffer.events.drain(..) {
-            let topic = event_topic(&event);
-            batch.push((event, topic));
+            persist_workspace.push_with_topic(event, write_event_topic);
         }
 
-        if !batch.is_empty() {
-            let batch_result = es.0.append_with_outbox_batch(
-                batch.iter().map(|(event, topic)| (event, topic.as_str())),
-            );
+        if !persist_workspace.is_empty() {
+            let event_count = persist_workspace.len();
+            let batch_result = es.0.append_with_outbox_batch(persist_workspace.entries());
 
             if let Err(err) = batch_result {
                 warn!(
-                    event_count = batch.len(),
+                    event_count,
                     "persist_system: failed to write event batch: {err}"
                 );
             } else if let Some(ref fanout) = fanout_sender {
                 // Nach erfolgreichem Limbo-Write: Events an Zenoh Fan-Out Bridge senden
-                for (event, _) in batch {
+                for event in persist_workspace.drain_events() {
                     if fanout.sender.try_send(event).is_err() {
                         // Channel voll — Event droppen (Limbo ist SSOT, Zenoh ist best-effort)
                     }
                 }
             }
+
+            persist_workspace.clear();
         }
     } else {
         // Kein Event Store: Buffer leeren damit er nicht unendlich waechst
@@ -2129,12 +2130,12 @@ pub fn persist_system(
     }
 }
 
-/// Bestimmt das Zenoh-Topic fuer ein DomainEvent.
-fn event_topic(event: &DomainEvent) -> String {
-    format!(
-        "sentinel/events/{}/{}",
-        event.event_type, event.aggregate_id
-    )
+/// Schreibt das Zenoh-Topic fuer ein DomainEvent in einen wiederverwendeten Buffer.
+fn write_event_topic(output: &mut String, event: &DomainEvent) {
+    output.push_str("sentinel/events/");
+    output.push_str(&event.event_type);
+    output.push('/');
+    output.push_str(&event.aggregate_id);
 }
 
 fn encode_agent_snapshot(tick: u64, position: &Position, bio: &BioState, mood: &Mood) -> Vec<u8> {

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -2055,15 +2055,28 @@ pub fn persist_system(
 
     // 1. Events aus Buffer nach Limbo schreiben (mit Outbox) + Zenoh Fan-Out
     if let Some(es) = &event_store {
+        let mut batch = Vec::with_capacity(event_buffer.events.len());
         for event in event_buffer.events.drain(..) {
             let topic = event_topic(&event);
-            if let Err(err) = es.0.append_with_outbox(&event, &topic) {
-                warn!(event_id = %event.event_id, "persist_system: failed to write event: {err}");
-            }
-            // Nach erfolgreichem Limbo-Write: Event an Zenoh Fan-Out Bridge senden
-            if let Some(ref fanout) = fanout_sender {
-                if fanout.sender.try_send(event).is_err() {
-                    // Channel voll — Event droppen (Limbo ist SSOT, Zenoh ist best-effort)
+            batch.push((event, topic));
+        }
+
+        if !batch.is_empty() {
+            let batch_result = es.0.append_with_outbox_batch(
+                batch.iter().map(|(event, topic)| (event, topic.as_str())),
+            );
+
+            if let Err(err) = batch_result {
+                warn!(
+                    event_count = batch.len(),
+                    "persist_system: failed to write event batch: {err}"
+                );
+            } else if let Some(ref fanout) = fanout_sender {
+                // Nach erfolgreichem Limbo-Write: Events an Zenoh Fan-Out Bridge senden
+                for (event, _) in batch {
+                    if fanout.sender.try_send(event).is_err() {
+                        // Channel voll — Event droppen (Limbo ist SSOT, Zenoh ist best-effort)
+                    }
                 }
             }
         }

--- a/crates/sentinel-ecs/src/systems.rs
+++ b/crates/sentinel-ecs/src/systems.rs
@@ -27,6 +27,7 @@ use sentinel_common::{
     Perception, RoomStimulusType, Timestamp,
 };
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::time::Instant;
 use tracing::{debug, warn};
 
@@ -1363,57 +1364,68 @@ pub fn perception_system(
 ) {
     for (bio, position, mood, mut perception) in &mut query {
         // Koerper-Wahrnehmung
-        let mut body_parts: Vec<&str> = Vec::new();
+        perception.body_text.clear();
 
         if bio.hunger > 70.0 {
-            body_parts.push("Du hast grossen Hunger.");
+            append_perception_part(&mut perception.body_text, "Du hast grossen Hunger.");
         } else if bio.hunger > 40.0 {
-            body_parts.push("Du spuerst leichten Hunger.");
+            append_perception_part(&mut perception.body_text, "Du spuerst leichten Hunger.");
         }
 
         if bio.energy < 30.0 {
-            body_parts.push("Du bist sehr muede.");
+            append_perception_part(&mut perception.body_text, "Du bist sehr muede.");
         } else if bio.energy < 50.0 {
-            body_parts.push("Du fuehlst dich etwas schlapp.");
+            append_perception_part(&mut perception.body_text, "Du fuehlst dich etwas schlapp.");
         } else if bio.energy > 85.0 {
-            body_parts.push("Du fuehlst dich voller Energie.");
+            append_perception_part(&mut perception.body_text, "Du fuehlst dich voller Energie.");
         }
 
         if bio.caffeine_mg > 80.0 {
-            body_parts.push("Der Kaffee wirkt, du bist wach und konzentriert.");
+            append_perception_part(
+                &mut perception.body_text,
+                "Der Kaffee wirkt, du bist wach und konzentriert.",
+            );
         } else if bio.caffeine_mg > 30.0 {
-            body_parts.push("Du spuerst noch etwas Koffein.");
+            append_perception_part(&mut perception.body_text, "Du spuerst noch etwas Koffein.");
         }
 
         if bio.bladder > 70.0 {
-            body_parts.push("Du musst dringend auf die Toilette.");
+            append_perception_part(
+                &mut perception.body_text,
+                "Du musst dringend auf die Toilette.",
+            );
         } else if bio.bladder > 40.0 {
-            body_parts.push("Du bemerkst leichten Blasendrang.");
+            append_perception_part(
+                &mut perception.body_text,
+                "Du bemerkst leichten Blasendrang.",
+            );
         }
 
         if bio.stress > 70.0 {
-            body_parts.push("Du bist sehr gestresst.");
+            append_perception_part(&mut perception.body_text, "Du bist sehr gestresst.");
         } else if bio.stress > 40.0 {
-            body_parts.push("Du fuehlst leichten Stress.");
+            append_perception_part(&mut perception.body_text, "Du fuehlst leichten Stress.");
         }
 
-        perception.body_text = body_parts.join(" ");
-
         // Umgebungs-Wahrnehmung
-        let room_desc = room_id_to_german(&position.room_id);
-        perception.environment_text = if position.in_transit {
-            format!(
-                "Du bist auf dem Weg von {} nach {}.",
-                room_desc,
-                position
-                    .transit_target
-                    .as_deref()
-                    .map(room_id_to_german)
-                    .unwrap_or_else(|| "unbekannt".to_string())
-            )
+        perception.environment_text.clear();
+        if position.in_transit {
+            perception
+                .environment_text
+                .push_str("Du bist auf dem Weg von ");
+            append_room_id_to_german(&mut perception.environment_text, &position.room_id);
+            perception.environment_text.push_str(" nach ");
+            if let Some(target) = position.transit_target.as_deref() {
+                append_room_id_to_german(&mut perception.environment_text, target);
+            } else {
+                perception.environment_text.push_str("unbekannt");
+            }
+            perception.environment_text.push('.');
         } else {
-            format!("Du bist {}.", room_desc)
-        };
+            perception.environment_text.push_str("Du bist ");
+            append_room_id_to_german(&mut perception.environment_text, &position.room_id);
+            perception.environment_text.push('.');
+        }
 
         // Aktive Gerueche im aktuellen Raum in die Umgebungswahrnehmung injizieren
         if !position.in_transit {
@@ -1439,13 +1451,16 @@ pub fn perception_system(
         }
 
         // Stimmungs-basierte soziale Wahrnehmung
-        perception.social_text = if bio.social_need > 70.0 {
-            "Du hast das Beduerfnis, mit jemandem zu reden.".to_string()
+        perception.social_text.clear();
+        if bio.social_need > 70.0 {
+            perception
+                .social_text
+                .push_str("Du hast das Beduerfnis, mit jemandem zu reden.");
         } else if bio.social_need < 20.0 {
-            "Du moechtest gerade lieber allein sein.".to_string()
-        } else {
-            String::new()
-        };
+            perception
+                .social_text
+                .push_str("Du moechtest gerade lieber allein sein.");
+        }
 
         // Stimmungstext anhaengen wenn markant
         let mood_text = match mood.dominant_emotion {
@@ -1470,35 +1485,58 @@ pub fn perception_system(
 
 /// Mappt Raum-ID auf deutschen Beschreibungstext
 fn room_id_to_german(room_id: &str) -> String {
-    match room_id {
-        "empfang" => "im Empfangsbereich".to_string(),
-        "flur-eg" => "im Flur des Erdgeschosses".to_string(),
-        "flur-og" => "im Flur des Obergeschosses".to_string(),
-        "kueche" => "in der Kueche".to_string(),
-        "buero-dev-1" => "im Entwicklerbuero 1".to_string(),
-        "buero-dev-2" => "im Entwicklerbuero 2".to_string(),
-        "buero-design-1" => "im Designbuero 1".to_string(),
-        "buero-design-2" => "im Designbuero 2".to_string(),
-        "buero-ceo" => "im Buero der Geschaeftsfuehrung".to_string(),
-        "meetingraum-01" => "im Meetingraum 1 (EG)".to_string(),
-        "meetingraum-02" => "im Meetingraum 2 (OG)".to_string(),
-        "meetingraum-03" => "im Meetingraum 3 (OG)".to_string(),
-        "toilette-eg-damen" => "auf der Damentoilette (EG)".to_string(),
-        "toilette-eg-herren" => "auf der Herrentoilette (EG)".to_string(),
-        "toilette-og-damen" => "auf der Damentoilette (OG)".to_string(),
-        "toilette-og-herren" => "auf der Herrentoilette (OG)".to_string(),
-        "treppenhaus" => "im Treppenhaus".to_string(),
-        "buero-sales" => "im Vertriebsbuero".to_string(),
-        "buero-pm" => "im Projektmanagement-Buero".to_string(),
-        "buero-marketing" => "im Marketingbuero".to_string(),
-        "buero-admin" => "im Verwaltungsbuero".to_string(),
-        "buero-qa" => "im QA-Buero".to_string(),
-        "buero-it" => "im IT-Buero".to_string(),
-        "buero-betriebsrat" => "im Betriebsratsbuero".to_string(),
-        "buero-betriebspsych" => "in der Betriebspsychologie".to_string(),
-        "buero-betriebsarzt" => "in der Betriebsmedizin".to_string(),
-        other => format!("im Raum '{}'", other),
+    if let Some(room) = room_id_to_german_static(room_id) {
+        room.to_string()
+    } else {
+        format!("im Raum '{}'", room_id)
     }
+}
+
+fn room_id_to_german_static(room_id: &str) -> Option<&'static str> {
+    match room_id {
+        "empfang" => Some("im Empfangsbereich"),
+        "flur-eg" => Some("im Flur des Erdgeschosses"),
+        "flur-og" => Some("im Flur des Obergeschosses"),
+        "kueche" => Some("in der Kueche"),
+        "buero-dev-1" => Some("im Entwicklerbuero 1"),
+        "buero-dev-2" => Some("im Entwicklerbuero 2"),
+        "buero-design-1" => Some("im Designbuero 1"),
+        "buero-design-2" => Some("im Designbuero 2"),
+        "buero-ceo" => Some("im Buero der Geschaeftsfuehrung"),
+        "meetingraum-01" => Some("im Meetingraum 1 (EG)"),
+        "meetingraum-02" => Some("im Meetingraum 2 (OG)"),
+        "meetingraum-03" => Some("im Meetingraum 3 (OG)"),
+        "toilette-eg-damen" => Some("auf der Damentoilette (EG)"),
+        "toilette-eg-herren" => Some("auf der Herrentoilette (EG)"),
+        "toilette-og-damen" => Some("auf der Damentoilette (OG)"),
+        "toilette-og-herren" => Some("auf der Herrentoilette (OG)"),
+        "treppenhaus" => Some("im Treppenhaus"),
+        "buero-sales" => Some("im Vertriebsbuero"),
+        "buero-pm" => Some("im Projektmanagement-Buero"),
+        "buero-marketing" => Some("im Marketingbuero"),
+        "buero-admin" => Some("im Verwaltungsbuero"),
+        "buero-qa" => Some("im QA-Buero"),
+        "buero-it" => Some("im IT-Buero"),
+        "buero-betriebsrat" => Some("im Betriebsratsbuero"),
+        "buero-betriebspsych" => Some("in der Betriebspsychologie"),
+        "buero-betriebsarzt" => Some("in der Betriebsmedizin"),
+        _ => None,
+    }
+}
+
+fn append_room_id_to_german(output: &mut String, room_id: &str) {
+    if let Some(room) = room_id_to_german_static(room_id) {
+        output.push_str(room);
+    } else {
+        write!(output, "im Raum '{}'", room_id).expect("writing to String cannot fail");
+    }
+}
+
+fn append_perception_part(output: &mut String, text: &str) {
+    if !output.is_empty() {
+        output.push(' ');
+    }
+    output.push_str(text);
 }
 
 #[cfg(feature = "wasm")]

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -309,6 +309,145 @@ impl RoomPhysicsState {
     }
 }
 
+const ROOM_PHYSICS_WORKSPACE_CAPACITY: usize = 32;
+
+/// Reusable scratch storage for per-tick room physics aggregation.
+#[derive(Resource, Debug, Clone)]
+pub struct RoomPhysicsWorkspace {
+    rooms: Vec<RoomPhysicsWorkspaceRoom>,
+    active_len: usize,
+    adjacent_noise: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+struct RoomPhysicsWorkspaceRoom {
+    room_id: String,
+    occupant_count: usize,
+    has_meeting: bool,
+    seed_noise_db: f32,
+}
+
+impl Default for RoomPhysicsWorkspace {
+    fn default() -> Self {
+        Self {
+            rooms: Vec::with_capacity(ROOM_PHYSICS_WORKSPACE_CAPACITY),
+            active_len: 0,
+            adjacent_noise: Vec::with_capacity(ROOM_PHYSICS_WORKSPACE_CAPACITY),
+        }
+    }
+}
+
+impl RoomPhysicsWorkspace {
+    pub fn clear(&mut self) {
+        self.active_len = 0;
+        self.adjacent_noise.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.active_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active_len == 0
+    }
+
+    pub fn ensure_room(&mut self, room_id: &str) {
+        if self.find_room_index(room_id).is_none() {
+            self.activate_room(room_id);
+        }
+    }
+
+    pub fn add_occupant(&mut self, room_id: &str, has_meeting: bool) {
+        let index = match self.find_room_index(room_id) {
+            Some(index) => index,
+            None => self.activate_room(room_id),
+        };
+
+        let room = &mut self.rooms[index];
+        room.occupant_count += 1;
+        room.has_meeting |= has_meeting;
+    }
+
+    pub fn room_stats(&self, index: usize) -> (&str, usize, bool) {
+        assert!(index < self.active_len);
+        let room = &self.rooms[index];
+        (room.room_id.as_str(), room.occupant_count, room.has_meeting)
+    }
+
+    pub fn set_seed_noise(&mut self, index: usize, seed_noise_db: f32) {
+        assert!(index < self.active_len);
+        self.rooms[index].seed_noise_db = seed_noise_db;
+    }
+
+    pub fn collect_adjacent_noise_for(
+        &mut self,
+        index: usize,
+        room_distances: Option<&RoomDistanceMap>,
+    ) -> &[f32] {
+        self.adjacent_noise.clear();
+        let Some(room_distances) = room_distances else {
+            return &self.adjacent_noise;
+        };
+
+        assert!(index < self.active_len);
+        let rooms = &self.rooms[..self.active_len];
+        let adjacent_noise = &mut self.adjacent_noise;
+        let room_id = rooms[index].room_id.as_str();
+
+        room_distances.for_rooms_within(room_id, 1, |adjacent_room, _| {
+            if let Some(seed_noise_db) = rooms
+                .iter()
+                .find(|room| room.room_id == adjacent_room)
+                .map(|room| room.seed_noise_db)
+            {
+                adjacent_noise.push(seed_noise_db);
+            }
+        });
+
+        adjacent_noise
+    }
+
+    pub fn room_capacity(&self) -> usize {
+        self.rooms.capacity()
+    }
+
+    fn activate_room(&mut self, room_id: &str) -> usize {
+        let index = self.active_len;
+        if let Some(room) = self.rooms.get_mut(index) {
+            room.reset(room_id);
+        } else {
+            self.rooms.push(RoomPhysicsWorkspaceRoom::new(room_id));
+        }
+        self.active_len += 1;
+        index
+    }
+
+    fn find_room_index(&self, room_id: &str) -> Option<usize> {
+        self.rooms[..self.active_len]
+            .iter()
+            .position(|room| room.room_id == room_id)
+    }
+}
+
+impl RoomPhysicsWorkspaceRoom {
+    fn new(room_id: &str) -> Self {
+        Self {
+            room_id: room_id.to_string(),
+            occupant_count: 0,
+            has_meeting: false,
+            seed_noise_db: 0.0,
+        }
+    }
+
+    fn reset(&mut self, room_id: &str) {
+        self.room_id.clear();
+        self.room_id.push_str(room_id);
+        self.occupant_count = 0;
+        self.has_meeting = false;
+        self.seed_noise_db = 0.0;
+    }
+}
+
 /// Simulationszeit-Resource (muss vor jedem Schedule::run() aktualisiert werden)
 #[derive(Resource, Debug, Clone, Serialize, Deserialize)]
 pub struct SimulationTime {
@@ -854,6 +993,18 @@ impl RoomDistanceMap {
             .collect()
     }
 
+    /// Besucht alle Raeume die max `max_hops` entfernt sind, ohne ein Vec zu allozieren.
+    pub fn for_rooms_within<F>(&self, from: &str, max_hops: u32, mut visit: F)
+    where
+        F: FnMut(&str, u32),
+    {
+        for ((source, target), &distance) in &self.distances {
+            if source == from && distance > 0 && distance <= max_hops {
+                visit(target.as_str(), distance);
+            }
+        }
+    }
+
     /// Gibt die bekannte Liste aller Raum-IDs aus `rooms.toml` zurueck.
     pub fn all_rooms(&self) -> &[String] {
         &self.room_ids
@@ -943,6 +1094,7 @@ pub fn create_simulation_world() -> (World, Schedule) {
     world.insert_resource(ActiveChaos::default());
     world.insert_resource(ActiveRoomStimuli::default());
     world.insert_resource(RoomPhysicsState::default());
+    world.insert_resource(RoomPhysicsWorkspace::default());
     world.insert_resource(ActiveAgentsThisTick::default());
     world.insert_resource(RoomChatBuffer::default());
     world.insert_resource(GaiaBuffer::default());
@@ -1427,6 +1579,47 @@ pub fn restore_ecs_state(world: &mut World, snapshot: &sentinel_common::EcsSnaps
         {
             world.insert_resource(stimuli);
         }
+    }
+}
+
+#[cfg(test)]
+mod room_physics_workspace_tests {
+    use super::*;
+
+    #[test]
+    fn create_world_registers_room_physics_workspace() {
+        let (world, _) = create_simulation_world();
+        assert!(world.get_resource::<RoomPhysicsWorkspace>().is_some());
+    }
+
+    #[test]
+    fn room_physics_workspace_reuses_room_storage_after_clear() {
+        let mut workspace = RoomPhysicsWorkspace::default();
+        assert!(workspace.room_capacity() >= ROOM_PHYSICS_WORKSPACE_CAPACITY);
+
+        for index in 0..40 {
+            workspace.ensure_room(&format!("room-{index:02}"));
+        }
+        let expanded_capacity = workspace.room_capacity();
+        assert!(expanded_capacity >= 40);
+
+        workspace.clear();
+        assert_eq!(workspace.len(), 0);
+        assert_eq!(workspace.room_capacity(), expanded_capacity);
+
+        workspace.ensure_room("empfang");
+        assert_eq!(workspace.room_capacity(), expanded_capacity);
+    }
+
+    #[test]
+    fn room_physics_workspace_merges_occupants_by_room() {
+        let mut workspace = RoomPhysicsWorkspace::default();
+
+        workspace.add_occupant("empfang", false);
+        workspace.add_occupant("empfang", true);
+
+        assert_eq!(workspace.len(), 1);
+        assert_eq!(workspace.room_stats(0), ("empfang", 2, true));
     }
 }
 

--- a/crates/sentinel-ecs/src/world.rs
+++ b/crates/sentinel-ecs/src/world.rs
@@ -555,6 +555,81 @@ impl PersistTelemetry {
     }
 }
 
+const PERSIST_WORKSPACE_CAPACITY: usize = 64;
+const PERSIST_TOPIC_CAPACITY: usize = 96;
+
+/// Reusable scratch storage for the Limbo write phase of a tick.
+#[derive(Resource, Debug, Clone)]
+pub struct PersistWorkspace {
+    events: Vec<DomainEvent>,
+    topics: Vec<String>,
+    active_len: usize,
+}
+
+impl Default for PersistWorkspace {
+    fn default() -> Self {
+        Self {
+            events: Vec::with_capacity(PERSIST_WORKSPACE_CAPACITY),
+            topics: Vec::with_capacity(PERSIST_WORKSPACE_CAPACITY),
+            active_len: 0,
+        }
+    }
+}
+
+impl PersistWorkspace {
+    pub fn clear(&mut self) {
+        self.events.clear();
+        self.active_len = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.active_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active_len == 0
+    }
+
+    pub fn push_with_topic<F>(&mut self, event: DomainEvent, write_topic: F)
+    where
+        F: FnOnce(&mut String, &DomainEvent),
+    {
+        let index = self.active_len;
+        if self.topics.len() == index {
+            self.topics
+                .push(String::with_capacity(PERSIST_TOPIC_CAPACITY));
+        }
+
+        let topic = &mut self.topics[index];
+        topic.clear();
+        write_topic(topic, &event);
+        self.events.push(event);
+        self.active_len += 1;
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&DomainEvent, &str)> {
+        self.events[..self.active_len]
+            .iter()
+            .zip(self.topics[..self.active_len].iter())
+            .map(|(event, topic)| (event, topic.as_str()))
+    }
+
+    pub fn drain_events(&mut self) -> std::vec::Drain<'_, DomainEvent> {
+        self.active_len = 0;
+        self.events.drain(..)
+    }
+
+    #[cfg(test)]
+    pub fn event_capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
+    #[cfg(test)]
+    pub fn topic_capacity(&self, index: usize) -> Option<usize> {
+        self.topics.get(index).map(String::capacity)
+    }
+}
+
 /// Empfaengt AgentActions vom externen Zenoh-Subscriber (oder Test-Code).
 /// Mutex-wrapped weil std::sync::mpsc::Receiver nicht Sync ist (bevy_ecs braucht Sync).
 #[derive(Resource)]
@@ -1089,6 +1164,7 @@ pub fn create_simulation_world() -> (World, Schedule) {
     // Resources einfuegen
     world.insert_resource(SimulationTime::default());
     world.insert_resource(PersistTelemetry::default());
+    world.insert_resource(PersistWorkspace::default());
     world.insert_resource(EventBuffer::default());
     world.insert_resource(ActiveSmells::default());
     world.insert_resource(ActiveChaos::default());
@@ -1620,6 +1696,72 @@ mod room_physics_workspace_tests {
 
         assert_eq!(workspace.len(), 1);
         assert_eq!(workspace.room_stats(0), ("empfang", 2, true));
+    }
+}
+
+#[cfg(test)]
+mod persist_workspace_tests {
+    use super::*;
+
+    fn push_default_topic(workspace: &mut PersistWorkspace, event: DomainEvent) {
+        workspace.push_with_topic(event, |topic, event| {
+            topic.push_str("sentinel/events/");
+            topic.push_str(&event.event_type);
+            topic.push('/');
+            topic.push_str(&event.aggregate_id);
+        });
+    }
+
+    #[test]
+    fn create_world_registers_persist_workspace() {
+        let (world, _) = create_simulation_world();
+        assert!(world.get_resource::<PersistWorkspace>().is_some());
+    }
+
+    #[test]
+    fn persist_workspace_reuses_topic_storage_after_clear() {
+        let mut workspace = PersistWorkspace::default();
+        assert!(workspace.event_capacity() >= PERSIST_WORKSPACE_CAPACITY);
+
+        let event = DomainEvent::new("agent_action_received", "AGENT-01", "{}", "corr-1", 1);
+        push_default_topic(&mut workspace, event);
+        let topic_capacity = workspace.topic_capacity(0).unwrap();
+
+        workspace.clear();
+        let event = DomainEvent::new("agent_action_received", "AGENT-02", "{}", "corr-2", 2);
+        push_default_topic(&mut workspace, event);
+
+        assert_eq!(workspace.len(), 1);
+        assert_eq!(workspace.topic_capacity(0), Some(topic_capacity));
+    }
+
+    #[test]
+    fn persist_workspace_preserves_entry_order() {
+        let mut workspace = PersistWorkspace::default();
+        let first = DomainEvent::new("agent_action_received", "AGENT-01", "{}", "corr-1", 1);
+        let second = DomainEvent::new("transit_started", "AGENT-02", "{}", "corr-2", 2);
+
+        push_default_topic(&mut workspace, first);
+        push_default_topic(&mut workspace, second);
+
+        let entries: Vec<_> = workspace
+            .entries()
+            .map(|(event, topic)| (event.event_type.as_str(), topic))
+            .collect();
+
+        assert_eq!(
+            entries,
+            vec![
+                (
+                    "agent_action_received",
+                    "sentinel/events/agent_action_received/AGENT-01"
+                ),
+                (
+                    "transit_started",
+                    "sentinel/events/transit_started/AGENT-02"
+                )
+            ]
+        );
     }
 }
 

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -12,6 +12,7 @@
 //! 3. Realistisches Mixed-Workload Szenario
 
 use std::hint::black_box;
+use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use sentinel_common::DomainEvent;
@@ -78,11 +79,53 @@ fn make_issue276_event(tick: u64, agent: u64) -> DomainEvent {
     )
 }
 
+fn deterministic_uuidish(tick: u64, agent: u64, salt: u64) -> String {
+    format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        (tick ^ salt) as u32,
+        agent as u16,
+        ((tick >> 16) as u16) | 0x4000,
+        ((agent as u16) & 0x0fff) | 0x8000,
+        tick.wrapping_mul(31).wrapping_add(agent).wrapping_add(salt) & 0x0000_ffff_ffff_ffff
+    )
+}
+
+fn make_issue276_prebuilt_event(tick: u64, agent: u64) -> DomainEvent {
+    DomainEvent {
+        event_id: deterministic_uuidish(tick, agent, 0x276),
+        event_type: "agent_action_received".to_string(),
+        aggregate_id: format!("AGENT-{agent:02}"),
+        payload: format!(r#"{{"tick":{tick},"action":"work","agent":{agent}}}"#),
+        correlation_id: format!("issue276-corr-{tick}"),
+        causation_id: None,
+        operation_id: deterministic_uuidish(tick, agent, 0x2760),
+        tick: tick * 100,
+        timestamp_ms: 1_700_000_000_000 + tick * 100 + agent,
+        schema_version: 1,
+        compensation_type: "none".to_string(),
+    }
+}
+
 fn issue276_topic(event: &DomainEvent) -> String {
     format!(
         "sentinel/events/{}/{}",
         event.event_type, event.aggregate_id
     )
+}
+
+fn prebuild_issue276_batches(start_tick: u64, batch_count: u64) -> Vec<Vec<(DomainEvent, String)>> {
+    (0..batch_count)
+        .map(|offset| {
+            let tick = start_tick + offset;
+            (1..=ISSUE276_ACTIVE_AGENTS)
+                .map(|agent| {
+                    let event = make_issue276_prebuilt_event(tick, agent);
+                    let topic = issue276_topic(&event);
+                    (event, topic)
+                })
+                .collect()
+        })
+        .collect()
 }
 
 fn bench_issue276_persist_26_events_individual_tx(c: &mut Criterion) {
@@ -99,6 +142,30 @@ fn bench_issue276_persist_26_events_individual_tx(c: &mut Criterion) {
                 black_box(store.append_with_outbox(&event, &topic).unwrap());
             }
             tick += 1;
+        });
+    });
+}
+
+fn bench_issue276_persist_26_events_individual_tx_prebuilt(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_issue276_persist_prebuilt.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut next_tick = 0u64;
+    c.bench_function("issue276.persist_26_events_individual_tx_prebuilt", |b| {
+        b.iter_custom(|iters| {
+            let batches = prebuild_issue276_batches(next_tick, iters);
+            next_tick += iters;
+
+            let mut total = Duration::ZERO;
+            for batch in &batches {
+                let start = Instant::now();
+                for (event, topic) in batch {
+                    black_box(store.append_with_outbox(event, topic).unwrap());
+                }
+                total += start.elapsed();
+            }
+            total
         });
     });
 }
@@ -126,6 +193,34 @@ fn bench_issue276_persist_26_events_batch_tx(c: &mut Criterion) {
                     .unwrap(),
             );
             tick += 1;
+        });
+    });
+}
+
+fn bench_issue276_persist_26_events_batch_tx_prebuilt(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_issue276_persist_batch_prebuilt.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut next_tick = 0u64;
+    c.bench_function("issue276.persist_26_events_batch_tx_prebuilt", |b| {
+        b.iter_custom(|iters| {
+            let batches = prebuild_issue276_batches(next_tick, iters);
+            next_tick += iters;
+
+            let mut total = Duration::ZERO;
+            for batch in &batches {
+                let start = Instant::now();
+                black_box(
+                    store
+                        .append_with_outbox_batch(
+                            batch.iter().map(|(event, topic)| (event, topic.as_str())),
+                        )
+                        .unwrap(),
+                );
+                total += start.elapsed();
+            }
+            total
         });
     });
 }
@@ -435,7 +530,9 @@ criterion_group!(
     bench_append_event,
     bench_append_with_outbox,
     bench_issue276_persist_26_events_individual_tx,
+    bench_issue276_persist_26_events_individual_tx_prebuilt,
     bench_issue276_persist_26_events_batch_tx,
+    bench_issue276_persist_26_events_batch_tx_prebuilt,
     bench_get_events_since,
     bench_get_events_by_aggregate,
     bench_save_snapshot,

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -19,6 +19,8 @@ use sentinel_limbo::EventStore;
 
 /// Anzahl Agents pro Schicht (SSOT: config/rooms.toml + sprint2-domain.md)
 const AGENTS_PER_SHIFT: u64 = 15;
+/// Aktive Agents fuer Issue #276 Tick-Loop-Hot-Path Messungen.
+const ISSUE276_ACTIVE_AGENTS: u64 = 26;
 /// Tick-Rate Schwellenwert aus CLAUDE.md (>100 ticks/s)
 const MIN_TICKS_PER_SECOND: u64 = 100;
 
@@ -62,6 +64,33 @@ fn bench_append_with_outbox(c: &mut Criterion) {
                     .unwrap(),
             );
             i += 1;
+        });
+    });
+}
+
+fn bench_issue276_persist_26_events_individual_tx(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_issue276_persist.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut tick = 0u64;
+    c.bench_function("issue276.persist_26_events_individual_tx", |b| {
+        b.iter(|| {
+            for agent in 1..=ISSUE276_ACTIVE_AGENTS {
+                let event = DomainEvent::new(
+                    "agent_action_received",
+                    &format!("AGENT-{agent:02}"),
+                    &format!(r#"{{"tick":{tick},"action":"work","agent":{agent}}}"#),
+                    &format!("issue276-corr-{tick}"),
+                    tick * 100,
+                );
+                let topic = format!(
+                    "sentinel/events/{}/{}",
+                    event.event_type, event.aggregate_id
+                );
+                black_box(store.append_with_outbox(&event, &topic).unwrap());
+            }
+            tick += 1;
         });
     });
 }
@@ -370,6 +399,7 @@ criterion_group!(
     // Einzeloperationen
     bench_append_event,
     bench_append_with_outbox,
+    bench_issue276_persist_26_events_individual_tx,
     bench_get_events_since,
     bench_get_events_by_aggregate,
     bench_save_snapshot,

--- a/crates/sentinel-limbo/benches/event_store_bench.rs
+++ b/crates/sentinel-limbo/benches/event_store_bench.rs
@@ -68,6 +68,23 @@ fn bench_append_with_outbox(c: &mut Criterion) {
     });
 }
 
+fn make_issue276_event(tick: u64, agent: u64) -> DomainEvent {
+    DomainEvent::new(
+        "agent_action_received",
+        &format!("AGENT-{agent:02}"),
+        &format!(r#"{{"tick":{tick},"action":"work","agent":{agent}}}"#),
+        &format!("issue276-corr-{tick}"),
+        tick * 100,
+    )
+}
+
+fn issue276_topic(event: &DomainEvent) -> String {
+    format!(
+        "sentinel/events/{}/{}",
+        event.event_type, event.aggregate_id
+    )
+}
+
 fn bench_issue276_persist_26_events_individual_tx(c: &mut Criterion) {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bench_issue276_persist.db");
@@ -77,19 +94,37 @@ fn bench_issue276_persist_26_events_individual_tx(c: &mut Criterion) {
     c.bench_function("issue276.persist_26_events_individual_tx", |b| {
         b.iter(|| {
             for agent in 1..=ISSUE276_ACTIVE_AGENTS {
-                let event = DomainEvent::new(
-                    "agent_action_received",
-                    &format!("AGENT-{agent:02}"),
-                    &format!(r#"{{"tick":{tick},"action":"work","agent":{agent}}}"#),
-                    &format!("issue276-corr-{tick}"),
-                    tick * 100,
-                );
-                let topic = format!(
-                    "sentinel/events/{}/{}",
-                    event.event_type, event.aggregate_id
-                );
+                let event = make_issue276_event(tick, agent);
+                let topic = issue276_topic(&event);
                 black_box(store.append_with_outbox(&event, &topic).unwrap());
             }
+            tick += 1;
+        });
+    });
+}
+
+fn bench_issue276_persist_26_events_batch_tx(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bench_issue276_persist_batch.db");
+    let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+    let mut tick = 0u64;
+    c.bench_function("issue276.persist_26_events_batch_tx", |b| {
+        b.iter(|| {
+            let mut entries = Vec::with_capacity(ISSUE276_ACTIVE_AGENTS as usize);
+            for agent in 1..=ISSUE276_ACTIVE_AGENTS {
+                let event = make_issue276_event(tick, agent);
+                let topic = issue276_topic(&event);
+                entries.push((event, topic));
+            }
+
+            black_box(
+                store
+                    .append_with_outbox_batch(
+                        entries.iter().map(|(event, topic)| (event, topic.as_str())),
+                    )
+                    .unwrap(),
+            );
             tick += 1;
         });
     });
@@ -400,6 +435,7 @@ criterion_group!(
     bench_append_event,
     bench_append_with_outbox,
     bench_issue276_persist_26_events_individual_tx,
+    bench_issue276_persist_26_events_batch_tx,
     bench_get_events_since,
     bench_get_events_by_aggregate,
     bench_save_snapshot,

--- a/crates/sentinel-limbo/src/event_store.rs
+++ b/crates/sentinel-limbo/src/event_store.rs
@@ -305,6 +305,74 @@ impl EventStore {
         Ok(row_id)
     }
 
+    /// Atomar: mehrere Events + Outbox-Eintraege in einer Transaktion.
+    ///
+    /// Nutzt dieselbe operation_id-Idempotenz wie `append_with_outbox`.
+    /// Duplikate werden ignoriert und erzeugen keinen Outbox-Eintrag.
+    pub fn append_with_outbox_batch<'a, I>(&self, entries: I) -> anyhow::Result<usize>
+    where
+        I: IntoIterator<Item = (&'a DomainEvent, &'a str)>,
+    {
+        let _telemetry_start = std::time::Instant::now();
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let tx = conn.transaction()?;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let inserted_count = {
+            let mut insert_event = tx.prepare(
+                "INSERT OR IGNORE INTO events (event_id, event_type, aggregate_id, payload, correlation_id, causation_id, operation_id, tick, timestamp_ms, schema_version, compensation_type) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            )?;
+            let mut insert_outbox = tx.prepare(
+                "INSERT INTO outbox (event_id, topic, payload, status, created_at) VALUES (?1, ?2, ?3, 'pending', ?4)",
+            )?;
+            let mut inserted_count = 0usize;
+
+            for (event, topic) in entries {
+                let inserted = insert_event.execute(params![
+                    event.event_id,
+                    event.event_type,
+                    event.aggregate_id,
+                    event.payload,
+                    event.correlation_id,
+                    event.causation_id,
+                    event.operation_id,
+                    event.tick as i64,
+                    event.timestamp_ms as i64,
+                    event.schema_version,
+                    event.compensation_type,
+                ])?;
+
+                if inserted > 0 {
+                    insert_outbox.execute(params![event.event_id, topic, event.payload, now_ms])?;
+                    inserted_count += inserted;
+                }
+            }
+
+            inserted_count
+        };
+
+        tx.commit()?;
+
+        #[cfg(feature = "telemetry")]
+        {
+            let reg = sentinel_telemetry::MetricsRegistry::global();
+            reg.counter("sentinel.limbo.event.append_outbox_batch.count")
+                .increment_by(inserted_count as u64);
+            reg.histogram(
+                "sentinel.limbo.event.append_outbox_batch.duration_us",
+                LATENCY_BUCKETS,
+            )
+            .observe(_telemetry_start.elapsed().as_micros() as f64);
+        }
+        Ok(inserted_count)
+    }
+
     /// Liest Events nach einer bestimmten internen ID (Cursor-basiert).
     pub fn get_events_since(
         &self,
@@ -1087,6 +1155,100 @@ mod tests {
         // Nur 1 Outbox-Eintrag
         let outbox = store.poll_outbox(10).unwrap();
         assert_eq!(outbox.len(), 1, "Duplicate should not create outbox entry");
+    }
+
+    #[test]
+    fn test_append_with_outbox_batch_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-batch-empty.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let inserted = store
+            .append_with_outbox_batch(std::iter::empty::<(&DomainEvent, &str)>())
+            .unwrap();
+        assert_eq!(inserted, 0);
+
+        let conn = store.conn();
+        let event_count: i64 = conn
+            .query_row("SELECT count(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+        let outbox_count: i64 = conn
+            .query_row("SELECT count(*) FROM outbox", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(event_count, 0);
+        assert_eq!(outbox_count, 0);
+    }
+
+    #[test]
+    fn test_append_with_outbox_batch_preserves_order_and_outbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-batch-order.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let event_a = test_event("agent_action_received", "AGENT-01");
+        let event_b = test_event("transit_started", "AGENT-02");
+        let event_c = test_event("transit_completed", "AGENT-03");
+        let entries = [
+            (&event_a, "sentinel/events/agent_action_received/AGENT-01"),
+            (&event_b, "sentinel/events/transit_started/AGENT-02"),
+            (&event_c, "sentinel/events/transit_completed/AGENT-03"),
+        ];
+
+        let inserted = store.append_with_outbox_batch(entries).unwrap();
+        assert_eq!(inserted, 3);
+
+        let events = store.get_events_since(0, 10).unwrap();
+        let event_ids: Vec<&str> = events.iter().map(|event| event.event_id.as_str()).collect();
+        assert_eq!(
+            event_ids,
+            vec![
+                event_a.event_id.as_str(),
+                event_b.event_id.as_str(),
+                event_c.event_id.as_str()
+            ]
+        );
+
+        let outbox = store.poll_outbox(10).unwrap();
+        let outbox_event_ids: Vec<&str> =
+            outbox.iter().map(|entry| entry.event_id.as_str()).collect();
+        assert_eq!(outbox_event_ids, event_ids);
+        assert_eq!(
+            outbox[0].topic,
+            "sentinel/events/agent_action_received/AGENT-01"
+        );
+        assert_eq!(outbox[1].topic, "sentinel/events/transit_started/AGENT-02");
+        assert_eq!(
+            outbox[2].topic,
+            "sentinel/events/transit_completed/AGENT-03"
+        );
+    }
+
+    #[test]
+    fn test_append_with_outbox_batch_idempotency() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-batch-idempotency.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let mut event = test_event("agent_action_received", "AGENT-01");
+        event.operation_id = "op-batch-fixed".to_string();
+        let mut duplicate = test_event("agent_action_received", "AGENT-02");
+        duplicate.operation_id = "op-batch-fixed".to_string();
+
+        let inserted = store
+            .append_with_outbox_batch([
+                (&event, "sentinel/events/agent_action_received/AGENT-01"),
+                (&duplicate, "sentinel/events/agent_action_received/AGENT-02"),
+            ])
+            .unwrap();
+        assert_eq!(inserted, 1);
+
+        let events = store.get_events_since(0, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, event.event_id);
+
+        let outbox = store.poll_outbox(10).unwrap();
+        assert_eq!(outbox.len(), 1);
+        assert_eq!(outbox[0].event_id, event.event_id);
     }
 
     /// AC4: causation_id Kette - Event B.causation_id == Event A.event_id

--- a/crates/sentinel-wasm/Cargo.toml
+++ b/crates/sentinel-wasm/Cargo.toml
@@ -15,8 +15,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 sentinel-common = { path = "../sentinel-common" }
-wasmtime = { version = "42", features = ["component-model"], optional = true }
-wasmtime-wasi = { version = "42", optional = true }
+wasmtime = { version = "44.0.2", features = ["component-model"], optional = true }
+wasmtime-wasi = { version = "44.0.2", optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/sentinel-wasm/src/lib.rs
+++ b/crates/sentinel-wasm/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides sandboxed tool execution with capability-based access control.
 //! Native handlers for FileRead/FileWrite enforce filesystem restrictions.
-//! WASM Component Model plugins execute via wasmtime 42 (enable with `--features wasm`).
+//! WASM Component Model plugins execute via wasmtime 44 (enable with `--features wasm`).
 
 pub mod registry;
 pub mod runner;

--- a/dashboard/public/css/style.css
+++ b/dashboard/public/css/style.css
@@ -539,6 +539,62 @@ main { padding: 2rem; }
 }
 .metric-card .value { font-size: 2rem; font-weight: 700; color: var(--accent); }
 .metric-card .label { font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.3rem; }
+.benchmark-panel {
+  margin-top: 1.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.2rem;
+}
+.benchmark-panel h2 {
+  font-size: 1rem;
+  margin-bottom: 0.4rem;
+  color: var(--bright);
+}
+.benchmark-meta {
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  margin-bottom: 0.9rem;
+}
+.benchmark-body {
+  overflow-x: auto;
+}
+.benchmark-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 920px;
+}
+.benchmark-table th,
+.benchmark-table td {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82rem;
+}
+.benchmark-table th {
+  color: var(--text-secondary);
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+}
+.benchmark-table td {
+  color: var(--text-primary);
+}
+.benchmark-table td:last-child {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+.benchmark-table td:nth-child(4) {
+  color: var(--success);
+  font-weight: 700;
+}
+.benchmark-notes {
+  margin-top: 0.9rem;
+  padding-left: 1.1rem;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
 
 /* eBPF Metrics Grid */
 .ebpf-grid {

--- a/dashboard/public/js/metrics.js
+++ b/dashboard/public/js/metrics.js
@@ -51,6 +51,7 @@ export function renderMetrics(metrics) {
   }
 
   container.appendChild(grid);
+  renderBenchmarkSnapshot(container);
 }
 
 function formatUptime(seconds) {
@@ -95,6 +96,98 @@ function fetchEbpfStatus(badge, retries) {
       badge.className = 'ebpf-badge unavailable';
       badge.textContent = 'eBPF: N/A';
     });
+}
+
+function renderBenchmarkSnapshot(container) {
+  const section = document.createElement('section');
+  section.className = 'benchmark-panel';
+  section.id = 'issue276-benchmarks';
+
+  const heading = document.createElement('h2');
+  heading.textContent = 'Tick-Loop Benchmarks #276';
+  section.appendChild(heading);
+
+  const meta = document.createElement('div');
+  meta.className = 'benchmark-meta';
+  meta.textContent = 'Lade Benchmark-Snapshot...';
+  section.appendChild(meta);
+
+  const body = document.createElement('div');
+  body.className = 'benchmark-body';
+  section.appendChild(body);
+
+  container.appendChild(section);
+
+  fetch('/api/metrics/benchmarks')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      renderBenchmarkTable(meta, body, data);
+    })
+    .catch(function() {
+      meta.textContent = 'Benchmark-Snapshot nicht verfuegbar';
+    });
+}
+
+function renderBenchmarkTable(meta, body, data) {
+  while (body.firstChild) body.removeChild(body.firstChild);
+
+  meta.textContent = data.host + ' / ' + data.cpu + ' / ' + data.comparison_scope;
+
+  const table = document.createElement('table');
+  table.className = 'benchmark-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  for (const label of ['Pfad', 'Vorher', 'Nachher', 'Delta', 'System']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  for (const row of data.results || []) {
+    const tr = document.createElement('tr');
+    appendBenchmarkCell(tr, row.label + ' (' + row.after_benchmark + ')');
+    appendBenchmarkCell(tr, formatNsWithSpread(row.before_ns_per_iter, row.before_stddev_ns_per_iter));
+    appendBenchmarkCell(tr, formatNsWithSpread(row.after_ns_per_iter, row.after_stddev_ns_per_iter));
+    appendBenchmarkCell(tr, row.improvement_percent.toFixed(2) + '% schneller');
+    appendBenchmarkCell(tr, row.system_metrics_summary);
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  body.appendChild(table);
+
+  if (Array.isArray(data.notes) && data.notes.length > 0) {
+    const notes = document.createElement('ul');
+    notes.className = 'benchmark-notes';
+    for (const note of data.notes) {
+      const item = document.createElement('li');
+      item.textContent = note;
+      notes.appendChild(item);
+    }
+    body.appendChild(notes);
+  }
+}
+
+function appendBenchmarkCell(row, text) {
+  const td = document.createElement('td');
+  td.textContent = text;
+  row.appendChild(td);
+}
+
+function formatNs(ns) {
+  if (ns == null) return '--';
+  if (ns >= 1_000_000) return (ns / 1_000_000).toFixed(2) + ' ms';
+  if (ns >= 1_000) return (ns / 1_000).toFixed(2) + ' us';
+  return String(ns) + ' ns';
+}
+
+function formatNsWithSpread(ns, spread) {
+  const base = formatNs(ns);
+  if (spread == null) return base;
+  return base + ' +/- ' + formatNs(spread);
 }
 
 function renderEbpfCards(container, data) {

--- a/dashboard/src/__tests__/acceptance.test.ts
+++ b/dashboard/src/__tests__/acceptance.test.ts
@@ -295,6 +295,18 @@ describe("Acceptance Tests - Issue #24: Dashboard Live-Daten", () => {
     expect(typeof data.uptime).toBe("number");
   });
 
+  test("AC-276: /api/metrics/benchmarks exposes VM benchmark evidence", async () => {
+    const res = await app.request("/api/metrics/benchmarks");
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.issue).toBe(276);
+    expect(data.host).toBe("sentinel-ubuntu-2404");
+    expect(data.cpu).toContain("i7-3930K");
+    expect(data.notes.join(" ")).toContain("gateway");
+    expect(data.results.find((row: { id: string }) => row.id === "persist-prebuilt").improvement_percent).toBe(86.95);
+  });
+
   // AC-5: GET /api/health hat projection_lag
   test("AC-5: /api/health returns projection_lag from EventStore", async () => {
     const res = await app.request("/api/health");

--- a/dashboard/src/__tests__/api.test.ts
+++ b/dashboard/src/__tests__/api.test.ts
@@ -144,6 +144,24 @@ describe("Dashboard API", () => {
     expect(data.total_transits).toBe(5);
   });
 
+  it("GET /api/metrics/benchmarks returns issue #276 VM-relative results", async () => {
+    const res = await app.request("/api/metrics/benchmarks");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.issue).toBe(276);
+    expect(data.cpu).toContain("i7-3930K");
+    expect(data.comparison_scope).toContain("Deploy-VM same-machine");
+    expect(data.results.map((row: { id: string }) => row.id)).toEqual([
+      "physics",
+      "perception",
+      "persist",
+      "persist-prebuilt",
+      "bio-tick",
+    ]);
+    expect(data.results[0].before_ns_per_iter).toBe(1_172_325);
+    expect(data.results[0].after_ns_per_iter).toBe(857_440);
+  });
+
   it("GET /api/agents/:id/state returns 404 for unknown", async () => {
     const res = await app.request("/api/agents/999/state");
     expect(res.status).toBe(404);

--- a/dashboard/src/routes/metrics.ts
+++ b/dashboard/src/routes/metrics.ts
@@ -1,10 +1,97 @@
 import { Hono } from "hono";
 import { getLatestKpi, getProjectionLag, getActiveAgents, getTotalEventCount, getEventRatePerMinute, getRecentEvolutionAlerts, getLastNightrunStats } from "../db";
-import type { MetricsResponse, HealthResponse } from "../types";
+import type { BenchmarkSnapshotResponse, MetricsResponse, HealthResponse } from "../types";
 
 export const metricRoutes = new Hono();
 
 const startTime = Date.now();
+
+const ISSUE_276_BENCHMARKS: BenchmarkSnapshotResponse = {
+  issue: 276,
+  title: "ECS tick-loop hot-path",
+  measured_at: "2026-05-28T18:33:14+02:00",
+  host: "sentinel-ubuntu-2404",
+  cpu: "Intel Core i7-3930K @ 3.20 GHz (2011, KVM, 8 vCPU, taskset core 2)",
+  comparison_scope: "Deploy-VM same-machine before/after only; TOGAF absolute baselines intentionally not used",
+  notes: [
+    "Measured on ubuntu@10.0.0.240 with sentinel-gateway and health-monitor timer stopped.",
+    "Deploy config excludes sentinel-gateway from platform-controlplane monitored_services so gateway-off smokes stay stable.",
+    "Persist benches are storage-bound on this VM; relative deltas are valid, absolute latency is not a production-baseline gate.",
+    "prepare_cached/IMMEDIATE EventStore trial was rejected after mixed A/B results; gateway self-heal restart was treated as a benchmark anomaly and fixed by config.",
+  ],
+  results: [
+    {
+      id: "physics",
+      label: "Physics",
+      before_benchmark: "issue276.physics_system/tick_26_agents",
+      after_benchmark: "issue276.physics_system/tick_26_agents",
+      before_ns_per_iter: 1_172_325,
+      before_stddev_ns_per_iter: 35_864,
+      after_ns_per_iter: 857_440,
+      after_stddev_ns_per_iter: 24_774,
+      improvement_percent: 26.86,
+      system_metrics_log_dir: "/tmp/issue-276-bench/logs clean-baseline-tick clean-after2-tick",
+      system_metrics_summary: "CPU-pinned run; mpstat iowait 0.01%, sda util below 0.3%.",
+      note: "RoomPhysicsWorkspace removes per-tick HashMap allocation and keeps room aggregation in reusable Vec storage.",
+    },
+    {
+      id: "perception",
+      label: "Perception",
+      before_benchmark: "issue276.generate_perception/texts_26_agents",
+      after_benchmark: "issue276.generate_perception/texts_26_agents",
+      before_ns_per_iter: 149_127,
+      before_stddev_ns_per_iter: 3_788,
+      after_ns_per_iter: 109_845,
+      after_stddev_ns_per_iter: 4_944,
+      improvement_percent: 26.34,
+      system_metrics_log_dir: "/tmp/issue-276-bench/logs clean-baseline-tick clean-after2-tick",
+      system_metrics_summary: "CPU-pinned run; same tick benchmark pass as physics.",
+      note: "generate_perception_into reuses caller-owned buffers and static text fragments where output is deterministic.",
+    },
+    {
+      id: "persist",
+      label: "Persist e2e",
+      before_benchmark: "issue276.persist_26_events_individual_tx",
+      after_benchmark: "issue276.persist_26_events_batch_tx",
+      before_ns_per_iter: 40_377_309,
+      before_stddev_ns_per_iter: 17_368_530,
+      after_ns_per_iter: 19_151_838,
+      after_stddev_ns_per_iter: 6_010_275,
+      improvement_percent: 52.57,
+      system_metrics_log_dir: "/tmp/issue-276-bench/logs clean-baseline-persist-individual clean-after2-persist-batch",
+      system_metrics_summary: "Storage-bound SQLite path; mpstat iowait about 8%, sda util about 63-65%.",
+      note: "append_with_outbox_batch writes all 26 events/outbox rows in one SQLite transaction.",
+    },
+    {
+      id: "persist-prebuilt",
+      label: "Persist write-only",
+      before_benchmark: "issue276.persist_26_events_individual_tx_prebuilt",
+      after_benchmark: "issue276.persist_26_events_batch_tx_prebuilt",
+      before_ns_per_iter: 34_143_782,
+      before_stddev_ns_per_iter: 12_614_457,
+      after_ns_per_iter: 4_454_866,
+      after_stddev_ns_per_iter: 1_560_601,
+      improvement_percent: 86.95,
+      system_metrics_log_dir: "/tmp/issue-276-bench/logs clean2-after2-persist-individual-prebuilt clean2-after2-persist-batch-prebuilt",
+      system_metrics_summary: "Events/topics prebuilt to isolate store writes; still storage-bound on sda.",
+      note: "This isolates EventStore write behavior from UUID/getrandom and event construction overhead.",
+    },
+    {
+      id: "bio-tick",
+      label: "Full tick",
+      before_benchmark: "room_phase2.bio_tick_26_agents",
+      after_benchmark: "room_phase2.bio_tick_26_agents",
+      before_ns_per_iter: 2_357_373,
+      before_stddev_ns_per_iter: 186_539,
+      after_ns_per_iter: 1_951_265,
+      after_stddev_ns_per_iter: 84_290,
+      improvement_percent: 17.23,
+      system_metrics_log_dir: "/tmp/issue-276-bench/logs clean-baseline-bio clean-after2-bio",
+      system_metrics_summary: "CPU-pinned full tick run; mpstat iowait 0.01%, sda util below 0.5%.",
+      note: "Regression guard: total 26-agent tick improved on the same VM.",
+    },
+  ],
+};
 
 metricRoutes.get("/metrics", async (c) => {
   const kpi = getLatestKpi();
@@ -67,6 +154,8 @@ metricRoutes.get("/metrics", async (c) => {
     psi_io: psi_io / 1000,
   });
 });
+
+metricRoutes.get("/metrics/benchmarks", (c) => c.json(ISSUE_276_BENCHMARKS));
 
 metricRoutes.get("/ebpf/status", async (c) => {
   try {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -170,6 +170,32 @@ export interface MetricsResponse {
   event_rate_per_min: number;
 }
 
+export interface BenchmarkResult {
+  id: string;
+  label: string;
+  before_benchmark: string;
+  after_benchmark: string;
+  before_ns_per_iter: number;
+  before_stddev_ns_per_iter: number;
+  after_ns_per_iter: number;
+  after_stddev_ns_per_iter: number;
+  improvement_percent: number;
+  system_metrics_log_dir: string;
+  system_metrics_summary: string;
+  note: string;
+}
+
+export interface BenchmarkSnapshotResponse {
+  issue: number;
+  title: string;
+  measured_at: string;
+  host: string;
+  cpu: string;
+  comparison_scope: string;
+  notes: string[];
+  results: BenchmarkResult[];
+}
+
 // ── Chaos Event Feed ────────────────────────────
 
 export interface ChaosEventItem {

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -90,7 +90,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | Encounter-detection benchmark | ✅ | 7.34 – 8.05 µs |
 | Bio-tick benchmark            | ✅ | 154 – 171 µs |
 | Synthesis-engine latency      | ✅ | 95 – 103 µs end-to-end |
-| Tick-loop hot-path (#276)     | ⏳ | open issue, planned post-v0.1.0-alpha |
+| Tick-loop hot-path (#276)     | ✅ | Deploy-VM relative before/after on Intel i7-3930K @ 3.20 GHz (2011): physics 26.86% faster, perception 26.34% faster, persist e2e batch 52.57% faster, persist write-only batch 86.95% faster, full tick 17.23% faster; absolute TOGAF baselines intentionally not used for this hardware |
 
 ## Cluster 07 — Deployment & Tuning
 
@@ -143,7 +143,6 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | GitHub issue | Cluster | Topic |
 |--------------|---------|-------|
 | #266 | 01 | Gaia firmen-konfigurator (multi-tenant company definitions) |
-| #276 | 06 | Tick-loop hot-path optimisation |
 | #277 | 05b | Dashboard polling efficiency |
 | #278 | 11 | Non-blocking nightrun |
 | #336 | 10 | Acronym glossary section + README cross-links (good-first-issue) |

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 use (
 	./cmd/cortex-gateway

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,5 @@
+github.com/silentspike/project-sentinel/pkg/sentinel-go v0.0.0-20260426185014-30c7fd621515/go.mod h1:O23Is4HFuLB04LZFerrjWhIsX/W9wWmlGRlusXQVUdM=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -363,6 +363,14 @@ fn spawn_agent_full(
                             );
                         }
                     }
+                } else {
+                    record_security_runtime_snapshot(
+                        security_runtime_state,
+                        agent_id,
+                        &agent_cfg.identity.name,
+                        None,
+                        fs_mount,
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Implements Issue #276 ECS tick-loop hot-path optimization with VM-only before/after benchmark evidence on the Deploy-VM (`ubuntu@10.0.0.240`). The change removes avoidable per-tick allocation pressure from room physics, perception text generation, and event persistence while preserving deterministic behavior.

## Changes

- Added Criterion coverage for isolated physics, perception, persist, persist write-only, and full tick paths.
- Replaced room-physics per-tick maps with `RoomPhysicsWorkspace` reusable ECS storage.
- Added perception buffer reuse via `generate_perception_into` and static fragments for deterministic text.
- Added Limbo event/outbox batch persistence and ECS `PersistWorkspace` reuse.
- Exposed Issue #276 benchmark evidence through `/api/metrics/benchmarks` and the dashboard UI.
- Updated Wasmtime dependencies to `44.0.2` for RUSTSEC-2026-0114 and RUSTSEC-2026-0149.
- Bumped the Go toolchain to `1.26.3` after CI govulncheck flagged fixed stdlib vulnerabilities in `1.26.2`.
- Recorded degraded sandbox security snapshots after CI exposed a daemon restart-path gap.
- Updated `CHANGELOG.md`, `docs/togaf-gap-v22.md`, and deployment config `monitored_services` so gateway-off validation stays stable.

## Linked Issues

- Resolves #276

## Test Plan

- `cargo fmt --all`
- `cargo remote -c -- test -p sentinel-ecs`
- `cargo remote -c -- test -p sentinel-limbo`
- `cargo remote -c -- test -p sentinel-wasm --features wasm`
- `cargo remote -c -- test -p sentinel-daemon orchestrator::tests::test_restart_agent_fast_path_recreates_runtime_and_security_state -- --exact`
- `cargo remote -c -- build -p sentinel-ecs --benches`
- `cargo remote -c -- build -p sentinel-limbo --benches`
- `cargo remote -c -- clippy --workspace --all-targets -- -D warnings`
- `cargo remote -c -- build -p sentinel-daemon --release --features fuse`
- `cargo audit`
- `GOTOOLCHAIN=auto go test ./cmd/cortex-gateway/...`
- `cd cmd/cortex-gateway && GOTOOLCHAIN=auto go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `cd dashboard && bun test`
- `cd dashboard && bun run typecheck`
- `git diff --check`
- Deploy-VM smoke with gateway and health-monitor timer inactive

## Benchmarks

Measured on Deploy-VM `ubuntu@10.0.0.240` / `sentinel-ubuntu-2404`, Intel i7-3930K @ 3.20 GHz (Sandy Bridge-E, 2011), KVM, 8 vCPU, `taskset -c 2`. Comparisons are same-machine before/after only; TOGAF absolute baselines from newer hardware are intentionally not used as a gate.

| Benchmark | Before | After | Delta |
|---|---:|---:|---:|
| `issue276.physics_system/tick_26_agents` | 1,172,325 ns/iter (+/- 35,864) | 857,440 ns/iter (+/- 24,774) | 26.86% faster |
| `issue276.generate_perception/texts_26_agents` | 149,127 ns/iter (+/- 3,788) | 109,845 ns/iter (+/- 4,944) | 26.34% faster |
| `issue276.persist_26_events_individual_tx` -> `issue276.persist_26_events_batch_tx` | 40,377,309 ns/iter (+/- 17,368,530) | 19,151,838 ns/iter (+/- 6,010,275) | 52.57% faster |
| `issue276.persist_26_events_individual_tx_prebuilt` -> `issue276.persist_26_events_batch_tx_prebuilt` | 34,143,782 ns/iter (+/- 12,614,457) | 4,454,866 ns/iter (+/- 1,560,601) | 86.95% faster |
| `room_phase2.bio_tick_26_agents` | 2,357,373 ns/iter (+/- 186,539) | 1,951,265 ns/iter (+/- 84,290) | 17.23% faster |

System metrics were captured with `vmstat 1`, `mpstat 1`, and `iostat -x 1`. CPU-bound tick runs had ~0.01% iowait; persist runs were storage-bound on this VM with ~6-8% iowait and high sda utilization, so persist absolute latency is not a production-baseline gate.

## Evidence (AC Mapping)

| AC | Result | Evidence |
|---|---|---|
| AC-1 | PASS | `physics_system` no longer allocates per-tick room/seed `HashMap`; `RoomPhysicsWorkspace` reuses backing storage; VM physics benchmark improved 26.86%. |
| AC-2 | PASS | Perception generation uses static deterministic fragments and caller-owned buffers; snapshot/acceptance tests pass; VM perception benchmark improved 26.34%. |
| AC-3 | PASS | `append_with_outbox_batch` writes events/outbox rows in one transaction while preserving order/idempotency; VM persist benchmark improved 52.57% e2e and 86.95% write-only. |
| AC-4 | PASS | `room_phase2.bio_tick_26_agents` improved 17.23%, so no full-tick regression. |
| AC-5 | PASS | Remote ECS/limbo/wasm tests, workspace clippy, release build, audit, govulncheck, and daemon deploy smoke passed. |
| AC-6 | PASS | Final Deploy-VM smoke kept `sentinel-gateway` and health-monitor inactive; events grew `4,055,670 -> 4,055,725` in 60s; `panic|drift=0`; gateway restart interventions `0`. |

Concrete verification commands/results:

```text
cargo audit
# PASS: no unallowed vulnerabilities after Wasmtime 44.0.2; only existing allowed unmaintained warnings remain.

cargo remote -c -- test -p sentinel-wasm --features wasm
# PASS: 51 unit tests, 62 acceptance tests, doc-tests.

cargo remote -c -- clippy --workspace --all-targets -- -D warnings
# PASS.

cargo remote -c -- test -p sentinel-daemon orchestrator::tests::test_restart_agent_fast_path_recreates_runtime_and_security_state -- --exact
# PASS.

cd cmd/cortex-gateway && GOTOOLCHAIN=auto go run golang.org/x/vuln/cmd/govulncheck@latest ./...
# PASS: no called vulnerabilities.
```

## Checklist

- [x] Build and tests run through `cargo remote -c --`; no benchmarks executed on the build server.
- [x] Before and after benchmarks measured on the same Deploy-VM hardware.
- [x] Hardware context and relative-only comparison documented.
- [x] System metrics captured alongside benchmarks.
- [x] Dashboard exposes benchmark evidence.
- [x] TOGAF gap doc updated without editing the architecture HTML.
- [x] Gateway-off smoke verified with `sentinel-gateway` inactive.
- [x] Wasmtime upgraded to `44.0.2` for RUSTSEC-2026-0114 and RUSTSEC-2026-0149.