### PR TITLE
build: bump go toolchain to 1.26.3

### DIFF
--- a/cmd/cortex-gateway/go.mod
+++ b/cmd/cortex-gateway/go.mod
@@ -2,7 +2,7 @@ module github.com/silentspike/project-sentinel/cmd/cortex-gateway
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 use (
 	./cmd/cortex-gateway

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,5 @@
+github.com/silentspike/project-sentinel/pkg/sentinel-go v0.0.0-20260426185014-30c7fd621515/go.mod h1:O23Is4HFuLB04LZFerrjWhIsX/W9wWmlGRlusXQVUdM=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=


### PR DESCRIPTION
## Summary

Separate PR for the Go toolchain bump that was previously mixed into the #276/#277 branch history.

## Changes

- Updates `cmd/cortex-gateway/go.mod` to Go 1.26.3.
- Updates `go.work` accordingly.
- Adds the generated `go.work.sum` entries.

## Verification

- `cd cmd/cortex-gateway && go test ./...` passed.
- `git diff --check HEAD` passed.

## Notes

This is intentionally separate from #372 so #276/#277 stay scoped to tick-loop and dashboard-polling work.
