### PR TITLE
perf: optimize FUSE dedup and nightrun verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Moved Issue #278 nightrun/shift evolution LLM calls out of the ECS tick loop into an async background task, with VM evidence for fake-gateway success, gateway-down fail-safe behavior, and redb `EVOLUTION_VERSION` writes.
+- Added Issue #379 live sentinel-fs FUSE/CAS verification paths for storage stats and dedup-hit benchmarking; Deploy-VM evidence shows active FUSE agent homes and 99.22% dedup savings, while the `<100us` dedup-hit latency target remains unmet on the i7-3930K VM.
 - Updated optional `sentinel-wasm` Wasmtime dependencies to 44.0.2 to clear current RustSec advisories.
 - Optimized Issue #277 dashboard WebSocket change detection from five per-view polling queries to one Projection-DB `projection_watermarks` lookup per poll cycle, with idle polling skipped when no WebSocket clients are connected; VM benchmark evidence is captured with `dashboard/scripts/measure-ws-polling.sh`.
 - Optimized Issue #276 ECS tick-loop hot paths: reusable room-physics and persist workspaces, perception buffer reuse, and batched Limbo event/outbox writes. Deploy-VM benchmarks on Intel i7-3930K show relative improvements of 26.86% physics, 26.34% perception, 52.57% persist e2e, 86.95% persist write-only, and 17.23% full tick.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Moved Issue #278 nightrun/shift evolution LLM calls out of the ECS tick loop into an async background task, with VM evidence for fake-gateway success, gateway-down fail-safe behavior, and redb `EVOLUTION_VERSION` writes.
-- Added Issue #379 live sentinel-fs FUSE/CAS verification paths for storage stats and dedup-hit benchmarking; Deploy-VM evidence shows active FUSE agent homes and 99.22% dedup savings, while the `<100us` dedup-hit latency target remains unmet on the i7-3930K VM.
+- Added and optimized Issue #379 live sentinel-fs FUSE/CAS verification paths for storage stats and dedup-hit benchmarking; Deploy-VM evidence shows active FUSE agent homes, 99.22% dedup savings, and same-VM median dedup-hit write p95 improved from 40,411 us to 189 us, while the strict `<100us` target remains unmet on the i7-3930K VM.
 - Updated optional `sentinel-wasm` Wasmtime dependencies to 44.0.2 to clear current RustSec advisories.
 - Optimized Issue #277 dashboard WebSocket change detection from five per-view polling queries to one Projection-DB `projection_watermarks` lookup per poll cycle, with idle polling skipped when no WebSocket clients are connected; VM benchmark evidence is captured with `dashboard/scripts/measure-ws-polling.sh`.
 - Optimized Issue #276 ECS tick-loop hot paths: reusable room-physics and persist workspaces, perception buffer reuse, and batched Limbo event/outbox writes. Deploy-VM benchmarks on Intel i7-3930K show relative improvements of 26.86% physics, 26.34% perception, 52.57% persist e2e, 86.95% persist write-only, and 17.23% full tick.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3801,9 +3801,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,6 +4291,7 @@ name = "sentinel-fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "blake3",
  "criterion 0.8.2",
  "fuser",

--- a/config/daemon.toml
+++ b/config/daemon.toml
@@ -6,6 +6,10 @@ time_scale = 1.0
 max_agents = 60
 zenoh_prefix = "sentinel"
 fs_mount = "/opt/sentinel/fs"
+# sentinel-fs metadata write durability.
+# "immediate" = fsync on every metadata commit (crash-safe, higher latency)
+# "eventual"  = skip fsync for FUSE hot-path commits (lower latency, recent metadata may be lost on VM crash)
+fs_metadata_durability = "eventual"
 
 # PSI-basierte adaptive Tick-Rate (TOGAF Adaptive Scheduling)
 [daemon.adaptive]

--- a/crates/sentinel-fs/Cargo.toml
+++ b/crates/sentinel-fs/Cargo.toml
@@ -18,6 +18,7 @@ sentinel-common = { path = "../sentinel-common" }
 sentinel-telemetry = { path = "../sentinel-telemetry" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+bincode = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
 tracing = { workspace = true }

--- a/crates/sentinel-fs/src/layer.rs
+++ b/crates/sentinel-fs/src/layer.rs
@@ -39,6 +39,18 @@ pub struct LayerManager {
     meta: MetadataStore,
 }
 
+/// Live storage stats for the layer manager.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LayerStorageStats {
+    pub cas_blob_count: u64,
+    pub cas_bytes_on_disk: u64,
+    pub regular_file_count: u64,
+    pub logical_regular_file_bytes: u64,
+    pub dedup_savings_bytes: u64,
+    pub dedup_ratio_percent: f64,
+    pub unreadable_inode_rows: u64,
+}
+
 impl LayerManager {
     /// Create a new layer manager.
     pub fn new(cas: CasStore, meta: MetadataStore) -> Self {
@@ -53,6 +65,29 @@ impl LayerManager {
     /// Access the metadata store.
     pub fn meta(&self) -> &MetadataStore {
         &self.meta
+    }
+
+    /// Aggregate CAS and metadata counters for live dedup verification.
+    pub fn storage_stats(&self) -> anyhow::Result<LayerStorageStats> {
+        let cas_stats = self.cas.stats()?;
+        let metadata_stats = self.meta.storage_stats()?;
+        let dedup_savings_bytes = metadata_stats
+            .logical_regular_file_bytes
+            .saturating_sub(cas_stats.total_bytes_on_disk);
+        let dedup_ratio_percent = if metadata_stats.logical_regular_file_bytes == 0 {
+            0.0
+        } else {
+            (dedup_savings_bytes as f64 * 100.0) / metadata_stats.logical_regular_file_bytes as f64
+        };
+        Ok(LayerStorageStats {
+            cas_blob_count: cas_stats.blob_count,
+            cas_bytes_on_disk: cas_stats.total_bytes_on_disk,
+            regular_file_count: metadata_stats.regular_file_count,
+            logical_regular_file_bytes: metadata_stats.logical_regular_file_bytes,
+            dedup_savings_bytes,
+            dedup_ratio_percent,
+            unreadable_inode_rows: metadata_stats.unreadable_inode_rows,
+        })
     }
 
     // === BASE LAYER OPERATIONS (populating shared content) ===
@@ -440,6 +475,26 @@ mod tests {
         // Refcount should be 3
         let hash = CasStore::hash(content);
         assert_eq!(lm.meta().get_refcount(&hash).unwrap(), 3);
+    }
+
+    #[test]
+    fn storage_stats_report_logical_bytes_and_dedup_savings() {
+        let (lm, _dir) = temp_layer();
+        let content = b"identical content for live stats";
+
+        lm.write_file("AGENT-01", 1, "same-1.txt", content, 0o644)
+            .unwrap();
+        lm.write_file("AGENT-02", 1, "same-2.txt", content, 0o644)
+            .unwrap();
+        lm.write_file("AGENT-03", 1, "same-3.txt", content, 0o644)
+            .unwrap();
+
+        let stats = lm.storage_stats().unwrap();
+        assert_eq!(stats.regular_file_count, 3);
+        assert_eq!(stats.logical_regular_file_bytes, (content.len() * 3) as u64);
+        assert_eq!(stats.cas_blob_count, 1);
+        assert!(stats.dedup_savings_bytes > 0);
+        assert!(stats.dedup_ratio_percent > 0.0);
     }
 
     #[test]

--- a/crates/sentinel-fs/src/layer.rs
+++ b/crates/sentinel-fs/src/layer.rs
@@ -5,6 +5,9 @@
 //! Deletes place a whiteout marker in the agent layer that hides the base entry.
 //! Agent layers are created lazily on first write.
 
+use std::collections::HashSet;
+use std::sync::RwLock;
+
 use crate::cas::CasStore;
 use crate::metadata::{FileKind, InodeData, MetadataStore};
 use tracing::instrument;
@@ -37,6 +40,7 @@ fn whiteout_marker() -> InodeData {
 pub struct LayerManager {
     cas: CasStore,
     meta: MetadataStore,
+    known_agent_roots: RwLock<HashSet<String>>,
 }
 
 /// Live storage stats for the layer manager.
@@ -54,7 +58,11 @@ pub struct LayerStorageStats {
 impl LayerManager {
     /// Create a new layer manager.
     pub fn new(cas: CasStore, meta: MetadataStore) -> Self {
-        Self { cas, meta }
+        Self {
+            cas,
+            meta,
+            known_agent_roots: RwLock::new(HashSet::new()),
+        }
     }
 
     /// Access the CAS store.
@@ -136,10 +144,32 @@ impl LayerManager {
 
     /// Ensure agent root directory exists (lazy creation).
     pub fn ensure_agent_root(&self, agent_id: &str) -> anyhow::Result<()> {
+        if self.agent_root_known(agent_id)? {
+            return Ok(());
+        }
+
         if self.meta.get_inode(agent_id, 1)?.is_none() {
             let root = InodeData::directory(0o755);
             self.meta.set_inode(agent_id, 1, &root)?;
         }
+        self.mark_agent_root_known(agent_id)?;
+        Ok(())
+    }
+
+    fn agent_root_known(&self, agent_id: &str) -> anyhow::Result<bool> {
+        let roots = self
+            .known_agent_roots
+            .read()
+            .map_err(|err| anyhow::anyhow!("Agent-Root-Cache read failed: {err}"))?;
+        Ok(roots.contains(agent_id))
+    }
+
+    fn mark_agent_root_known(&self, agent_id: &str) -> anyhow::Result<()> {
+        let mut roots = self
+            .known_agent_roots
+            .write()
+            .map_err(|err| anyhow::anyhow!("Agent-Root-Cache write failed: {err}"))?;
+        roots.insert(agent_id.to_string());
         Ok(())
     }
 
@@ -201,13 +231,19 @@ impl LayerManager {
         content: &[u8],
         mode: u32,
     ) -> anyhow::Result<u64> {
-        self.ensure_agent_root(agent_id)?;
-
         let (hash, _deduped) = self.cas.store(content)?;
-        let inode = self.meta.next_inode(agent_id)?;
         let data = InodeData::regular(hash, content.len() as u64, mode);
-        self.meta
-            .create_file(agent_id, parent_inode, name, inode, &data)?;
+        let ensure_root = !self.agent_root_known(agent_id)?;
+        let inode = self.meta.create_file_allocating_inode(
+            agent_id,
+            parent_inode,
+            name,
+            &data,
+            ensure_root,
+        )?;
+        if ensure_root {
+            self.mark_agent_root_known(agent_id)?;
+        }
         Ok(inode)
     }
 
@@ -219,12 +255,18 @@ impl LayerManager {
         name: &str,
         mode: u32,
     ) -> anyhow::Result<u64> {
-        self.ensure_agent_root(agent_id)?;
-
-        let inode = self.meta.next_inode(agent_id)?;
         let data = InodeData::directory(mode);
-        self.meta
-            .create_file(agent_id, parent_inode, name, inode, &data)?;
+        let ensure_root = !self.agent_root_known(agent_id)?;
+        let inode = self.meta.create_file_allocating_inode(
+            agent_id,
+            parent_inode,
+            name,
+            &data,
+            ensure_root,
+        )?;
+        if ensure_root {
+            self.mark_agent_root_known(agent_id)?;
+        }
         Ok(inode)
     }
 
@@ -454,6 +496,31 @@ mod tests {
 
         // Now agent root exists
         assert!(lm.meta().get_inode("AGENT-99", 1).unwrap().is_some());
+    }
+
+    #[test]
+    fn write_file_allocates_sequential_inodes_in_single_metadata_path() {
+        let (lm, _dir) = temp_layer();
+
+        let first = lm
+            .write_file("AGENT-88", 1, "first.txt", b"same", 0o644)
+            .unwrap();
+        let second = lm
+            .write_file("AGENT-88", 1, "second.txt", b"same", 0o644)
+            .unwrap();
+
+        assert_eq!(first, 2);
+        assert_eq!(second, 3);
+        assert!(lm.meta().get_inode("AGENT-88", 1).unwrap().is_some());
+        assert_eq!(
+            lm.meta().get_dirent("AGENT-88", 1, "first.txt").unwrap(),
+            Some(first)
+        );
+        assert_eq!(
+            lm.meta().get_dirent("AGENT-88", 1, "second.txt").unwrap(),
+            Some(second)
+        );
+        assert_eq!(lm.meta().get_refcount(&CasStore::hash(b"same")).unwrap(), 2);
     }
 
     #[test]

--- a/crates/sentinel-fs/src/metadata.rs
+++ b/crates/sentinel-fs/src/metadata.rs
@@ -118,6 +118,14 @@ pub struct MetadataStore {
     db: Database,
 }
 
+/// Aggregated metadata statistics for storage and dedup verification.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MetadataStorageStats {
+    pub regular_file_count: u64,
+    pub logical_regular_file_bytes: u64,
+    pub unreadable_inode_rows: u64,
+}
+
 impl MetadataStore {
     /// Open or create the metadata store at the given path.
     #[instrument(level = "debug", fields(path = %path.as_ref().display()))]
@@ -403,6 +411,29 @@ impl MetadataStore {
             refcounts,
             trash_queue,
         })
+    }
+
+    /// Sum logical payload bytes for live storage/dedup verification.
+    pub fn storage_stats(&self) -> anyhow::Result<MetadataStorageStats> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(FS_INODES)?;
+        let mut stats = MetadataStorageStats::default();
+        for entry in table.iter()? {
+            let (_, value) = entry?;
+            let data = match InodeData::deserialize(value.value()) {
+                Ok(data) => data,
+                Err(_) => {
+                    stats.unreadable_inode_rows += 1;
+                    continue;
+                }
+            };
+            if data.kind == FileKind::Regular && data.size != u64::MAX {
+                stats.regular_file_count += 1;
+                stats.logical_regular_file_bytes =
+                    stats.logical_regular_file_bytes.saturating_add(data.size);
+            }
+        }
+        Ok(stats)
     }
 
     /// Restore all sentinel-fs metadata tables from a snapshot dump.

--- a/crates/sentinel-fs/src/metadata.rs
+++ b/crates/sentinel-fs/src/metadata.rs
@@ -6,7 +6,7 @@
 //! - `CAS_REFCOUNT`: `sha256_hash` -> reference count (u32)
 
 use crate::cas::{CasStore, ChunkGcStats};
-use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, WriteTransaction};
 use sentinel_common::FsMetadataDump;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -26,6 +26,8 @@ const CAS_REFCOUNT: TableDefinition<&[u8; 32], u32> = TableDefinition::new("cas_
 
 /// Grace-period Trash-Queue fuer null-ref CAS-Bloecke.
 const FS_TRASH_QUEUE: TableDefinition<&[u8; 32], u64> = TableDefinition::new("fs_trash_queue");
+
+const INODE_DATA_BINCODE_V1: &[u8; 4] = b"SFI1";
 
 // --- Types ---
 
@@ -103,11 +105,24 @@ impl InodeData {
     }
 
     fn serialize(&self) -> anyhow::Result<Vec<u8>> {
-        serde_json::to_vec(self).map_err(|e| anyhow::anyhow!("InodeData serialize: {e}"))
+        let payload = bincode::serde::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| anyhow::anyhow!("InodeData bincode serialize: {e}"))?;
+        let mut bytes = Vec::with_capacity(INODE_DATA_BINCODE_V1.len() + payload.len());
+        bytes.extend_from_slice(INODE_DATA_BINCODE_V1);
+        bytes.extend_from_slice(&payload);
+        Ok(bytes)
     }
 
     fn deserialize(data: &[u8]) -> anyhow::Result<Self> {
-        serde_json::from_slice(data).map_err(|e| anyhow::anyhow!("InodeData deserialize: {e}"))
+        if let Some(payload) = data.strip_prefix(INODE_DATA_BINCODE_V1) {
+            let (decoded, _): (Self, usize) =
+                bincode::serde::decode_from_slice(payload, bincode::config::standard())
+                    .map_err(|e| anyhow::anyhow!("InodeData bincode deserialize: {e}"))?;
+            return Ok(decoded);
+        }
+
+        serde_json::from_slice(data)
+            .map_err(|e| anyhow::anyhow!("InodeData legacy json deserialize: {e}"))
     }
 }
 
@@ -116,6 +131,19 @@ impl InodeData {
 /// Filesystem metadata backed by a single redb database.
 pub struct MetadataStore {
     db: Database,
+    durability: MetadataDurability,
+}
+
+/// Durability level for metadata write transactions.
+///
+/// `Immediate` is the default and fsyncs every commit. `Eventual` skips fsync
+/// for FUSE hot-path writes, trading crash durability for substantially lower
+/// VM write latency.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MetadataDurability {
+    #[default]
+    Immediate,
+    Eventual,
 }
 
 /// Aggregated metadata statistics for storage and dedup verification.
@@ -130,10 +158,19 @@ impl MetadataStore {
     /// Open or create the metadata store at the given path.
     #[instrument(level = "debug", fields(path = %path.as_ref().display()))]
     pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        Self::open_with_durability(path, MetadataDurability::Immediate)
+    }
+
+    /// Open or create the metadata store with a specific write durability.
+    #[instrument(level = "debug", fields(path = %path.as_ref().display(), ?durability))]
+    pub fn open_with_durability(
+        path: impl AsRef<Path>,
+        durability: MetadataDurability,
+    ) -> anyhow::Result<Self> {
         let db = Database::create(path.as_ref())
             .map_err(|e| anyhow::anyhow!("MetadataStore open: {e}"))?;
 
-        // Initialize all tables
+        // Initialize all tables with immediate durability.
         let write_txn = db.begin_write()?;
         {
             write_txn.open_table(FS_INODES)?;
@@ -143,7 +180,18 @@ impl MetadataStore {
         }
         write_txn.commit()?;
 
-        Ok(Self { db })
+        Ok(Self { db, durability })
+    }
+
+    fn begin_write(&self) -> anyhow::Result<WriteTransaction> {
+        let mut write_txn = self.db.begin_write()?;
+        match self.durability {
+            MetadataDurability::Immediate => {}
+            MetadataDurability::Eventual => {
+                write_txn.set_durability(redb::Durability::None)?;
+            }
+        }
+        Ok(write_txn)
     }
 
     // === INODE OPERATIONS ===
@@ -161,7 +209,7 @@ impl MetadataStore {
     /// Set inode metadata for an agent.
     pub fn set_inode(&self, agent_id: &str, inode: u64, data: &InodeData) -> anyhow::Result<()> {
         let serialized = data.serialize()?;
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         {
             let mut table = write_txn.open_table(FS_INODES)?;
             table.insert((agent_id, inode), serialized.as_slice())?;
@@ -172,7 +220,7 @@ impl MetadataStore {
 
     /// Remove an inode. Returns the old data if it existed.
     pub fn remove_inode(&self, agent_id: &str, inode: u64) -> anyhow::Result<Option<InodeData>> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let old = {
             let mut table = write_txn.open_table(FS_INODES)?;
             let x = match table.remove((agent_id, inode))? {
@@ -209,7 +257,7 @@ impl MetadataStore {
         name: &str,
         child_inode: u64,
     ) -> anyhow::Result<()> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         {
             let mut table = write_txn.open_table(FS_DIRENTS)?;
             table.insert((agent_id, parent, name), child_inode)?;
@@ -225,7 +273,7 @@ impl MetadataStore {
         parent: u64,
         name: &str,
     ) -> anyhow::Result<Option<u64>> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let old = {
             let mut table = write_txn.open_table(FS_DIRENTS)?;
             // Deliberate match instead of .map() — redb AccessGuard lifetime workaround
@@ -269,14 +317,16 @@ impl MetadataStore {
 
     /// Increment reference count. Returns the new count.
     pub fn inc_refcount(&self, hash: &[u8; 32]) -> anyhow::Result<u32> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let new_count = {
             let mut table = write_txn.open_table(CAS_REFCOUNT)?;
             let current = table.get(hash)?.map(|g| g.value()).unwrap_or(0);
             let new = current + 1;
             table.insert(hash, new)?;
-            let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
-            trash.remove(hash)?;
+            if current == 0 {
+                let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
+                trash.remove(hash)?;
+            }
             new
         };
         write_txn.commit()?;
@@ -285,7 +335,7 @@ impl MetadataStore {
 
     /// Decrement reference count. Returns the new count (clamped to 0).
     pub fn dec_refcount(&self, hash: &[u8; 32]) -> anyhow::Result<u32> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let new_count = {
             let mut table = write_txn.open_table(CAS_REFCOUNT)?;
             let current = table.get(hash)?.map(|g| g.value()).unwrap_or(0);
@@ -324,7 +374,7 @@ impl MetadataStore {
         hash: &[u8; 32],
         trashed_at_ms: Option<u64>,
     ) -> anyhow::Result<bool> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let updated = {
             let mut table = write_txn.open_table(FS_TRASH_QUEUE)?;
             match trashed_at_ms {
@@ -341,7 +391,7 @@ impl MetadataStore {
 
     /// Remove a hash from the trash queue and re-establish a refcount if needed.
     pub fn restore_from_trash(&self, hash: &[u8; 32]) -> anyhow::Result<bool> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let restored = {
             let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
             if trash.remove(hash)?.is_none() {
@@ -439,7 +489,7 @@ impl MetadataStore {
     /// Restore all sentinel-fs metadata tables from a snapshot dump.
     pub fn restore_all_tables(&self, dump: &FsMetadataDump) -> anyhow::Result<()> {
         let current = self.dump_all_tables()?;
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         {
             let mut inodes = write_txn.open_table(FS_INODES)?;
             for (agent_id, inode, _) in &current.inodes {
@@ -511,7 +561,7 @@ impl MetadataStore {
 
         let gc_stats = cas.gc(&expired_hashes)?;
 
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         {
             let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
             let refs = write_txn.open_table(CAS_REFCOUNT)?;
@@ -543,7 +593,7 @@ impl MetadataStore {
         data: &InodeData,
     ) -> anyhow::Result<()> {
         let serialized = data.serialize()?;
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         {
             let mut inodes = write_txn.open_table(FS_INODES)?;
             inodes.insert((agent_id, inode), serialized.as_slice())?;
@@ -555,12 +605,75 @@ impl MetadataStore {
                 let mut refs = write_txn.open_table(CAS_REFCOUNT)?;
                 let current = refs.get(&data.hash)?.map(|g| g.value()).unwrap_or(0);
                 refs.insert(&data.hash, current + 1)?;
-                let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
-                trash.remove(&data.hash)?;
+                if current == 0 {
+                    let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
+                    trash.remove(&data.hash)?;
+                }
             }
         }
         write_txn.commit()?;
         Ok(())
+    }
+
+    /// Atomically allocate an inode and create an entry in one transaction.
+    ///
+    /// This is the hot-path variant for agent writes: it avoids the old
+    /// `next_inode()` transaction followed by a second `create_file()`
+    /// transaction. When `ensure_root` is true, the agent root inode is also
+    /// checked/created inside the same write transaction.
+    pub fn create_file_allocating_inode(
+        &self,
+        agent_id: &str,
+        parent_inode: u64,
+        name: &str,
+        data: &InodeData,
+        ensure_root: bool,
+    ) -> anyhow::Result<u64> {
+        let serialized = data.serialize()?;
+
+        let write_txn = self.begin_write()?;
+        let inode = {
+            let mut inodes = write_txn.open_table(FS_INODES)?;
+
+            if ensure_root && inodes.get((agent_id, 1u64))?.is_none() {
+                let root = InodeData::directory(0o755).serialize()?;
+                inodes.insert((agent_id, 1u64), root.as_slice())?;
+            }
+
+            let current = inodes
+                .get((agent_id, 0u64))?
+                .map(|g| {
+                    let bytes = g.value();
+                    if bytes.len() == 8 {
+                        u64::from_le_bytes(bytes.try_into().unwrap())
+                    } else {
+                        1
+                    }
+                })
+                .unwrap_or(1);
+            let inode = current + 1;
+            inodes.insert((agent_id, 0u64), inode.to_le_bytes().as_slice())?;
+            inodes.insert((agent_id, inode), serialized.as_slice())?;
+            inode
+        };
+
+        {
+            let mut dirents = write_txn.open_table(FS_DIRENTS)?;
+            dirents.insert((agent_id, parent_inode, name), inode)?;
+        }
+
+        if data.kind == FileKind::Regular {
+            let mut refs = write_txn.open_table(CAS_REFCOUNT)?;
+            let current = refs.get(&data.hash)?.map(|g| g.value()).unwrap_or(0);
+            refs.insert(&data.hash, current + 1)?;
+            if current == 0 {
+                let mut trash = write_txn.open_table(FS_TRASH_QUEUE)?;
+                trash.remove(&data.hash)?;
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(inode)
     }
 
     /// Atomically remove a file: remove inode + dirent + dec refcount in one transaction.
@@ -572,7 +685,7 @@ impl MetadataStore {
         name: &str,
         inode: u64,
     ) -> anyhow::Result<Option<InodeData>> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let old_data = {
             let mut inodes = write_txn.open_table(FS_INODES)?;
             let old = match inodes.remove((agent_id, inode))? {
@@ -619,7 +732,7 @@ impl MetadataStore {
     /// Allocate the next inode number for an agent.
     /// Uses a special inode 0 entry to track the counter.
     pub fn next_inode(&self, agent_id: &str) -> anyhow::Result<u64> {
-        let write_txn = self.db.begin_write()?;
+        let write_txn = self.begin_write()?;
         let next = {
             let mut table = write_txn.open_table(FS_INODES)?;
             // Use inode 0 as the counter (never a real inode in FUSE — root is 1)
@@ -683,6 +796,24 @@ mod tests {
         let old = store.remove_inode(agent, 1).unwrap().unwrap();
         assert_eq!(old.size, 2048);
         assert!(store.get_inode(agent, 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn inode_data_serializes_as_bincode_with_legacy_json_fallback() {
+        let data = InodeData::regular([0xA1; 32], 1024, 0o644);
+
+        let encoded = data.serialize().unwrap();
+        assert!(encoded.starts_with(INODE_DATA_BINCODE_V1));
+        let decoded = InodeData::deserialize(&encoded).unwrap();
+        assert_eq!(decoded.kind, FileKind::Regular);
+        assert_eq!(decoded.hash, [0xA1; 32]);
+        assert_eq!(decoded.size, 1024);
+
+        let legacy_json = serde_json::to_vec(&data).unwrap();
+        let legacy_decoded = InodeData::deserialize(&legacy_json).unwrap();
+        assert_eq!(legacy_decoded.kind, FileKind::Regular);
+        assert_eq!(legacy_decoded.hash, [0xA1; 32]);
+        assert_eq!(legacy_decoded.size, 1024);
     }
 
     #[test]
@@ -783,6 +914,67 @@ mod tests {
 
         // Refcount incremented
         assert_eq!(store.get_refcount(&hash).unwrap(), 1);
+    }
+
+    #[test]
+    fn create_file_allocating_inode_is_single_path_counter_and_refcount() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-77";
+        let hash = [0xC7; 32];
+        let data = InodeData::regular(hash, 512, 0o644);
+
+        let first = store
+            .create_file_allocating_inode(agent, 1, "first.txt", &data, true)
+            .unwrap();
+        let second = store
+            .create_file_allocating_inode(agent, 1, "second.txt", &data, true)
+            .unwrap();
+
+        assert_eq!(first, 2);
+        assert_eq!(second, 3);
+        assert!(store.get_inode(agent, 1).unwrap().is_some());
+        assert_eq!(store.get_dirent(agent, 1, "first.txt").unwrap(), Some(2));
+        assert_eq!(store.get_dirent(agent, 1, "second.txt").unwrap(), Some(3));
+        assert_eq!(store.get_refcount(&hash).unwrap(), 2);
+        assert_eq!(store.next_inode(agent).unwrap(), 4);
+    }
+
+    #[test]
+    fn create_file_allocating_inode_removes_zero_ref_trash_entry() {
+        let (store, _dir) = temp_meta();
+        let agent = "AGENT-78";
+        let hash = [0xC8; 32];
+        let data = InodeData::regular(hash, 512, 0o644);
+
+        let first = store
+            .create_file_allocating_inode(agent, 1, "first.txt", &data, true)
+            .unwrap();
+        store.remove_file(agent, 1, "first.txt", first).unwrap();
+        assert_eq!(store.get_refcount(&hash).unwrap(), 0);
+        assert!(store.get_trash_timestamp(&hash).unwrap().is_some());
+
+        let second = store
+            .create_file_allocating_inode(agent, 1, "second.txt", &data, true)
+            .unwrap();
+
+        assert_eq!(second, 3);
+        assert_eq!(store.get_refcount(&hash).unwrap(), 1);
+        assert_eq!(store.get_trash_timestamp(&hash).unwrap(), None);
+    }
+
+    #[test]
+    fn open_with_eventual_metadata_durability() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MetadataStore::open_with_durability(
+            dir.path().join("meta.redb"),
+            MetadataDurability::Eventual,
+        )
+        .unwrap();
+
+        assert_eq!(store.durability, MetadataDurability::Eventual);
+        let data = InodeData::directory(0o755);
+        store.set_inode("AGENT-01", 1, &data).unwrap();
+        assert!(store.get_inode("AGENT-01", 1).unwrap().is_some());
     }
 
     #[test]

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -47,7 +47,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | Pub/Sub (Zenoh, Rust)         | ✅ | `crates/sentinel-zenoh/`; SHM local <10µs |
 | Pub/Sub (NATS JetStream, Go)  | ✅ | `pkg/sentinel-go/messaging/`, two streams |
 | Sandbox (bwrap + Landlock + cgroups + netns) | ✅ | `crates/sentinel-sandbox/`; 9/9 breakout tests pass |
-| sentinel-fs CAS-FUSE (#379)  | 🟡 | Deploy-VM daemon namespace shows active `fuse sentinel-fs` at `/opt/sentinel/fs` and agent homes bound through `/opt/sentinel/fs/AGENT-*`; live dedup benchmark on Intel i7-3930K @ 3.20 GHz (2011) reached 99.22% dedup savings, but dedup-hit p95 write latency was 21,712 us, above the `<100us` target |
+| sentinel-fs CAS-FUSE (#379)  | 🟡 | Deploy-VM daemon namespace shows active `fuse sentinel-fs` at `/opt/sentinel/fs` and agent homes bound through `/opt/sentinel/fs/AGENT-*`; same-VM optimization loop on Intel i7-3930K @ 3.20 GHz (2011) reached 99.22% dedup savings and improved median dedup-hit write p95 from 40,411 us to 189 us, but the strict `<100us` target remains unmet on this VM |
 | WASM tool runtime             | ✅ | `crates/sentinel-wasm/` |
 | eBPF monitoring (aya-rs)      | ✅ | `crates/sentinel-ebpf/` |
 

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -47,6 +47,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | Pub/Sub (Zenoh, Rust)         | ✅ | `crates/sentinel-zenoh/`; SHM local <10µs |
 | Pub/Sub (NATS JetStream, Go)  | ✅ | `pkg/sentinel-go/messaging/`, two streams |
 | Sandbox (bwrap + Landlock + cgroups + netns) | ✅ | `crates/sentinel-sandbox/`; 9/9 breakout tests pass |
+| sentinel-fs CAS-FUSE (#379)  | 🟡 | Deploy-VM daemon namespace shows active `fuse sentinel-fs` at `/opt/sentinel/fs` and agent homes bound through `/opt/sentinel/fs/AGENT-*`; live dedup benchmark on Intel i7-3930K @ 3.20 GHz (2011) reached 99.22% dedup savings, but dedup-hit p95 write latency was 21,712 us, above the `<100us` target |
 | WASM tool runtime             | ✅ | `crates/sentinel-wasm/` |
 | eBPF monitoring (aya-rs)      | ✅ | `crates/sentinel-ebpf/` |
 
@@ -135,6 +136,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | WorldSnapshot (bincode 2)     | ✅ | `crates/sentinel-limbo/src/snapshot.rs` |
 | Hot-swap restore              | ✅ | `services/sentinel-daemon/src/runtime_health.rs` (snapshot reload path) |
 | Deterministic replay          | ✅ | `services/sentinel-nightrun/` |
+| Non-blocking evolution LLM (#278) | 🟡 | Async `evolution_task` moves nightrun/shift LLM calls out of the ECS tick loop; Deploy-VM nightrun returned in 0.669 ms and gateway-down shift jobs failed safe, but total shift transition measured ~1.455 s on the i7-3930K VM, above the strict `<1s` AC target due remaining Hippocampus/sandbox work |
 | Time-travel debugging UI      | ⏳ | dashboard hook designed, frontend deferred |
 
 ---

--- a/services/sentinel-daemon/Cargo.toml
+++ b/services/sentinel-daemon/Cargo.toml
@@ -40,7 +40,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false, optional = true }
 uuid = { workspace = true }
 bincode = { workspace = true }
 async-nats = { workspace = true, optional = true }

--- a/services/sentinel-daemon/src/config.rs
+++ b/services/sentinel-daemon/src/config.rs
@@ -66,6 +66,14 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub fs_mount: Option<String>,
 
+    /// redb-Durability fuer sentinel-fs Metadata-Commits.
+    ///
+    /// `immediate` fsyncs every commit. `eventual` skips fsync for the FUSE
+    /// hot path and is only appropriate when lower write latency is preferred
+    /// over crash durability for the most recent metadata commits.
+    #[serde(default)]
+    pub fs_metadata_durability: FsMetadataDurability,
+
     /// Time Machine: Tiered Snapshot + Event Retention.
     #[serde(default)]
     pub retention: RetentionConfig,
@@ -81,6 +89,14 @@ pub struct DaemonConfig {
     /// Traffic Control Defaults fuer den Gateway-Start.
     #[serde(default)]
     pub traffic_control: TrafficControlConfig,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FsMetadataDurability {
+    #[default]
+    Immediate,
+    Eventual,
 }
 
 /// Traffic-Control Defaults fuer den Gateway Bootstrap.
@@ -636,6 +652,10 @@ shared_secret = "secret"
         assert_eq!(file.daemon.tick_rate_ms, 500);
         assert_eq!(file.daemon.max_agents, 10);
         assert_eq!(file.daemon.zenoh_prefix, "test");
+        assert_eq!(
+            file.daemon.fs_metadata_durability,
+            FsMetadataDurability::Immediate
+        );
         assert!(file.daemon.operator_api.enabled);
         assert_eq!(file.daemon.operator_api.bind_addr, "127.0.0.1:9999");
         assert_eq!(
@@ -659,6 +679,10 @@ data_dir = "/tmp/data"
         assert_eq!(file.daemon.max_agents, 30);
         assert_eq!(file.daemon.zenoh_prefix, "sentinel");
         assert_eq!(file.daemon.time_scale, 1.0);
+        assert_eq!(
+            file.daemon.fs_metadata_durability,
+            FsMetadataDurability::Immediate
+        );
         assert_eq!(file.daemon.agent_command, vec!["/usr/bin/agent-runtime"]);
         assert!(!file.daemon.traffic_control.synthesis_enabled);
         assert!(!file.daemon.traffic_control.sequencing_enabled);
@@ -718,6 +742,21 @@ data_dir = "/tmp/data"
                 .platform_controlplane
                 .llm_max_failed_interventions,
             3
+        );
+    }
+
+    #[test]
+    fn test_parse_fs_metadata_eventual_durability() {
+        let toml_str = r#"
+[daemon]
+config_dir = "/tmp/cfg"
+data_dir = "/tmp/data"
+fs_metadata_durability = "eventual"
+"#;
+        let file: DaemonConfigFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            file.daemon.fs_metadata_durability,
+            FsMetadataDurability::Eventual
         );
     }
 

--- a/services/sentinel-daemon/src/evolution_task.rs
+++ b/services/sentinel-daemon/src/evolution_task.rs
@@ -1,0 +1,464 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::Result;
+use sentinel_common::AgentId;
+use sentinel_redb::StateStore;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+pub const DEFAULT_EVOLUTION_CHANNEL_CAPACITY: usize = 32;
+pub const DEFAULT_EVOLUTION_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_MAX_CONCURRENT_JOBS: usize = 8;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EvolutionSource {
+    ShiftTransition,
+    Nightrun,
+}
+
+impl EvolutionSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ShiftTransition => "shift_transition",
+            Self::Nightrun => "nightrun",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvolutionJob {
+    pub agent_id: AgentId,
+    pub agent_name: String,
+    pub agent_role: String,
+    pub narrative: String,
+    pub source: EvolutionSource,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvolutionResult {
+    pub agent_id: AgentId,
+    pub agent_name: String,
+    pub source: EvolutionSource,
+    pub voice_style: Option<Vec<u8>>,
+    pub behavioral_notes: Option<Vec<u8>>,
+    pub narrative: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvolutionTaskConfig {
+    pub gateway_url: String,
+    pub timeout: Duration,
+    pub max_concurrent_jobs: usize,
+}
+
+impl EvolutionTaskConfig {
+    pub fn from_env() -> Self {
+        Self {
+            gateway_url: std::env::var("CORTEX_GATEWAY_URL")
+                .unwrap_or_else(|_| "http://localhost:8080".to_string()),
+            timeout: DEFAULT_EVOLUTION_TIMEOUT,
+            max_concurrent_jobs: DEFAULT_MAX_CONCURRENT_JOBS,
+        }
+    }
+}
+
+pub fn spawn_evolution_background_task(
+    config: EvolutionTaskConfig,
+    result_tx: mpsc::Sender<EvolutionResult>,
+) -> tokio::sync::mpsc::Sender<EvolutionJob> {
+    let (job_tx, job_rx) = tokio::sync::mpsc::channel(DEFAULT_EVOLUTION_CHANNEL_CAPACITY);
+    tokio::spawn(evolution_background_task(job_rx, result_tx, config));
+    job_tx
+}
+
+pub async fn evolution_background_task(
+    mut job_rx: tokio::sync::mpsc::Receiver<EvolutionJob>,
+    result_tx: mpsc::Sender<EvolutionResult>,
+    config: EvolutionTaskConfig,
+) {
+    let concurrency = config.max_concurrent_jobs.max(1);
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+
+    #[cfg(feature = "llm")]
+    let client = match reqwest::Client::builder().timeout(config.timeout).build() {
+        Ok(client) => Some(client),
+        Err(error) => {
+            warn!(error = %error, "Evolution LLM Client erstellen fehlgeschlagen");
+            None
+        }
+    };
+
+    while let Some(job) = job_rx.recv().await {
+        let permit = match semaphore.clone().acquire_owned().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                warn!(error = %error, "Evolution Background-Semaphore geschlossen");
+                break;
+            }
+        };
+        let result_tx = result_tx.clone();
+        let config = config.clone();
+
+        #[cfg(feature = "llm")]
+        let client = client.clone();
+
+        tokio::spawn(async move {
+            let _permit = permit;
+
+            #[cfg(feature = "llm")]
+            let result = match client {
+                Some(client) => run_evolution_job(&client, &config.gateway_url, job).await,
+                None => fail_safe_result(job),
+            };
+
+            #[cfg(not(feature = "llm"))]
+            let result = {
+                warn!(
+                    agent = %job.agent_name,
+                    source = job.source.as_str(),
+                    "Evolution LLM deaktiviert, schreibe Narrative ohne Voice/Behavioral Notes"
+                );
+                fail_safe_result(job)
+            };
+
+            if result_tx.send(result).is_err() {
+                warn!("Evolution-Ergebnis konnte nicht an ECS Tick-Loop gesendet werden");
+            }
+        });
+    }
+}
+
+#[cfg(feature = "llm")]
+async fn run_evolution_job(
+    client: &reqwest::Client,
+    gateway_url: &str,
+    job: EvolutionJob,
+) -> EvolutionResult {
+    let url = format!("{}/v1/chat/completions", gateway_url.trim_end_matches('/'));
+    info!(
+        agent = %job.agent_name,
+        source = job.source.as_str(),
+        "Evolution Background-Job gestartet"
+    );
+
+    let voice_user_prompt =
+        voice_style_user_prompt(&job.agent_name, &job.agent_role, &job.narrative);
+    let behavioral_user_prompt =
+        behavioral_notes_user_prompt(&job.agent_name, &job.agent_role, &job.narrative);
+
+    let (voice_style, behavioral_notes) = tokio::join!(
+        llm_evolution_call(
+            client,
+            &url,
+            &job.agent_name,
+            voice_style_system_prompt(),
+            &voice_user_prompt,
+        ),
+        llm_evolution_call(
+            client,
+            &url,
+            &job.agent_name,
+            behavioral_notes_system_prompt(),
+            &behavioral_user_prompt,
+        ),
+    );
+
+    info!(
+        agent = %job.agent_name,
+        source = job.source.as_str(),
+        voice_style = voice_style.is_some(),
+        behavioral_notes = behavioral_notes.is_some(),
+        "Evolution Background-Job abgeschlossen"
+    );
+
+    EvolutionResult {
+        agent_id: job.agent_id,
+        agent_name: job.agent_name,
+        source: job.source,
+        voice_style,
+        behavioral_notes,
+        narrative: job.narrative,
+    }
+}
+
+pub fn apply_evolution_result(store: &StateStore, result: &EvolutionResult) -> Result<u64> {
+    store.set_evolution_batch(
+        result.agent_id,
+        result.voice_style.as_deref(),
+        result.behavioral_notes.as_deref(),
+        Some(result.narrative.as_bytes()),
+        None,
+    )
+}
+
+fn fail_safe_result(job: EvolutionJob) -> EvolutionResult {
+    EvolutionResult {
+        agent_id: job.agent_id,
+        agent_name: job.agent_name,
+        source: job.source,
+        voice_style: None,
+        behavioral_notes: None,
+        narrative: job.narrative,
+    }
+}
+
+#[cfg(feature = "llm")]
+async fn llm_evolution_call(
+    client: &reqwest::Client,
+    url: &str,
+    agent_name: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Option<Vec<u8>> {
+    let body = serde_json::json!({
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ],
+        "temperature": 0.3,
+        "max_tokens": 500,
+        "model": "default",
+        "metadata": {
+            "agent_id": agent_name,
+            "request_type": "evolution_analysis"
+        }
+    });
+
+    match client.post(url).json(&body).send().await {
+        Ok(response) => {
+            if !response.status().is_success() {
+                warn!(
+                    agent = agent_name,
+                    status = %response.status(),
+                    "Evolution LLM Call fehlgeschlagen (HTTP)"
+                );
+                return None;
+            }
+            match response.json::<serde_json::Value>().await {
+                Ok(json) => extract_evolution_content(&json).map(|content| content.into_bytes()),
+                Err(error) => {
+                    warn!(
+                        agent = agent_name,
+                        error = %error,
+                        "Evolution LLM Response parse fehlgeschlagen"
+                    );
+                    None
+                }
+            }
+        }
+        Err(error) => {
+            warn!(
+                agent = agent_name,
+                error = %error,
+                "Evolution LLM Call fehlgeschlagen"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(feature = "llm")]
+fn extract_evolution_content(json: &serde_json::Value) -> Option<String> {
+    if let Some(content) = json.get("content").and_then(|value| value.as_str()) {
+        if !content.is_empty() {
+            return Some(content.to_string());
+        }
+    }
+
+    let content = json
+        .get("choices")
+        .and_then(|value| value.as_array())
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    if content.is_empty() {
+        None
+    } else {
+        Some(content.to_string())
+    }
+}
+
+#[cfg(feature = "llm")]
+fn voice_style_system_prompt() -> &'static str {
+    "Du bist ein linguistischer Analyst fuer eine Firmen-Simulation. \
+     Analysiere den Sprachstil des Agenten basierend auf seiner Schicht-Zusammenfassung. \
+     Antworte AUSSCHLIESSLICH als valides JSON."
+}
+
+#[cfg(feature = "llm")]
+fn voice_style_user_prompt(agent_name: &str, agent_role: &str, narrative: &str) -> String {
+    format!(
+        "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
+         {narrative}\n\n\
+         Analysiere den Sprachstil. Antwort als JSON:\n\
+         {{\"phrases\": [\"phrase1\"], \"sentence_style\": \"kurz|mittel|lang\", \"formality\": 0.X}}"
+    )
+}
+
+#[cfg(feature = "llm")]
+fn behavioral_notes_system_prompt() -> &'static str {
+    "Du bist ein Verhaltensanalyst fuer eine Firmen-Simulation. \
+     Analysiere Verhaltensmuster des Agenten basierend auf seiner Schicht-Zusammenfassung. \
+     Antworte AUSSCHLIESSLICH als valides JSON."
+}
+
+#[cfg(feature = "llm")]
+fn behavioral_notes_user_prompt(agent_name: &str, agent_role: &str, narrative: &str) -> String {
+    format!(
+        "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
+         {narrative}\n\n\
+         Identifiziere Verhaltensmuster. Antwort als JSON:\n\
+         {{\"habits\": [\"habit1\"], \"interaction_style\": \"proaktiv|reaktiv|gemischt\", \
+         \"decision_style\": \"schnell|zoegerlich|ausgewogen\", \"anomalies\": []}}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_evolution_job_roundtrip() {
+        let (tx, rx) = mpsc::channel();
+        let job = EvolutionJob {
+            agent_id: AgentId(7),
+            agent_name: "Test Agent".to_string(),
+            agent_role: "Tester".to_string(),
+            narrative: "Observed a regression and wrote a report".to_string(),
+            source: EvolutionSource::ShiftTransition,
+        };
+
+        tx.send(job.clone()).unwrap();
+
+        assert_eq!(rx.recv().unwrap(), job);
+    }
+
+    #[test]
+    fn test_evolution_result_applied_to_redb() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(dir.path().join("state.redb").to_str().unwrap()).unwrap();
+        let result = EvolutionResult {
+            agent_id: AgentId(5),
+            agent_name: "Ada".to_string(),
+            source: EvolutionSource::Nightrun,
+            voice_style: Some(br#"{"phrases":["klar"]}"#.to_vec()),
+            behavioral_notes: Some(br#"{"habits":["audit"]}"#.to_vec()),
+            narrative: "Ada consolidated a shift".to_string(),
+        };
+
+        let version = apply_evolution_result(&store, &result).unwrap();
+
+        assert_eq!(version, 1);
+        assert_eq!(store.get_evolution_version(AgentId(5)).unwrap(), 1);
+        assert_eq!(
+            store.get_voice_style(AgentId(5)).unwrap(),
+            Some(br#"{"phrases":["klar"]}"#.to_vec())
+        );
+        assert_eq!(
+            store.get_behavioral_notes(AgentId(5)).unwrap(),
+            Some(br#"{"habits":["audit"]}"#.to_vec())
+        );
+        assert_eq!(
+            store.get_narrative_summary(AgentId(5)).unwrap(),
+            Some(b"Ada consolidated a shift".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_evolution_result_empty_fields_no_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StateStore::open(dir.path().join("state.redb").to_str().unwrap()).unwrap();
+        store
+            .set_evolution_batch(
+                AgentId(9),
+                Some(b"existing voice"),
+                Some(b"existing notes"),
+                Some(b"old narrative"),
+                None,
+            )
+            .unwrap();
+        let result = EvolutionResult {
+            agent_id: AgentId(9),
+            agent_name: "Grace".to_string(),
+            source: EvolutionSource::ShiftTransition,
+            voice_style: None,
+            behavioral_notes: None,
+            narrative: "new narrative".to_string(),
+        };
+
+        let version = apply_evolution_result(&store, &result).unwrap();
+
+        assert_eq!(version, 2);
+        assert_eq!(
+            store.get_voice_style(AgentId(9)).unwrap(),
+            Some(b"existing voice".to_vec())
+        );
+        assert_eq!(
+            store.get_behavioral_notes(AgentId(9)).unwrap(),
+            Some(b"existing notes".to_vec())
+        );
+        assert_eq!(
+            store.get_narrative_summary(AgentId(9)).unwrap(),
+            Some(b"new narrative".to_vec())
+        );
+    }
+
+    #[cfg(feature = "llm")]
+    #[test]
+    fn test_extract_evolution_content_supports_gateway_shapes() {
+        let flat = serde_json::json!({"content": "{\"flat\":true}"});
+        let openai = serde_json::json!({
+            "choices": [{"message": {"content": "{\"openai\":true}"}}]
+        });
+
+        assert_eq!(
+            extract_evolution_content(&flat).unwrap(),
+            "{\"flat\":true}".to_string()
+        );
+        assert_eq!(
+            extract_evolution_content(&openai).unwrap(),
+            "{\"openai\":true}".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evolution_background_task_fail_safe_on_gateway_failure() {
+        let (result_tx, result_rx) = mpsc::channel();
+        let (job_tx, job_rx) = tokio::sync::mpsc::channel(1);
+        let config = EvolutionTaskConfig {
+            gateway_url: "http://127.0.0.1:9".to_string(),
+            timeout: Duration::from_millis(100),
+            max_concurrent_jobs: 1,
+        };
+
+        tokio::spawn(evolution_background_task(job_rx, result_tx, config));
+        job_tx
+            .send(EvolutionJob {
+                agent_id: AgentId(11),
+                agent_name: "Linus".to_string(),
+                agent_role: "Engineer".to_string(),
+                narrative: "Network failed but the tick loop must continue".to_string(),
+                source: EvolutionSource::Nightrun,
+            })
+            .await
+            .unwrap();
+        drop(job_tx);
+
+        let result =
+            tokio::task::spawn_blocking(move || result_rx.recv_timeout(Duration::from_secs(2)))
+                .await
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(result.agent_id, AgentId(11));
+        assert_eq!(result.voice_style, None);
+        assert_eq!(result.behavioral_notes, None);
+        assert_eq!(
+            result.narrative,
+            "Network failed but the tick loop must continue"
+        );
+    }
+}

--- a/services/sentinel-daemon/src/lib.rs
+++ b/services/sentinel-daemon/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod controlplane;
 pub mod ebpf;
 pub mod episode_producer;
+pub mod evolution_task;
 pub mod fanout;
 pub mod llm_bridge;
 #[cfg(feature = "nats")]

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -12,7 +12,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result as AnyResult};
-use sentinel_fs::{cas::CasStore, layer::LayerManager, metadata::MetadataStore};
+use sentinel_fs::{
+    cas::CasStore,
+    layer::LayerManager,
+    metadata::{FileKind, MetadataStore},
+};
 use sentinel_redb::{ApiCpSnapshot, StateStore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -61,6 +65,8 @@ const OPERATOR_SECURITY_FS_TRASH_PATH: &str = "/operator/security/fs-trash";
 const OPERATOR_SECURITY_FS_TRASH_FIXTURE_PATH: &str = "/operator/security/fs-trash-fixture";
 const OPERATOR_SECURITY_FS_TRASH_AGE_PATH: &str = "/operator/security/fs-trash-age";
 const OPERATOR_SECURITY_FS_TRASH_GC_PATH: &str = "/operator/security/fs-trash-gc";
+const OPERATOR_SECURITY_FS_STATS_PATH: &str = "/operator/security/fs-stats";
+const OPERATOR_SECURITY_FS_DEDUP_BENCHMARK_PATH: &str = "/operator/security/fs-dedup-benchmark";
 const OPERATOR_SECURITY_FS_RANSOMWARE_TEST_PATH: &str = "/operator/security/fs-ransomware-test";
 const OPERATOR_SECURITY_AGENT_RUNTIME_STATE_PATH: &str = "/operator/security/agent-runtime-state";
 const OPERATOR_SECURITY_WRITE_ANOMALY_TEST_PATH: &str = "/operator/security/write-anomaly-test";
@@ -121,7 +127,37 @@ pub struct TriggerNightrunRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TriggerNightrunResponse {
     pub accepted: bool,
+    #[serde(default)]
+    pub agents_queued: u32,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NightrunAgentCounts {
+    total: u32,
+    by_shift: HashMap<u8, u32>,
+}
+
+impl NightrunAgentCounts {
+    pub fn from_shift_sets(shift_sets: impl IntoIterator<Item = u8>) -> Self {
+        let mut total = 0u32;
+        let mut by_shift = HashMap::new();
+        for shift_set in shift_sets {
+            if shift_set == 0 {
+                continue;
+            }
+            total += 1;
+            *by_shift.entry(shift_set).or_insert(0) += 1;
+        }
+        Self { total, by_shift }
+    }
+
+    fn agents_queued(&self, shift_set: Option<u8>) -> u32 {
+        match shift_set {
+            Some(shift) => self.by_shift.get(&shift).copied().unwrap_or(0),
+            None => self.total,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -229,6 +265,56 @@ struct AgentRuntimeStateResponse {
     fs_mount: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct FsStorageStatsResponse {
+    accepted: bool,
+    fs_mount: Option<String>,
+    cas_blob_count: u64,
+    cas_bytes_on_disk: u64,
+    regular_file_count: u64,
+    logical_regular_file_bytes: u64,
+    dedup_savings_bytes: u64,
+    dedup_ratio_percent: f64,
+    unreadable_inode_rows: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FsDedupBenchmarkRequest {
+    agent_name: String,
+    #[serde(default = "default_fs_dedup_benchmark_writes")]
+    writes: u32,
+    #[serde(default = "default_fs_dedup_benchmark_bytes")]
+    bytes_per_write: usize,
+    #[serde(default)]
+    file_prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct FsDedupBenchmarkResponse {
+    accepted: bool,
+    agent_name: String,
+    fs_agent_dir: String,
+    file_prefix: String,
+    bytes_per_write: usize,
+    seed_write_us: u64,
+    dedup_hit_writes: u32,
+    dedup_hits: u32,
+    logical_bytes_written: u64,
+    cas_blob_count_before: u64,
+    cas_blob_count_after: u64,
+    cas_bytes_before: u64,
+    cas_bytes_after: u64,
+    cas_bytes_delta: u64,
+    dedup_ratio_percent: f64,
+    target_87_percent_met: bool,
+    dedup_hit_latency_us_min: u64,
+    dedup_hit_latency_us_p50: u64,
+    dedup_hit_latency_us_p95: u64,
+    dedup_hit_latency_us_max: u64,
+    dedup_hit_latency_us_mean: f64,
+    target_100us_met: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct WriteAnomalyTestRequest {
     agent_name: String,
@@ -286,6 +372,7 @@ struct AppState {
     platform_tx: mpsc::Sender<PlatformControlCommand>,
     runtime_tx: mpsc::Sender<RuntimeControlCommand>,
     nightrun_tx: mpsc::Sender<OperatorNightrunCommand>,
+    nightrun_agent_counts: NightrunAgentCounts,
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
     event_store: Arc<sentinel_limbo::EventStore>,
@@ -335,6 +422,14 @@ fn default_write_anomaly_alignment() -> bool {
     true
 }
 
+fn default_fs_dedup_benchmark_writes() -> u32 {
+    64
+}
+
+fn default_fs_dedup_benchmark_bytes() -> usize {
+    4096
+}
+
 impl ApiError {
     fn to_response(&self) -> HttpResponse {
         match self {
@@ -374,6 +469,7 @@ pub async fn start_server(
     platform_tx: mpsc::Sender<PlatformControlCommand>,
     runtime_tx: mpsc::Sender<RuntimeControlCommand>,
     nightrun_tx: mpsc::Sender<OperatorNightrunCommand>,
+    nightrun_agent_counts: NightrunAgentCounts,
     snapshot_tx: mpsc::Sender<sentinel_common::OperatorSnapshotCommand>,
     restore_tx: mpsc::Sender<sentinel_common::OperatorRestoreCommand>,
     event_store: Arc<sentinel_limbo::EventStore>,
@@ -397,6 +493,7 @@ pub async fn start_server(
         platform_tx,
         runtime_tx,
         nightrun_tx,
+        nightrun_agent_counts,
         snapshot_tx,
         restore_tx,
         event_store,
@@ -492,6 +589,10 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Ok(payload) => json_response(200, payload),
                 Err(err) => err.to_response(),
             },
+            OPERATOR_SECURITY_FS_STATS_PATH => match inspect_fs_storage_stats(state) {
+                Ok(payload) => json_response(200, payload),
+                Err(err) => err.to_response(),
+            },
             OPERATOR_SECURITY_AGENT_RUNTIME_STATE_PATH => {
                 match inspect_agent_runtime_state(query.get("agent_id"), state) {
                     Ok(payload) => json_response(200, payload),
@@ -557,6 +658,7 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                     202,
                     TriggerNightrunResponse {
                         accepted: true,
+                        agents_queued: 0,
                         message: "Snapshot-Erstellung gestartet".to_string(),
                     },
                 ),
@@ -580,6 +682,7 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                     202,
                     TriggerNightrunResponse {
                         accepted: true,
+                        agents_queued: 0,
                         message: "Restore gestartet".to_string(),
                     },
                 ),
@@ -816,6 +919,18 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                 Err(err) => err.to_response(),
             }
         }
+        OPERATOR_SECURITY_FS_DEDUP_BENCHMARK_PATH => {
+            let payload: FsDedupBenchmarkRequest = match serde_json::from_slice(&request.body) {
+                Ok(p) => p,
+                Err(_) => {
+                    return ApiError::BadRequest("Request-JSON ungueltig").to_response();
+                }
+            };
+            match run_fs_dedup_benchmark(payload, state) {
+                Ok(response) => json_response(200, response),
+                Err(err) => err.to_response(),
+            }
+        }
         OPERATOR_SECURITY_FS_RANSOMWARE_TEST_PATH => {
             let payload: FsRansomwareTestRequest = match serde_json::from_slice(&request.body) {
                 Ok(p) => p,
@@ -975,6 +1090,8 @@ fn dispatch_nightrun_trigger(
         "Nightrun-Trigger via Operator-API empfangen"
     );
 
+    let agents_queued = state.nightrun_agent_counts.agents_queued(payload.shift_set);
+
     state
         .nightrun_tx
         .send(command)
@@ -982,6 +1099,7 @@ fn dispatch_nightrun_trigger(
 
     Ok(TriggerNightrunResponse {
         accepted: true,
+        agents_queued,
         message: "Nightrun-Konsolidierung gestartet".to_string(),
     })
 }
@@ -996,6 +1114,7 @@ fn dispatch_platform_analyze(
 
     Ok(TriggerNightrunResponse {
         accepted: true,
+        agents_queued: 0,
         message: "Platform-Analyse eingeplant".to_string(),
     })
 }
@@ -1043,6 +1162,7 @@ fn dispatch_platform_trigger_test(
 
     Ok(TriggerNightrunResponse {
         accepted: true,
+        agents_queued: 0,
         message: format!("Platform-Testtrigger {trigger} eingeplant"),
     })
 }
@@ -1129,6 +1249,7 @@ fn dispatch_platform_analysis_test(
 
     Ok(TriggerNightrunResponse {
         accepted: true,
+        agents_queued: 0,
         message: "Platform-Analyse-Test eingeplant".to_string(),
     })
 }
@@ -1516,6 +1637,219 @@ fn run_fs_trash_gc(
         freed_from_trash: stats.freed_from_trash,
         freed_bytes: stats.freed_bytes,
     })
+}
+
+fn inspect_fs_storage_stats(
+    state: &AppState,
+) -> std::result::Result<FsStorageStatsResponse, ApiError> {
+    let layer = open_fs_layer(state)?;
+    let stats = layer
+        .storage_stats()
+        .map_err(|_| ApiError::ServiceUnavailable("sentinel-fs Storage-Stats nicht lesbar"))?;
+    Ok(FsStorageStatsResponse {
+        accepted: true,
+        fs_mount: state.fs_mount.clone(),
+        cas_blob_count: stats.cas_blob_count,
+        cas_bytes_on_disk: stats.cas_bytes_on_disk,
+        regular_file_count: stats.regular_file_count,
+        logical_regular_file_bytes: stats.logical_regular_file_bytes,
+        dedup_savings_bytes: stats.dedup_savings_bytes,
+        dedup_ratio_percent: stats.dedup_ratio_percent,
+        unreadable_inode_rows: stats.unreadable_inode_rows,
+    })
+}
+
+fn run_fs_dedup_benchmark(
+    payload: FsDedupBenchmarkRequest,
+    state: &AppState,
+) -> std::result::Result<FsDedupBenchmarkResponse, ApiError> {
+    let agent_name = payload.agent_name.trim();
+    if agent_name.is_empty() {
+        return Err(ApiError::BadRequest("agent_name fehlt"));
+    }
+    if payload.writes == 0 || payload.writes > 512 {
+        return Err(ApiError::BadRequest(
+            "writes muss zwischen 1 und 512 liegen",
+        ));
+    }
+    if payload.bytes_per_write == 0 || payload.bytes_per_write > 64 * 1024 {
+        return Err(ApiError::BadRequest(
+            "bytes_per_write muss zwischen 1 und 65536 liegen",
+        ));
+    }
+
+    let requested_prefix = payload.file_prefix.as_deref().unwrap_or("issue379");
+    let file_prefix = format!(
+        "{}-{}",
+        validate_benchmark_file_prefix(requested_prefix)?,
+        uuid::Uuid::now_v7()
+    );
+    let fs_agent_dir = fs_agent_dir_for_name(state, agent_name)?;
+    let layer = open_fs_layer(state)?;
+    let parent_inode = ensure_issue379_benchmark_dir(&layer, &fs_agent_dir)?;
+    let content = dedup_benchmark_content(payload.bytes_per_write, &file_prefix);
+    let content_hash = CasStore::hash(&content);
+
+    let before = layer
+        .storage_stats()
+        .map_err(|_| ApiError::ServiceUnavailable("sentinel-fs Storage-Stats nicht lesbar"))?;
+    let seed_started = Instant::now();
+    layer
+        .write_file(
+            &fs_agent_dir,
+            parent_inode,
+            &format!("{file_prefix}-seed.bin"),
+            &content,
+            0o644,
+        )
+        .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Seed-Write fehlgeschlagen"))?;
+    let seed_write_us = elapsed_us(seed_started.elapsed());
+
+    let mut latencies = Vec::with_capacity(payload.writes as usize);
+    let mut dedup_hits = 0u32;
+    for idx in 0..payload.writes {
+        if layer.cas().contains(&content_hash) {
+            dedup_hits += 1;
+        }
+        let started = Instant::now();
+        layer
+            .write_file(
+                &fs_agent_dir,
+                parent_inode,
+                &format!("{file_prefix}-hit-{idx:04}.bin"),
+                &content,
+                0o644,
+            )
+            .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Write fehlgeschlagen"))?;
+        latencies.push(elapsed_us(started.elapsed()));
+    }
+
+    let after = layer
+        .storage_stats()
+        .map_err(|_| ApiError::ServiceUnavailable("sentinel-fs Storage-Stats nicht lesbar"))?;
+    let logical_bytes_written =
+        u64::from(payload.writes + 1).saturating_mul(payload.bytes_per_write as u64);
+    let cas_bytes_delta = after
+        .cas_bytes_on_disk
+        .saturating_sub(before.cas_bytes_on_disk);
+    let dedup_ratio_percent = if logical_bytes_written == 0 {
+        0.0
+    } else {
+        (logical_bytes_written.saturating_sub(cas_bytes_delta) as f64 * 100.0)
+            / logical_bytes_written as f64
+    };
+    latencies.sort_unstable();
+    let latency_min = *latencies.first().unwrap_or(&0);
+    let latency_max = *latencies.last().unwrap_or(&0);
+    let latency_p50 = percentile_us(&latencies, 0.50);
+    let latency_p95 = percentile_us(&latencies, 0.95);
+    let latency_mean = if latencies.is_empty() {
+        0.0
+    } else {
+        latencies.iter().sum::<u64>() as f64 / latencies.len() as f64
+    };
+
+    Ok(FsDedupBenchmarkResponse {
+        accepted: true,
+        agent_name: agent_name.to_string(),
+        fs_agent_dir,
+        file_prefix,
+        bytes_per_write: payload.bytes_per_write,
+        seed_write_us,
+        dedup_hit_writes: payload.writes,
+        dedup_hits,
+        logical_bytes_written,
+        cas_blob_count_before: before.cas_blob_count,
+        cas_blob_count_after: after.cas_blob_count,
+        cas_bytes_before: before.cas_bytes_on_disk,
+        cas_bytes_after: after.cas_bytes_on_disk,
+        cas_bytes_delta,
+        dedup_ratio_percent,
+        target_87_percent_met: dedup_ratio_percent >= 87.0,
+        dedup_hit_latency_us_min: latency_min,
+        dedup_hit_latency_us_p50: latency_p50,
+        dedup_hit_latency_us_p95: latency_p95,
+        dedup_hit_latency_us_max: latency_max,
+        dedup_hit_latency_us_mean: latency_mean,
+        target_100us_met: latency_p95 <= 100,
+    })
+}
+
+fn validate_benchmark_file_prefix(prefix: &str) -> std::result::Result<String, ApiError> {
+    let trimmed = prefix.trim();
+    if trimmed.is_empty() || trimmed.len() > 64 {
+        return Err(ApiError::BadRequest(
+            "file_prefix muss 1 bis 64 Zeichen lang sein",
+        ));
+    }
+    if !trimmed
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+    {
+        return Err(ApiError::BadRequest(
+            "file_prefix darf nur ASCII alnum, Punkt, Bindestrich und Unterstrich enthalten",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn ensure_issue379_benchmark_dir(
+    layer: &LayerManager,
+    agent_id: &str,
+) -> std::result::Result<u64, ApiError> {
+    const BENCHMARK_DIR: &str = ".issue379-dedup";
+    if let Some(inode) = layer
+        .lookup_dirent(agent_id, 1, BENCHMARK_DIR)
+        .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Dirent-Lookup fehlgeschlagen"))?
+    {
+        let data = layer
+            .lookup_inode(agent_id, inode)
+            .map_err(|_| {
+                ApiError::ServiceUnavailable("Dedup-Benchmark Inode-Lookup fehlgeschlagen")
+            })?
+            .ok_or(ApiError::ServiceUnavailable(
+                "Dedup-Benchmark Verzeichnis-Inode fehlt",
+            ))?;
+        if data.kind != FileKind::Directory {
+            return Err(ApiError::ServiceUnavailable(
+                "Dedup-Benchmark Pfad ist kein Verzeichnis",
+            ));
+        }
+        return Ok(inode);
+    }
+    layer
+        .mkdir(agent_id, 1, BENCHMARK_DIR, 0o755)
+        .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Verzeichnis nicht anlegbar"))
+}
+
+fn dedup_benchmark_content(len: usize, file_prefix: &str) -> Vec<u8> {
+    let digest = Sha256::digest(file_prefix.as_bytes());
+    let mut seed_bytes = [0u8; 8];
+    seed_bytes.copy_from_slice(&digest[..8]);
+    let mut state = u64::from_le_bytes(seed_bytes);
+    let mut output = Vec::with_capacity(len);
+    for index in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state = state
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            .wrapping_add(index as u64);
+        output.push((state >> 32) as u8);
+    }
+    output
+}
+
+fn elapsed_us(duration: Duration) -> u64 {
+    duration.as_micros().min(u128::from(u64::MAX)) as u64
+}
+
+fn percentile_us(sorted_values: &[u64], percentile: f64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+    let index = ((sorted_values.len() - 1) as f64 * percentile).ceil() as usize;
+    sorted_values[index.min(sorted_values.len() - 1)]
 }
 
 fn inspect_agent_runtime_state(
@@ -2333,6 +2667,7 @@ mod tests {
             platform_tx,
             runtime_tx,
             nightrun_tx,
+            nightrun_agent_counts: NightrunAgentCounts::from_shift_sets([1, 1, 2, 3]),
             snapshot_tx: mpsc::channel().0,
             restore_tx: mpsc::channel().0,
             event_store: Arc::new(
@@ -2422,6 +2757,24 @@ mod tests {
             headers: HashMap::new(),
             body: serde_json::to_vec(&body).unwrap(),
         }
+    }
+
+    fn test_get_request(path: &str) -> HttpRequest {
+        HttpRequest {
+            method: "GET".to_string(),
+            path: path.to_string(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    fn attach_test_fs_layer(state: &mut AppState) -> Arc<LayerManager> {
+        let cas = CasStore::open(&state.data_dir).unwrap();
+        let meta = MetadataStore::open(state.data_dir.join("metadata.redb")).unwrap();
+        let layer = Arc::new(LayerManager::new(cas, meta));
+        layer.init_base_root().unwrap();
+        state.fs_layer = Some(Arc::clone(&layer));
+        layer
     }
 
     #[test]
@@ -2552,6 +2905,91 @@ mod tests {
             }
             other => panic!("unerwartetes Kommando: {other:?}"),
         }
+    }
+
+    #[test]
+    fn nightrun_request_returns_agents_queued_and_forwards_command() {
+        let (mut state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        let (nightrun_tx, nightrun_rx) = mpsc::channel();
+        state.nightrun_tx = nightrun_tx;
+        state.nightrun_agent_counts = NightrunAgentCounts::from_shift_sets([1, 1, 2, 3]);
+
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_NIGHTRUN_PATH,
+                serde_json::json!({
+                    "shift_set": 1,
+                    "dry_run": false
+                }),
+            ),
+            &state,
+        );
+
+        assert_eq!(response.status, 202);
+        let payload: TriggerNightrunResponse = serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.agents_queued, 2);
+        let command = nightrun_rx.recv().unwrap();
+        assert_eq!(command.shift_set, Some(1));
+        assert!(!command.dry_run);
+    }
+
+    #[test]
+    fn fs_storage_stats_get_reports_logical_and_cas_bytes() {
+        let (mut state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        let layer = attach_test_fs_layer(&mut state);
+        let fs_agent_dir = fs_agent_dir_for_name(&state, "Test Agent").unwrap();
+        let content = b"same content for fs stats";
+        layer
+            .write_file(&fs_agent_dir, 1, "stats-a.bin", content, 0o644)
+            .unwrap();
+        layer
+            .write_file(&fs_agent_dir, 1, "stats-b.bin", content, 0o644)
+            .unwrap();
+
+        let response =
+            handle_http_request(test_get_request(OPERATOR_SECURITY_FS_STATS_PATH), &state);
+
+        assert_eq!(response.status, 200);
+        let payload: FsStorageStatsResponse = serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.cas_blob_count, 1);
+        assert_eq!(
+            payload.logical_regular_file_bytes,
+            (content.len() * 2) as u64
+        );
+        assert!(payload.dedup_savings_bytes > 0);
+    }
+
+    #[test]
+    fn fs_dedup_benchmark_reports_hits_ratio_and_latency() {
+        let (mut state, _rx, _platform_rx, _runtime_rx) = test_state(None);
+        attach_test_fs_layer(&mut state);
+
+        let response = handle_http_request(
+            test_request(
+                OPERATOR_SECURITY_FS_DEDUP_BENCHMARK_PATH,
+                serde_json::json!({
+                    "agent_name": "Test Agent",
+                    "writes": 8,
+                    "bytes_per_write": 512,
+                    "file_prefix": "test-379"
+                }),
+            ),
+            &state,
+        );
+
+        assert_eq!(response.status, 200);
+        let payload: FsDedupBenchmarkResponse = serde_json::from_slice(&response.body).unwrap();
+        assert!(payload.accepted);
+        assert_eq!(payload.agent_name, "Test Agent");
+        assert_eq!(payload.fs_agent_dir, "AGENT-07");
+        assert_eq!(payload.dedup_hit_writes, 8);
+        assert_eq!(payload.dedup_hits, 8);
+        assert_eq!(payload.logical_bytes_written, 9 * 512);
+        assert!(payload.cas_blob_count_after >= payload.cas_blob_count_before + 1);
+        assert!(payload.target_87_percent_met);
+        assert!(payload.dedup_hit_latency_us_max >= payload.dedup_hit_latency_us_min);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -1724,8 +1724,11 @@ fn run_fs_dedup_benchmark(
     let mut cas_check_latencies = Vec::with_capacity(payload.writes as usize);
     let mut write_file_latencies = Vec::with_capacity(payload.writes as usize);
     let mut loop_latencies = Vec::with_capacity(payload.writes as usize);
+    let hit_file_names: Vec<String> = (0..payload.writes)
+        .map(|idx| format!("{file_prefix}-hit-{idx:04}.bin"))
+        .collect();
     let mut dedup_hits = 0u32;
-    for idx in 0..payload.writes {
+    for name in &hit_file_names {
         let loop_started = Instant::now();
         let cas_check_started = Instant::now();
         if layer.cas().contains(&content_hash) {
@@ -1735,13 +1738,7 @@ fn run_fs_dedup_benchmark(
 
         let write_started = Instant::now();
         layer
-            .write_file(
-                &fs_agent_dir,
-                parent_inode,
-                &format!("{file_prefix}-hit-{idx:04}.bin"),
-                &content,
-                0o644,
-            )
+            .write_file(&fs_agent_dir, parent_inode, name, &content, 0o644)
             .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Write fehlgeschlagen"))?;
         write_file_latencies.push(elapsed_us(write_started.elapsed()));
         loop_latencies.push(elapsed_us(loop_started.elapsed()));

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -2987,7 +2987,7 @@ mod tests {
         assert_eq!(payload.dedup_hit_writes, 8);
         assert_eq!(payload.dedup_hits, 8);
         assert_eq!(payload.logical_bytes_written, 9 * 512);
-        assert!(payload.cas_blob_count_after >= payload.cas_blob_count_before + 1);
+        assert!(payload.cas_blob_count_after > payload.cas_blob_count_before);
         assert!(payload.target_87_percent_met);
         assert!(payload.dedup_hit_latency_us_max >= payload.dedup_hit_latency_us_min);
     }

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -290,6 +290,15 @@ struct FsDedupBenchmarkRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct FsLatencySummary {
+    min_us: u64,
+    p50_us: u64,
+    p95_us: u64,
+    max_us: u64,
+    mean_us: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct FsDedupBenchmarkResponse {
     accepted: bool,
     agent_name: String,
@@ -312,6 +321,11 @@ struct FsDedupBenchmarkResponse {
     dedup_hit_latency_us_p95: u64,
     dedup_hit_latency_us_max: u64,
     dedup_hit_latency_us_mean: f64,
+    dedup_hit_cas_check_latency: FsLatencySummary,
+    dedup_hit_write_file_latency: FsLatencySummary,
+    dedup_hit_loop_latency: FsLatencySummary,
+    storage_stats_before_us: u64,
+    storage_stats_after_us: u64,
     target_100us_met: bool,
 }
 
@@ -1690,9 +1704,11 @@ fn run_fs_dedup_benchmark(
     let content = dedup_benchmark_content(payload.bytes_per_write, &file_prefix);
     let content_hash = CasStore::hash(&content);
 
+    let stats_before_started = Instant::now();
     let before = layer
         .storage_stats()
         .map_err(|_| ApiError::ServiceUnavailable("sentinel-fs Storage-Stats nicht lesbar"))?;
+    let storage_stats_before_us = elapsed_us(stats_before_started.elapsed());
     let seed_started = Instant::now();
     layer
         .write_file(
@@ -1705,13 +1721,19 @@ fn run_fs_dedup_benchmark(
         .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Seed-Write fehlgeschlagen"))?;
     let seed_write_us = elapsed_us(seed_started.elapsed());
 
-    let mut latencies = Vec::with_capacity(payload.writes as usize);
+    let mut cas_check_latencies = Vec::with_capacity(payload.writes as usize);
+    let mut write_file_latencies = Vec::with_capacity(payload.writes as usize);
+    let mut loop_latencies = Vec::with_capacity(payload.writes as usize);
     let mut dedup_hits = 0u32;
     for idx in 0..payload.writes {
+        let loop_started = Instant::now();
+        let cas_check_started = Instant::now();
         if layer.cas().contains(&content_hash) {
             dedup_hits += 1;
         }
-        let started = Instant::now();
+        cas_check_latencies.push(elapsed_us(cas_check_started.elapsed()));
+
+        let write_started = Instant::now();
         layer
             .write_file(
                 &fs_agent_dir,
@@ -1721,12 +1743,15 @@ fn run_fs_dedup_benchmark(
                 0o644,
             )
             .map_err(|_| ApiError::ServiceUnavailable("Dedup-Benchmark Write fehlgeschlagen"))?;
-        latencies.push(elapsed_us(started.elapsed()));
+        write_file_latencies.push(elapsed_us(write_started.elapsed()));
+        loop_latencies.push(elapsed_us(loop_started.elapsed()));
     }
 
+    let stats_after_started = Instant::now();
     let after = layer
         .storage_stats()
         .map_err(|_| ApiError::ServiceUnavailable("sentinel-fs Storage-Stats nicht lesbar"))?;
+    let storage_stats_after_us = elapsed_us(stats_after_started.elapsed());
     let logical_bytes_written =
         u64::from(payload.writes + 1).saturating_mul(payload.bytes_per_write as u64);
     let cas_bytes_delta = after
@@ -1738,16 +1763,14 @@ fn run_fs_dedup_benchmark(
         (logical_bytes_written.saturating_sub(cas_bytes_delta) as f64 * 100.0)
             / logical_bytes_written as f64
     };
-    latencies.sort_unstable();
-    let latency_min = *latencies.first().unwrap_or(&0);
-    let latency_max = *latencies.last().unwrap_or(&0);
-    let latency_p50 = percentile_us(&latencies, 0.50);
-    let latency_p95 = percentile_us(&latencies, 0.95);
-    let latency_mean = if latencies.is_empty() {
-        0.0
-    } else {
-        latencies.iter().sum::<u64>() as f64 / latencies.len() as f64
-    };
+    let cas_check_summary = latency_summary(cas_check_latencies);
+    let write_file_summary = latency_summary(write_file_latencies);
+    let loop_summary = latency_summary(loop_latencies);
+    let latency_min = write_file_summary.min_us;
+    let latency_max = write_file_summary.max_us;
+    let latency_p50 = write_file_summary.p50_us;
+    let latency_p95 = write_file_summary.p95_us;
+    let latency_mean = write_file_summary.mean_us;
 
     Ok(FsDedupBenchmarkResponse {
         accepted: true,
@@ -1771,8 +1794,34 @@ fn run_fs_dedup_benchmark(
         dedup_hit_latency_us_p95: latency_p95,
         dedup_hit_latency_us_max: latency_max,
         dedup_hit_latency_us_mean: latency_mean,
+        dedup_hit_cas_check_latency: cas_check_summary,
+        dedup_hit_write_file_latency: write_file_summary,
+        dedup_hit_loop_latency: loop_summary,
+        storage_stats_before_us,
+        storage_stats_after_us,
         target_100us_met: latency_p95 <= 100,
     })
+}
+
+fn latency_summary(mut latencies: Vec<u64>) -> FsLatencySummary {
+    latencies.sort_unstable();
+    let min_us = *latencies.first().unwrap_or(&0);
+    let max_us = *latencies.last().unwrap_or(&0);
+    let p50_us = percentile_us(&latencies, 0.50);
+    let p95_us = percentile_us(&latencies, 0.95);
+    let mean_us = if latencies.is_empty() {
+        0.0
+    } else {
+        latencies.iter().sum::<u64>() as f64 / latencies.len() as f64
+    };
+
+    FsLatencySummary {
+        min_us,
+        p50_us,
+        p95_us,
+        max_us,
+        mean_us,
+    }
 }
 
 fn validate_benchmark_file_prefix(prefix: &str) -> std::result::Result<String, ApiError> {
@@ -2990,6 +3039,18 @@ mod tests {
         assert!(payload.cas_blob_count_after > payload.cas_blob_count_before);
         assert!(payload.target_87_percent_met);
         assert!(payload.dedup_hit_latency_us_max >= payload.dedup_hit_latency_us_min);
+        assert_eq!(
+            payload.dedup_hit_latency_us_p95,
+            payload.dedup_hit_write_file_latency.p95_us
+        );
+        assert!(
+            payload.dedup_hit_cas_check_latency.max_us
+                >= payload.dedup_hit_cas_check_latency.min_us
+        );
+        assert!(
+            payload.dedup_hit_loop_latency.p95_us >= payload.dedup_hit_write_file_latency.min_us
+        );
+        assert!(payload.storage_stats_after_us > 0);
     }
 
     #[test]

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -40,6 +40,7 @@ use crate::controlplane::config::ControlplaneConfig;
 use crate::controlplane::store::ControlplaneStore;
 use crate::controlplane::ControlplaneKernel;
 use crate::episode_producer::EpisodeProducer;
+use crate::evolution_task::{EvolutionJob, EvolutionResult, EvolutionSource};
 use crate::operator_api;
 use crate::runtime_control::{
     RespawnBackoffTracker, RespawnRetryDecision, RuntimeAnalysisFloodTestResponse,
@@ -624,6 +625,12 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let (snapshot_tx, snapshot_rx) = mpsc::channel::<sentinel_common::OperatorSnapshotCommand>();
     let (restore_tx, restore_rx) = mpsc::channel::<sentinel_common::OperatorRestoreCommand>();
     let (prune_tx, prune_rx) = mpsc::channel::<i64>();
+    let (evolution_result_tx, evolution_result_rx) = mpsc::channel::<EvolutionResult>();
+    let evolution_job_tx = crate::evolution_task::spawn_evolution_background_task(
+        crate::evolution_task::EvolutionTaskConfig::from_env(),
+        evolution_result_tx,
+    );
+    info!("Evolution Background-Task initialisiert");
     // Bounded Channel: 128 Slots. Bridge drainet per try_recv() vor jedem LLM-Call.
     // Output_system nutzt try_send() (non-blocking, WARN bei Drop).
     let (perception_tx, perception_rx) = mpsc::sync_channel::<Perception>(128);
@@ -730,6 +737,10 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
         handle
     };
 
+    let nightrun_agent_counts = operator_api::NightrunAgentCounts::from_shift_sets(
+        all_agents.iter().map(|agent| agent.identity.shift_set),
+    );
+
     let operator_api_handle = if config.operator_api.enabled {
         Some(
             operator_api::start_server(
@@ -742,6 +753,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 platform_tx.clone(),
                 runtime_tx.clone(),
                 nightrun_tx.clone(),
+                nightrun_agent_counts,
                 snapshot_tx.clone(),
                 restore_tx.clone(),
                 Arc::clone(&event_store),
@@ -809,6 +821,8 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
                 ebpf_tx,
                 episode_producer,
                 nightrun_rx,
+                Some(evolution_job_tx),
+                Some(evolution_result_rx),
                 snapshot_rx,
                 restore_rx,
                 prune_rx,
@@ -1956,6 +1970,101 @@ fn apply_platform_analysis_command(
     Ok(())
 }
 
+fn queue_evolution_job(
+    tx: &Option<tokio::sync::mpsc::Sender<EvolutionJob>>,
+    job: EvolutionJob,
+) -> bool {
+    let Some(tx) = tx else {
+        warn!(
+            agent = %job.agent_name,
+            source = job.source.as_str(),
+            "Evolution Background-Task nicht verfuegbar, Job wird nicht eingereiht"
+        );
+        return false;
+    };
+
+    let source = job.source.as_str();
+    let agent_name = job.agent_name.clone();
+    match tx.try_send(job) {
+        Ok(()) => {
+            info!(
+                agent = %agent_name,
+                source = source,
+                "Evolution Background-Job eingereiht"
+            );
+            true
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Full(job)) => {
+            warn!(
+                agent = %job.agent_name,
+                source = job.source.as_str(),
+                "Evolution Background-Channel voll, Job wird nicht blockierend verworfen"
+            );
+            false
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(job)) => {
+            warn!(
+                agent = %job.agent_name,
+                source = job.source.as_str(),
+                "Evolution Background-Channel geschlossen, Job wird nicht eingereiht"
+            );
+            false
+        }
+    }
+}
+
+fn write_evolution_narrative_only(
+    store: &StateStore,
+    agent_id: AgentId,
+    agent_name: &str,
+    source: EvolutionSource,
+    narrative: &str,
+) {
+    match store.set_evolution_batch(agent_id, None, None, Some(narrative.as_bytes()), None) {
+        Ok(version) => {
+            info!(
+                agent = agent_name,
+                source = source.as_str(),
+                version,
+                "Evolution Narrative fallback nach redb geschrieben, EVOLUTION_VERSION = {version}"
+            );
+        }
+        Err(error) => {
+            warn!(
+                agent = agent_name,
+                source = source.as_str(),
+                error = %error,
+                "Evolution Narrative fallback redb-Write fehlgeschlagen"
+            );
+        }
+    }
+}
+
+fn drain_evolution_results(store: &StateStore, rx: &mpsc::Receiver<EvolutionResult>) {
+    while let Ok(result) = rx.try_recv() {
+        match crate::evolution_task::apply_evolution_result(store, &result) {
+            Ok(version) => {
+                info!(
+                    agent = %result.agent_name,
+                    source = result.source.as_str(),
+                    version,
+                    voice_style = result.voice_style.is_some(),
+                    behavioral_notes = result.behavioral_notes.is_some(),
+                    "Evolution nach redb geschrieben, EVOLUTION_VERSION = {version}"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    agent = %result.agent_name,
+                    source = result.source.as_str(),
+                    error = %error,
+                    "Evolution redb-Write fehlgeschlagen"
+                );
+            }
+        }
+    }
+}
+
 /// ECS Tick-Loop auf dediziertem Thread.
 ///
 /// Verwaltet den RuntimeOrchestrator (Lifecycle-Events, Shift-Wechsel, Snapshots)
@@ -1982,6 +2091,8 @@ fn ecs_tick_loop(
     ebpf_tx: tokio::sync::mpsc::Sender<MetricsSnapshot>,
     mut episode_producer: EpisodeProducer,
     nightrun_rx: mpsc::Receiver<sentinel_common::OperatorNightrunCommand>,
+    evolution_job_tx: Option<tokio::sync::mpsc::Sender<EvolutionJob>>,
+    evolution_result_rx: Option<mpsc::Receiver<EvolutionResult>>,
     snapshot_rx: mpsc::Receiver<sentinel_common::OperatorSnapshotCommand>,
     restore_rx: mpsc::Receiver<sentinel_common::OperatorRestoreCommand>,
     prune_rx: mpsc::Receiver<i64>,
@@ -2427,6 +2538,10 @@ fn ecs_tick_loop(
 
         if shutdown.load(Ordering::SeqCst) {
             break;
+        }
+
+        if let Some(rx) = evolution_result_rx.as_ref() {
+            drain_evolution_results(&state_store_for_sim, rx);
         }
 
         // PSI-basierte adaptive Tick-Rate aktualisieren (alle N Ticks)
@@ -2997,49 +3112,39 @@ fn ecs_tick_loop(
                                         "Schichtwechsel-Konsolidierung abgeschlossen"
                                     );
 
-                                    // Evolution-Daten nach redb schreiben
-                                    if let Some(ref store) = redb_store {
-                                        let narrative: String = result
-                                            .consolidated_summaries
-                                            .iter()
-                                            .map(|(s, _score)| s.as_str())
-                                            .collect::<Vec<_>>()
-                                            .join("; ");
+                                    let narrative: String = result
+                                        .consolidated_summaries
+                                        .iter()
+                                        .map(|(s, _score)| s.as_str())
+                                        .collect::<Vec<_>>()
+                                        .join("; ");
 
-                                        // LLM-basierte Voice-Style + Behavioral-Notes Generierung
-                                        let agent_role = all_agents
-                                            .iter()
-                                            .find(|a| AgentId(a.identity.id) == *agent_id)
-                                            .map(|a| a.identity.role.as_str())
-                                            .unwrap_or("Mitarbeiter");
-                                        let (voice_style, behavioral_notes) =
-                                            generate_evolution_fields(name, agent_role, &narrative);
-
-                                        match store.set_evolution_batch(
+                                    let agent_role = all_agents
+                                        .iter()
+                                        .find(|a| AgentId(a.identity.id) == *agent_id)
+                                        .map(|a| a.identity.role.as_str())
+                                        .unwrap_or("Mitarbeiter");
+                                    let queued = queue_evolution_job(
+                                        &evolution_job_tx,
+                                        EvolutionJob {
+                                            agent_id: *agent_id,
+                                            agent_name: name.to_string(),
+                                            agent_role: agent_role.to_string(),
+                                            narrative: narrative.clone(),
+                                            source: EvolutionSource::ShiftTransition,
+                                        },
+                                    );
+                                    if !queued {
+                                        write_evolution_narrative_only(
+                                            &state_store_for_sim,
                                             *agent_id,
-                                            voice_style.as_deref(),
-                                            behavioral_notes.as_deref(),
-                                            Some(narrative.as_bytes()),
-                                            None, // agent_facts bridged separately
-                                        ) {
-                                            Ok(version) => {
-                                                info!(
-                                                    agent = name,
-                                                    version,
-                                                    voice_style = voice_style.is_some(),
-                                                    behavioral_notes = behavioral_notes.is_some(),
-                                                    "Evolution nach redb geschrieben, EVOLUTION_VERSION = {version}"
-                                                );
-                                            }
-                                            Err(e) => {
-                                                warn!(
-                                                    agent = name,
-                                                    error = %e,
-                                                    "Evolution redb-Write fehlgeschlagen"
-                                                );
-                                            }
-                                        }
+                                            name,
+                                            EvolutionSource::ShiftTransition,
+                                            &narrative,
+                                        );
+                                    }
 
+                                    if let Some(ref store) = redb_store {
                                         // NMDA scores nach redb schreiben
                                         let scores: Vec<f64> = result
                                             .consolidated_summaries
@@ -3242,6 +3347,7 @@ fn ecs_tick_loop(
                 })
                 .collect();
             let mut consolidated_total = 0u32;
+            let mut evolution_jobs_queued = 0u32;
             let mut evolution_entries: Vec<(String, u32)> = Vec::new();
             for agent_cfg in &target_agents {
                 let name = &agent_cfg.identity.name;
@@ -3254,6 +3360,33 @@ fn ecs_tick_loop(
                         consolidated_total += result.episodes_processed as u32;
                         evolution_entries
                             .push((name.to_string(), result.episodes_processed as u32));
+                        let narrative = result
+                            .consolidated_summaries
+                            .iter()
+                            .map(|(summary, _score)| summary.as_str())
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        let queued = queue_evolution_job(
+                            &evolution_job_tx,
+                            EvolutionJob {
+                                agent_id: AgentId(agent_cfg.identity.id),
+                                agent_name: name.to_string(),
+                                agent_role: agent_cfg.identity.role.clone(),
+                                narrative: narrative.clone(),
+                                source: EvolutionSource::Nightrun,
+                            },
+                        );
+                        if queued {
+                            evolution_jobs_queued += 1;
+                        } else {
+                            write_evolution_narrative_only(
+                                &state_store_for_sim,
+                                AgentId(agent_cfg.identity.id),
+                                name,
+                                EvolutionSource::Nightrun,
+                                &narrative,
+                            );
+                        }
                         info!(
                             agent = %name,
                             episodes = result.episodes_processed,
@@ -3320,6 +3453,7 @@ fn ecs_tick_loop(
             info!(
                 agents = target_agents.len(),
                 consolidated = consolidated_total,
+                evolution_jobs_queued,
                 dry_run = nightrun_cmd.dry_run,
                 "Nightrun abgeschlossen"
             );
@@ -3873,136 +4007,6 @@ fn ecs_tick_loop(
     Ok(tick_count)
 }
 
-/// Generiert voice_style und behavioral_notes via LLM (Cortex Gateway).
-///
-/// Laeuft im ECS std::thread — nutzt `reqwest::blocking` (kein Tokio).
-/// Fail-safe: Bei jedem Fehler wird `(None, None)` zurueckgegeben,
-/// die Konsolidierung laeuft trotzdem durch.
-#[cfg(feature = "llm")]
-fn generate_evolution_fields(
-    agent_name: &str,
-    agent_role: &str,
-    narrative: &str,
-) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-    let gateway_url =
-        std::env::var("CORTEX_GATEWAY_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
-    let url = format!("{gateway_url}/v1/chat/completions");
-
-    let client = match reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(error = %e, "Evolution LLM Client erstellen fehlgeschlagen");
-            return (None, None);
-        }
-    };
-
-    // Voice-Style Analyse
-    let voice_style = llm_evolution_call(
-        &client,
-        &url,
-        agent_name,
-        "Du bist ein linguistischer Analyst fuer eine Firmen-Simulation. \
-         Analysiere den Sprachstil des Agenten basierend auf seiner Schicht-Zusammenfassung. \
-         Antworte AUSSCHLIESSLICH als valides JSON.",
-        &format!(
-            "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
-             {narrative}\n\n\
-             Analysiere den Sprachstil. Antwort als JSON:\n\
-             {{\"phrases\": [\"phrase1\"], \"sentence_style\": \"kurz|mittel|lang\", \"formality\": 0.X}}"
-        ),
-    );
-
-    // Behavioral-Notes Analyse
-    let behavioral_notes = llm_evolution_call(
-        &client,
-        &url,
-        agent_name,
-        "Du bist ein Verhaltensanalyst fuer eine Firmen-Simulation. \
-         Analysiere Verhaltensmuster des Agenten basierend auf seiner Schicht-Zusammenfassung. \
-         Antworte AUSSCHLIESSLICH als valides JSON.",
-        &format!(
-            "Agent \"{agent_name}\" (Rolle: {agent_role}) hatte folgende Schicht-Erfahrungen:\n\n\
-             {narrative}\n\n\
-             Identifiziere Verhaltensmuster. Antwort als JSON:\n\
-             {{\"habits\": [\"habit1\"], \"interaction_style\": \"proaktiv|reaktiv|gemischt\", \
-             \"decision_style\": \"schnell|zoegerlich|ausgewogen\", \"anomalies\": []}}"
-        ),
-    );
-
-    (voice_style, behavioral_notes)
-}
-
-/// Einzelner LLM-Call fuer Evolution-Feld-Generierung.
-#[cfg(feature = "llm")]
-fn llm_evolution_call(
-    client: &reqwest::blocking::Client,
-    url: &str,
-    agent_name: &str,
-    system_prompt: &str,
-    user_prompt: &str,
-) -> Option<Vec<u8>> {
-    let body = serde_json::json!({
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt}
-        ],
-        "temperature": 0.3,
-        "max_tokens": 500,
-        "model": "default",
-        "metadata": {
-            "agent_id": agent_name,
-            "request_type": "evolution_analysis"
-        }
-    });
-
-    match client.post(url).json(&body).send() {
-        Ok(resp) => {
-            if !resp.status().is_success() {
-                warn!(
-                    agent = agent_name,
-                    status = %resp.status(),
-                    "Evolution LLM Call fehlgeschlagen (HTTP)"
-                );
-                return None;
-            }
-            match resp.json::<serde_json::Value>() {
-                Ok(json) => {
-                    let content = json
-                        .get("content")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default();
-                    if content.is_empty() {
-                        warn!(agent = agent_name, "Evolution LLM Response leer");
-                        return None;
-                    }
-                    Some(content.as_bytes().to_vec())
-                }
-                Err(e) => {
-                    warn!(agent = agent_name, error = %e, "Evolution LLM Response parse fehlgeschlagen");
-                    None
-                }
-            }
-        }
-        Err(e) => {
-            warn!(agent = agent_name, error = %e, "Evolution LLM Call fehlgeschlagen");
-            None
-        }
-    }
-}
-
-/// Fallback wenn LLM-Feature deaktiviert ist.
-#[cfg(not(feature = "llm"))]
-fn generate_evolution_fields(
-    _agent_name: &str,
-    _agent_role: &str,
-    _narrative: &str,
-) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-    (None, None)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4307,6 +4311,8 @@ mod tests {
             ebpf_tx,
             ep,
             mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
+            None,
+            None,
             mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
             mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
             mpsc::channel::<i64>().1,
@@ -4390,6 +4396,8 @@ mod tests {
                 ebpf_tx,
                 ep,
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
+                None,
+                None,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
                 mpsc::channel::<i64>().1,
@@ -4490,6 +4498,8 @@ mod tests {
                 ebpf_tx,
                 ep,
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
+                None,
+                None,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
                 mpsc::channel::<i64>().1,
@@ -4598,6 +4608,8 @@ mod tests {
                 ebpf_tx,
                 ep,
                 mpsc::channel::<sentinel_common::OperatorNightrunCommand>().1,
+                None,
+                None,
                 mpsc::channel::<sentinel_common::OperatorSnapshotCommand>().1,
                 mpsc::channel::<sentinel_common::OperatorRestoreCommand>().1,
                 mpsc::channel::<i64>().1,

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -436,8 +436,23 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
 
     let fs_layer = if config.fs_mount.is_some() {
         let cas = sentinel_fs::cas::CasStore::open(data_dir).context("sentinel-fs CAS oeffnen")?;
-        let meta = sentinel_fs::metadata::MetadataStore::open(data_dir.join("metadata.redb"))
-            .context("sentinel-fs Metadata oeffnen")?;
+        let metadata_durability = match config.fs_metadata_durability {
+            crate::config::FsMetadataDurability::Immediate => {
+                sentinel_fs::metadata::MetadataDurability::Immediate
+            }
+            crate::config::FsMetadataDurability::Eventual => {
+                sentinel_fs::metadata::MetadataDurability::Eventual
+            }
+        };
+        let meta = sentinel_fs::metadata::MetadataStore::open_with_durability(
+            data_dir.join("metadata.redb"),
+            metadata_durability,
+        )
+        .context("sentinel-fs Metadata oeffnen")?;
+        info!(
+            ?metadata_durability,
+            "sentinel-fs Metadata-Durability konfiguriert"
+        );
         let layer = Arc::new(sentinel_fs::layer::LayerManager::new(cas, meta));
         layer
             .init_base_root()

--- a/services/sentinel-daemon/src/service_health.rs
+++ b/services/sentinel-daemon/src/service_health.rs
@@ -290,8 +290,10 @@ mod tests {
         assert!(checker.trigger_panic_test());
 
         let mut recovered = false;
-        for _ in 0..100 {
+        let mut last_state = checker.worker_state();
+        for _ in 0..500 {
             let state = checker.worker_state();
+            last_state = state.clone();
             if state.running && state.restart_count >= 1 {
                 recovered = true;
                 assert_eq!(state.thread_name, "service-health-checker");
@@ -306,7 +308,7 @@ mod tests {
 
         assert!(
             recovered,
-            "service-health worker wurde nach panic-test nicht neu gestartet"
+            "service-health worker wurde nach panic-test nicht neu gestartet: {last_state:?}"
         );
     }
 }

--- a/test-278-verification.md
+++ b/test-278-verification.md
@@ -1,0 +1,142 @@
+# Issue #278 Verification
+
+Date: 2026-05-29
+Repo: `/work/company/project-sentinel`
+Branch: `feat/issues-278-379-nightrun-fuse`
+Deploy target: `ubuntu@10.0.0.240`
+
+## Hardware Context
+
+- Host: `sentinel-ubuntu-2404`
+- CPU: Intel Core i7-3930K @ 3.20 GHz, Sandy Bridge-E, 2011, KVM, 8 vCPU
+- Build/test policy: Rust build, test, and clippy via `cargo remote -c --`.
+- Runtime policy: benchmarks and live evidence on the Deploy-VM only.
+- Gateway policy: real `sentinel-gateway` stayed `inactive`; a local fake gateway on `127.0.0.1:8080` was used only for the non-token success path.
+
+## Implementation Verified
+
+- Added async `evolution_task` with bounded workers and async `reqwest::Client`.
+- Removed daemon `reqwest::blocking` usage.
+- Shift-transition and Operator-API nightrun enqueue `EvolutionJob`s instead of waiting for LLM completion.
+- ECS tick loop drains `EvolutionResult`s and writes voice style, behavioral notes, narrative, and `EVOLUTION_VERSION` to redb.
+- `/operator/nightrun` now responds with `agents_queued`.
+
+## Test Gates
+
+```text
+cargo fmt --check -> PASS
+cargo remote -c -- test -p sentinel-fs --lib -> 94 passed
+cargo remote -c -- test -p sentinel-daemon --lib -> 202 passed
+cargo remote -c -- clippy --workspace --all-targets -- -D warnings -> PASS after clippy::int_plus_one fix
+cargo remote -c -- build -p sentinel-daemon --release -> PASS
+```
+
+Focused tests:
+
+```text
+cargo remote -c -- test -p sentinel-daemon evolution_task --lib -> 5 passed
+cargo remote -c -- test -p sentinel-daemon nightrun_request_returns_agents_queued_and_forwards_command --lib -> 1 passed
+```
+
+## VM Deploy Evidence
+
+```text
+systemctl is-active sentinel-daemon -> active
+systemctl is-active sentinel-gateway -> inactive
+sha256(target/release/sentinel-daemon) -> 3db188b24a308e94e9eed2ed957044fdc861da6510fc7399b27083e12a0eb9b6
+journalctl -> Evolution Background-Task initialisiert
+```
+
+## Nightrun Background Evidence
+
+Command:
+
+```text
+curl -sS -w "\nHTTP %{http_code} time_total=%{time_total}\n" \
+  -X POST http://127.0.0.1:8084/operator/nightrun \
+  -H "Content-Type: application/json" -d "{}"
+```
+
+Output:
+
+```text
+{"accepted":true,"agents_queued":51,"message":"Nightrun-Konsolidierung gestartet"}
+HTTP 202 time_total=0.000669
+```
+
+Journal:
+
+```text
+Nightrun abgeschlossen agents=51 consolidated=109 evolution_jobs_queued=17 dry_run=false
+Evolution Background-Job gestartet agent=Sandra Vogel source="nightrun"
+Evolution Background-Job abgeschlossen agent=Sandra Vogel source="nightrun" voice_style=true behavioral_notes=true
+Evolution nach redb geschrieben, EVOLUTION_VERSION = 29 agent=Sandra Vogel source="nightrun" version=29 voice_style=true behavioral_notes=true
+Tick Checkpoint tick=1447020 sim_hour="17.77"
+```
+
+Fake gateway log:
+
+```text
+POST /v1/chat/completions HTTP/1.1" 200
+```
+
+## Shift Transition / Gateway-Failure Evidence
+
+The fake gateway was stopped and `sentinel-gateway` remained inactive. `time_scale` was temporarily set to `600.0`, then restored to `1.0` after the test.
+
+```text
+marker=2026-05-29T05:31:57+00:00
+systemctl is-active sentinel-gateway -> inactive
+time_scale = 600.0
+```
+
+Journal:
+
+```text
+05:33:41.016 Tick Checkpoint tick=1447140 sim_hour="10.11"
+05:33:42.202 Schichtwechsel erkannt old=3 new=1
+05:33:42.264 Evolution Background-Job eingereiht agent=David Nguyen source="shift_transition"
+05:33:42.266 Evolution LLM Call fehlgeschlagen agent="David Nguyen" error=error sending request for url (http://localhost:8080/v1/chat/completions)
+05:33:42.266 Evolution Background-Job abgeschlossen agent=David Nguyen source="shift_transition" voice_style=false behavioral_notes=false
+05:33:43.657 Schichtwechsel abgeschlossen removed=17 spawned=17 active=26
+05:33:46.095 Evolution nach redb geschrieben, EVOLUTION_VERSION = 30 agent=David Nguyen source="shift_transition" version=30 voice_style=false behavioral_notes=false
+```
+
+Measured transition window:
+
+```text
+Schichtwechsel erkannt -> Schichtwechsel abgeschlossen: ~1.455 s
+```
+
+System metrics during the accelerated shift:
+
+```text
+mpstat tail: idle mostly 87-100%, peak iowait ~6.27%
+iostat tail: sda peak ~50% util during redb/event writes
+vmstat tail: no swap, CPU idle mostly >=87%
+```
+
+After the test:
+
+```text
+time_scale = 1.0
+systemctl is-active sentinel-daemon -> active
+systemctl is-active sentinel-gateway -> inactive
+port 8080 -> no listener
+```
+
+## AC Evidence
+
+| AC | Result | Evidence |
+|---|---|---|
+| AC-1 | PASS | Nightrun API returned in 0.669 ms; LLM work ran in `evolution_task` background logs. |
+| AC-2 | TARGET MISS | Shift took ~1.455 s from detection to completion. LLM is removed from the path, but Hippocampus consolidation plus sandbox work still exceed `<1s` on this VM. |
+| AC-3 | PASS | Fake gateway returned voice/notes; redb writes logged `voice_style=true behavioral_notes=true`. |
+| AC-4 | PASS | `EVOLUTION_VERSION` increments are visible in nightrun and shift-transition redb write logs. |
+| AC-5 | PASS | `/operator/nightrun` queued the same background path and reported `agents_queued=51`. |
+| AC-6 | PASS | Gateway-down shift logged warnings, completed jobs with optional fields false, wrote redb narrative/version, and did not crash. |
+| AC-7 | PASS | Remote Rust tests, fmt, clippy, and release build passed. |
+
+## Residual Risk
+
+The main #278 LLM-blocking defect is fixed and deployed. The strict `<1s` total shift-transition target is still unmet on the Deploy-VM; remaining optimization should target Hippocampus archive/consolidation writes and sandbox spawn/teardown.

--- a/test-379-verification.md
+++ b/test-379-verification.md
@@ -19,6 +19,7 @@ Deploy target: `ubuntu@10.0.0.240`
 - Daemon Operator API exposes `GET /operator/security/fs-stats`.
 - Daemon Operator API exposes `POST /operator/security/fs-dedup-benchmark`.
 - The benchmark writes one seed blob and repeated identical hit files through the shared FUSE/CAS layer and reports dedup ratio plus latency target flags.
+- The benchmark now reports phase-level latency for CAS hit check, `LayerManager::write_file()`, full loop, and storage-stat overhead so AC-4 optimization work can target the real bottleneck.
 
 ## Test Gates
 
@@ -160,6 +161,67 @@ Interpretation:
 
 - PASS for storage savings: dedup ratio was 99.22%, above the 87% target.
 - TARGET MISS for dedup-hit latency: p95 was 21,712 us, above the `<100us` target. This is a real VM measurement through redb metadata writes and the CAS/FUSE path, not a synthetic in-memory number.
+
+## Instrumented Baseline
+
+Task-1 instrumented daemon:
+
+```text
+local sha256 target/release/sentinel-daemon -> cbb38e1be7a5d70158b61ee17b8a525212b5bc172e5ef48d0ceb0c3d1defda4e
+vm sha256 /opt/sentinel/bin/sentinel-daemon -> cbb38e1be7a5d70158b61ee17b8a525212b5bc172e5ef48d0ceb0c3d1defda4e
+systemctl is-active sentinel-daemon -> active
+systemctl is-active sentinel-gateway -> inactive
+/proc/118821/mountinfo -> fuse sentinel-fs at /opt/sentinel/fs
+```
+
+Live benchmark agent after daemon restart:
+
+```text
+curl http://127.0.0.1:8084/operator/security/agent-runtime-state?agent_id=1
+
+{
+  "found": true,
+  "agent_id": 1,
+  "aggregate_id": "AGENT-01",
+  "agent_name": "Thomas Mueller",
+  "home_host_path": "/opt/sentinel/fs/AGENT-01",
+  "fs_mount": "/opt/sentinel/fs"
+}
+```
+
+Command shape, repeated three times on the Deploy-VM:
+
+```text
+vmstat 1 12
+mpstat 1 12
+iostat -x 1 12
+curl -X POST http://127.0.0.1:8084/operator/security/fs-dedup-benchmark \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name":"Thomas Mueller","writes":128,"bytes_per_write":4096,"file_prefix":"issue379-baseline-rN"}'
+```
+
+Raw evidence path on VM:
+
+```text
+/tmp/issue379-baseline-20260529T071418/run-1
+/tmp/issue379-baseline-20260529T071418/run-2
+/tmp/issue379-baseline-20260529T071418/run-3
+```
+
+Instrumented baseline summary:
+
+| Run | Dedup ratio | CAS check p95 | write_file p50 | write_file p95 | loop p95 | Target <100us | mpstat avg idle |
+|---|---:|---:|---:|---:|---:|---|---:|
+| 1 | 99.2246% | 35 us | 12,474 us | 40,411 us | 40,440 us | false | 97.58% |
+| 2 | 99.2246% | 35 us | 11,822 us | 47,709 us | 47,740 us | false | 97.40% |
+| 3 | 99.2246% | 38 us | 12,099 us | 37,235 us | 37,261 us | false | 97.64% |
+
+Interpretation:
+
+- CAS hit lookup is already near the `<100us` target at p95 35-38 us.
+- The miss is dominated by `LayerManager::write_file()` metadata/write work: p95 37.2-47.7 ms.
+- Full-loop p95 is only 26-31 us above `write_file()` p95, so benchmark loop overhead is not the driver.
+- CPU was mostly idle and there was no swap pressure; this is a code-path/storage-sync bottleneck, not a saturated-CPU benchmark.
 
 ## Soak
 

--- a/test-379-verification.md
+++ b/test-379-verification.md
@@ -252,6 +252,7 @@ Raw evidence paths:
 /tmp/issue379-directbincode-warm-20260529T082022
 /tmp/issue379-final-bincode-20260529T082714
 /tmp/issue379-final-bincode-warm-20260529T082803
+/tmp/issue379-inodecache-warm-20260529T085737
 ```
 
 Median comparison, same VM and same command shape:
@@ -268,6 +269,7 @@ Median comparison, same VM and same command shape:
 | No root cache | remove root-known cache again | 171 us | 288 us | 303 us | Rejected |
 | Direct-buffer bincode | encode directly into final buffer | 144 us | 190 us | 198 us | Rejected after warm repeat showed worse stability |
 | Final bincode warm | final binary `91ef5767...` after reverting direct-buffer | 141 us | 189 us | 196 us | Final selected result |
+| In-memory inode counter | reserve per-agent inode IDs in memory and recover from DB after reopen | 145 us | 304 us | 321 us | Rejected, worse p95/noise than final selected |
 
 Final selected run:
 
@@ -300,6 +302,7 @@ Interpretation:
 
 - The original p95 miss was primarily redb commit durability, not CAS hit lookup or benchmark loop overhead.
 - The final code keeps the real FUSE/CAS write semantics and does not fake the benchmark by bypassing metadata writes.
+- A later in-memory inode-counter experiment was measured on the same VM and rejected because median p95 regressed from 189 us to 304 us.
 - The strict `<100us` target is still not met on this 2011 Sandy Bridge-E VM: final p95 is 189 us and `target_100us_met=false`.
 - Further reduction below 100 us likely requires a larger design change such as write-behind/batched metadata commits or a different metadata layout, which would change crash semantics and needs a separate architecture decision.
 

--- a/test-379-verification.md
+++ b/test-379-verification.md
@@ -20,6 +20,9 @@ Deploy target: `ubuntu@10.0.0.240`
 - Daemon Operator API exposes `POST /operator/security/fs-dedup-benchmark`.
 - The benchmark writes one seed blob and repeated identical hit files through the shared FUSE/CAS layer and reports dedup ratio plus latency target flags.
 - The benchmark now reports phase-level latency for CAS hit check, `LayerManager::write_file()`, full loop, and storage-stat overhead so AC-4 optimization work can target the real bottleneck.
+- The write hot path now allocates the inode, creates the dirent, writes metadata, and increments CAS refcount in one redb transaction.
+- The daemon exposes `fs_metadata_durability = "eventual"` so FUSE hot-path metadata commits can skip per-commit fsync when low latency is preferred over crash durability for the most recent metadata writes.
+- The dedup-hit metadata path skips `fs_trash_queue` access when the CAS refcount is already non-zero and serializes inode metadata as bincode with legacy JSON fallback.
 
 ## Test Gates
 
@@ -37,6 +40,9 @@ Focused tests:
 cargo remote -c -- test -p sentinel-fs storage_stats_report_logical_bytes_and_dedup_savings --lib -> 1 passed
 cargo remote -c -- test -p sentinel-daemon fs_storage_stats_get_reports_logical_and_cas_bytes --lib -> 1 passed
 cargo remote -c -- test -p sentinel-daemon fs_dedup_benchmark_reports_hits_ratio_and_latency --lib -> 1 passed
+cargo remote -c -- test -p sentinel-fs inode_data_serializes_as_bincode_with_legacy_json_fallback --lib -> 1 passed
+cargo remote -c -- test -p sentinel-fs create_file_allocating_inode_removes_zero_ref_trash_entry --lib -> 1 passed
+cargo remote -c -- test -p sentinel-daemon test_parse_fs_metadata_eventual_durability --lib -> 1 passed
 ```
 
 ## VM Deploy Evidence
@@ -109,6 +115,8 @@ After benchmark:
 Note: unreadable inode rows are existing metadata anomalies. The stats path now reports them explicitly instead of hiding or crashing on them.
 
 ## Dedup Benchmark
+
+This is the initial live-verification benchmark before the AC-4 optimization loop. The optimized same-VM benchmark is documented in the later "AC-4 Optimization Loop" section.
 
 Command shape:
 
@@ -223,6 +231,78 @@ Interpretation:
 - Full-loop p95 is only 26-31 us above `write_file()` p95, so benchmark loop overhead is not the driver.
 - CPU was mostly idle and there was no swap pressure; this is a code-path/storage-sync bottleneck, not a saturated-CPU benchmark.
 
+## AC-4 Optimization Loop
+
+All runs below were executed on the Deploy-VM `ubuntu@10.0.0.240` on Intel i7-3930K @ 3.20 GHz (2011). The gateway stayed inactive. Each run captured `vmstat 1`, `mpstat 1`, and `iostat -x 1` next to the benchmark result.
+
+Raw evidence paths:
+
+```text
+/tmp/issue379-baseline-20260529T071418
+/tmp/issue379-txconsolidated-20260529T072419
+/tmp/issue379-eventual-20260529T073637
+/tmp/issue379-lazyroot-20260529T074504
+/tmp/issue379-rootcache-20260529T075036
+/tmp/issue379-trashqueue-20260529T075452
+/tmp/issue379-bincode-20260529T080148
+/tmp/issue379-norootcache-20260529T080737
+/tmp/issue379-final-rootcache-20260529T081128
+/tmp/issue379-final-rootcache-warm-20260529T081219
+/tmp/issue379-directbincode-20260529T081916
+/tmp/issue379-directbincode-warm-20260529T082022
+/tmp/issue379-final-bincode-20260529T082714
+/tmp/issue379-final-bincode-warm-20260529T082803
+```
+
+Median comparison, same VM and same command shape:
+
+| Stage | Main change | Median write p50 | Median write p95 | Median loop p95 | Verdict |
+|---|---|---:|---:|---:|---|
+| Instrumented baseline | Phase timing only | 12,099 us | 40,411 us | 40,440 us | Bottleneck isolated to metadata write path |
+| Transaction consolidation | inode allocation + create file in one transaction | 5,796 us | 41,658 us | 41,685 us | p50 improved; p95 still dominated by redb fsync/noise |
+| Eventual durability | `redb::Durability::None` for configured FUSE hot path | 162 us | 214 us | 223 us | Major improvement; fsync was dominant cost |
+| Lazy root serialization | serialize root only when missing | 184 us | 273 us | 281 us | Rejected, slower/noisier |
+| Root-known cache | skip root check after first known agent root | 168 us | 228 us | 235 us | No reliable standalone improvement |
+| Conditional trash-queue skip | only touch trash queue on zero-ref -> one-ref transition | 149 us | 197 us | 205 us | Kept |
+| Bincode inode metadata | bincode v2 with legacy JSON fallback | 146 us | 188 us | 195 us | Kept |
+| No root cache | remove root-known cache again | 171 us | 288 us | 303 us | Rejected |
+| Direct-buffer bincode | encode directly into final buffer | 144 us | 190 us | 198 us | Rejected after warm repeat showed worse stability |
+| Final bincode warm | final binary `91ef5767...` after reverting direct-buffer | 141 us | 189 us | 196 us | Final selected result |
+
+Final selected run:
+
+```text
+Deploy hash: 91ef5767b810758acb02d5447b0c629a9949e62c4250c63db510f85bc251de1d
+Config: fs_metadata_durability = "eventual"
+Daemon: active
+Gateway: inactive
+FUSE: /proc/127633/mountinfo -> fuse sentinel-fs at /opt/sentinel/fs
+Raw path: /tmp/issue379-final-bincode-warm-20260529T082803
+```
+
+Final VM benchmark summary:
+
+| Run | Dedup ratio | CAS check p95 | write_file p50 | write_file p95 | write_file max | loop p95 | Target <100us | mpstat avg idle |
+|---|---:|---:|---:|---:|---:|---:|---|---:|
+| 1 | 99.2246% | 18 us | 140 us | 179 us | 233 us | 186 us | false | 99.73% |
+| 2 | 99.2246% | 9 us | 146 us | 195 us | 277 us | 202 us | false | 99.67% |
+| 3 | 99.2246% | 17 us | 141 us | 189 us | 229 us | 196 us | false | 99.67% |
+
+Relative result versus the instrumented same-VM baseline:
+
+```text
+median write_file p50: 12,099 us -> 141 us = 98.83% faster
+median write_file p95: 40,411 us -> 189 us = 99.53% faster
+median loop p95:       40,440 us -> 196 us = 99.52% faster
+```
+
+Interpretation:
+
+- The original p95 miss was primarily redb commit durability, not CAS hit lookup or benchmark loop overhead.
+- The final code keeps the real FUSE/CAS write semantics and does not fake the benchmark by bypassing metadata writes.
+- The strict `<100us` target is still not met on this 2011 Sandy Bridge-E VM: final p95 is 189 us and `target_100us_met=false`.
+- Further reduction below 100 us likely requires a larger design change such as write-behind/batched metadata commits or a different metadata layout, which would change crash semantics and needs a separate architecture decision.
+
 ## Soak
 
 Soak marker:
@@ -269,11 +349,12 @@ Runtime-health summary after soak:
 | AC-1 | PASS | Journal shows `sentinel-fs FUSE-Mount aktiv`; daemon `/proc/<MainPID>/mountinfo` shows `fuse sentinel-fs` at `/opt/sentinel/fs`. |
 | AC-2 | PASS | Runtime-state endpoint reports agent `AGENT-31` home as `/opt/sentinel/fs/AGENT-31`, not `/ram/agents`. |
 | AC-3 | PASS | Live dedup benchmark measured 99.22% storage savings against the 87% target. |
-| AC-4 | TARGET MISS | Dedup-hit latency was measured with system metrics, but p95 was 21,712 us and `target_100us_met=false`. |
+| AC-4 | OPTIMIZED / TARGET MISS | Dedup-hit latency was measured with system metrics and optimized in a same-VM loop. Median p95 improved from 40,411 us to 189 us, but the strict `<100us` target remains unmet on the i7-3930K VM (`target_100us_met=false`). |
 | AC-5 | PASS | 10-minute soak from `2026-05-29T05:35:33+00:00` to `2026-05-29T05:45:33+00:00`: daemon active, gateway inactive, FUSE still mounted, no journal errors/panics, and `projection_drift_detected=false`. |
 
 ## Evidence Log
 
 - Reconcile before soak cleared pre-existing projection drift: `projection_drift_detected=false`, `orphan_cgroups=0`.
 - `vmstat`, `mpstat`, and `iostat -x` were captured during the dedup benchmark and accelerated shift test.
+- AC-4 optimization loop raw paths are retained on the Deploy-VM under `/tmp/issue379-*`.
 - 10-minute FUSE soak passed with no daemon errors or panics.

--- a/test-379-verification.md
+++ b/test-379-verification.md
@@ -1,0 +1,217 @@
+# Issue #379 Verification
+
+Date: 2026-05-29
+Repo: `/work/company/project-sentinel`
+Branch: `feat/issues-278-379-nightrun-fuse`
+Deploy target: `ubuntu@10.0.0.240`
+
+## Hardware Context
+
+- Host: `sentinel-ubuntu-2404`
+- CPU: Intel Core i7-3930K @ 3.20 GHz, Sandy Bridge-E, 2011, KVM, 8 vCPU
+- Benchmark policy: FUSE/CAS benchmarks executed on the Deploy-VM, never on the build server.
+- System metrics captured with `vmstat 1`, `mpstat 1`, and `iostat -x 1`.
+
+## Implementation Verified
+
+- `sentinel-fs` exposes live logical/CAS storage stats through `LayerManager::storage_stats()`.
+- `MetadataStore::storage_stats()` counts logical regular-file bytes and reports unreadable inode rows instead of failing the whole stats path.
+- Daemon Operator API exposes `GET /operator/security/fs-stats`.
+- Daemon Operator API exposes `POST /operator/security/fs-dedup-benchmark`.
+- The benchmark writes one seed blob and repeated identical hit files through the shared FUSE/CAS layer and reports dedup ratio plus latency target flags.
+
+## Test Gates
+
+```text
+cargo fmt --check -> PASS
+cargo remote -c -- test -p sentinel-fs --lib -> 94 passed
+cargo remote -c -- test -p sentinel-daemon --lib -> 202 passed
+cargo remote -c -- clippy --workspace --all-targets -- -D warnings -> PASS after clippy::int_plus_one fix
+cargo remote -c -- build -p sentinel-daemon --release -> PASS
+```
+
+Focused tests:
+
+```text
+cargo remote -c -- test -p sentinel-fs storage_stats_report_logical_bytes_and_dedup_savings --lib -> 1 passed
+cargo remote -c -- test -p sentinel-daemon fs_storage_stats_get_reports_logical_and_cas_bytes --lib -> 1 passed
+cargo remote -c -- test -p sentinel-daemon fs_dedup_benchmark_reports_hits_ratio_and_latency --lib -> 1 passed
+```
+
+## VM Deploy Evidence
+
+```text
+systemctl is-active sentinel-daemon -> active
+systemctl is-active sentinel-gateway -> inactive
+journalctl -> sentinel-fs FUSE-Mount starten mountpoint=/opt/sentinel/fs data_dir=/opt/sentinel/data
+journalctl -> sentinel-fs FUSE-Mount aktiv mountpoint=/opt/sentinel/fs
+journalctl -> Sandbox nutzt sentinel-fs FUSE-Mount fuer Agent-Homes fs_mount=/opt/sentinel/fs
+```
+
+Because `sentinel-daemon.service` uses systemd hardening with a service mount namespace, host `findmnt /opt/sentinel/fs` is empty. The mount is visible in the daemon namespace:
+
+```text
+PID=114953
+/proc/114953/mountinfo:
+58 214 0:45 / /opt/sentinel/fs rw,nosuid,nodev,relatime shared:418 - fuse sentinel-fs rw,user_id=0,group_id=0,allow_other
+```
+
+Agent-home binding:
+
+```text
+curl http://127.0.0.1:8084/operator/security/agent-runtime-state?agent_id=31
+
+{
+  "found": true,
+  "agent_id": 31,
+  "aggregate_id": "AGENT-31",
+  "agent_name": "Sandra Vogel",
+  "home_host_path": "/opt/sentinel/fs/AGENT-31",
+  "fs_mount": "/opt/sentinel/fs"
+}
+```
+
+## Storage Stats
+
+Before benchmark:
+
+```text
+{
+  "accepted": true,
+  "fs_mount": "/opt/sentinel/fs",
+  "cas_blob_count": 15,
+  "cas_bytes_on_disk": 997,
+  "regular_file_count": 10,
+  "logical_regular_file_bytes": 550,
+  "dedup_savings_bytes": 0,
+  "dedup_ratio_percent": 0.0,
+  "unreadable_inode_rows": 5
+}
+```
+
+After benchmark:
+
+```text
+{
+  "accepted": true,
+  "fs_mount": "/opt/sentinel/fs",
+  "cas_blob_count": 17,
+  "cas_bytes_on_disk": 9191,
+  "regular_file_count": 156,
+  "logical_regular_file_bytes": 598566,
+  "dedup_savings_bytes": 589375,
+  "dedup_ratio_percent": 98.46449681405225,
+  "unreadable_inode_rows": 6
+}
+```
+
+Note: unreadable inode rows are existing metadata anomalies. The stats path now reports them explicitly instead of hiding or crashing on them.
+
+## Dedup Benchmark
+
+Command shape:
+
+```text
+vmstat 1 6
+mpstat 1 6
+iostat -x 1 6
+curl -X POST http://127.0.0.1:8084/operator/security/fs-dedup-benchmark \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name":"Sandra Vogel","writes":128,"bytes_per_write":4096,"file_prefix":"issue379-vm"}'
+```
+
+Output:
+
+```text
+{
+  "accepted": true,
+  "agent_name": "Sandra Vogel",
+  "fs_agent_dir": "AGENT-31",
+  "bytes_per_write": 4096,
+  "seed_write_us": 7932,
+  "dedup_hit_writes": 128,
+  "dedup_hits": 128,
+  "logical_bytes_written": 528384,
+  "cas_blob_count_before": 15,
+  "cas_blob_count_after": 16,
+  "cas_bytes_before": 997,
+  "cas_bytes_after": 5094,
+  "cas_bytes_delta": 4097,
+  "dedup_ratio_percent": 99.22461694525194,
+  "target_87_percent_met": true,
+  "dedup_hit_latency_us_min": 3314,
+  "dedup_hit_latency_us_p50": 7295,
+  "dedup_hit_latency_us_p95": 21712,
+  "dedup_hit_latency_us_max": 90875,
+  "dedup_hit_latency_us_mean": 10146.5859375,
+  "target_100us_met": false
+}
+```
+
+System metrics:
+
+```text
+mpstat average: user 0.21%, system 0.29%, iowait 2.76%, idle 96.72%
+iostat sda peak during benchmark: 1534 writes/s, 6492 kB/s, 87.20% util, w_await 0.74 ms
+vmstat: no swap, CPU idle 87-100%, peak iowait 11%
+```
+
+Interpretation:
+
+- PASS for storage savings: dedup ratio was 99.22%, above the 87% target.
+- TARGET MISS for dedup-hit latency: p95 was 21,712 us, above the `<100us` target. This is a real VM measurement through redb metadata writes and the CAS/FUSE path, not a synthetic in-memory number.
+
+## Soak
+
+Soak marker:
+
+```text
+2026-05-29T05:35:33+00:00
+```
+
+Final soak output:
+
+```text
+soak_done=2026-05-29T05:45:33+00:00
+systemctl is-active sentinel-daemon -> active
+systemctl is-active sentinel-gateway -> inactive
+/proc/114953/mountinfo -> fuse sentinel-fs at /opt/sentinel/fs
+journalctl -u sentinel-daemon --since 2026-05-29T05:35:33+00:00 -p err -> No entries
+journal panic grep -> no output
+Tick Checkpoint first/last -> 05:35:48 tick=1447260, 05:44:48 tick=1447800
+```
+
+Runtime-health summary after soak:
+
+```text
+{
+  "current_shift": 3,
+  "expected_active_agents": 26,
+  "runtime_agents": 26,
+  "projection_agents": 26,
+  "projection_drift_detected": false,
+  "projection_drift_agents": 0,
+  "stale_runtime_entries": 1,
+  "orphan_cgroups": 0,
+  "zombie_tracked_pids": 1,
+  "respawn_failures": 0,
+  "last_repair_error": null,
+  "repair_last_status": "projection_restart_requested"
+}
+```
+
+## AC Evidence
+
+| AC | Result | Evidence |
+|---|---|---|
+| AC-1 | PASS | Journal shows `sentinel-fs FUSE-Mount aktiv`; daemon `/proc/<MainPID>/mountinfo` shows `fuse sentinel-fs` at `/opt/sentinel/fs`. |
+| AC-2 | PASS | Runtime-state endpoint reports agent `AGENT-31` home as `/opt/sentinel/fs/AGENT-31`, not `/ram/agents`. |
+| AC-3 | PASS | Live dedup benchmark measured 99.22% storage savings against the 87% target. |
+| AC-4 | TARGET MISS | Dedup-hit latency was measured with system metrics, but p95 was 21,712 us and `target_100us_met=false`. |
+| AC-5 | PASS | 10-minute soak from `2026-05-29T05:35:33+00:00` to `2026-05-29T05:45:33+00:00`: daemon active, gateway inactive, FUSE still mounted, no journal errors/panics, and `projection_drift_detected=false`. |
+
+## Evidence Log
+
+- Reconcile before soak cleared pre-existing projection drift: `projection_drift_detected=false`, `orphan_cgroups=0`.
+- `vmstat`, `mpstat`, and `iostat -x` were captured during the dedup benchmark and accelerated shift test.
+- 10-minute FUSE soak passed with no daemon errors or panics.


### PR DESCRIPTION
## Summary
Combined #278 and #379 implementation and verification. User accepted the remaining strict target misses on 2026-05-29 after CI passed: #278 fixes blocking LLM calls in the shift path but still misses the strict sub-1s shift target on the deploy VM, and #379 improves dedup-hit latency by 99.53% but still misses the strict sub-100us target on the deploy VM.

## Linked Issues
Closes #278
Closes #379

## Changes
#278 moves evolution LLM work out of the tick/shift path into an async background queue, adds fail-safe gateway-down handling, persists completed evolution results back to redb, and extends `/operator/nightrun` with `agents_queued`.

#379 adds sentinel-fs storage statistics, CAS dedup accounting, operator endpoints for `/operator/security/fs-stats` and `/operator/security/fs-dedup-benchmark`, plus phase-level benchmark timing for CAS hit check, `LayerManager::write_file()`, full loop, and storage-stat overhead.

The #379 optimization loop consolidated inode allocation + file create into one redb transaction, added configurable sentinel-fs metadata durability, configured the deploy VM for `fs_metadata_durability = "eventual"`, skipped trash-queue table access for non-zero refcount dedup hits, changed inode metadata to bincode with legacy JSON fallback, and measured/rejected lazy-root, no-rootcache, direct-buffer bincode, and in-memory inode-counter variants.

## Test Plan
Build/test gates run through `cargo remote -c --` where applicable:

```text
cargo fmt && cargo fmt --check
cargo remote -c -- test -p sentinel-daemon evolution_task --lib
cargo remote -c -- test -p sentinel-daemon nightrun_request_returns_agents_queued_and_forwards_command --lib
cargo remote -c -- test -p sentinel-fs storage_stats_report_logical_bytes_and_dedup_savings --lib
cargo remote -c -- test -p sentinel-daemon fs_storage_stats_get_reports_logical_and_cas_bytes --lib
cargo remote -c -- test -p sentinel-daemon fs_dedup_benchmark_reports_hits_ratio_and_latency --lib
cargo remote -c -- test -p sentinel-fs inode_data_serializes_as_bincode_with_legacy_json_fallback --lib
cargo remote -c -- test -p sentinel-fs create_file_allocating_inode_removes_zero_ref_trash_entry --lib
cargo remote -c -- test -p sentinel-daemon test_parse_fs_metadata_eventual_durability --lib
cargo remote -c -- test -p sentinel-daemon service_health::tests::panic_test_restarts_worker_in_process --lib -- --exact
cargo remote -c -- test -p sentinel-fs
cargo remote -c -- test -p sentinel-daemon --lib
cargo remote -c -- clippy --workspace --all-targets -- -D warnings
cargo remote -c -- build -p sentinel-daemon --release
git diff --check
```

## Benchmarks
Benchmarks were executed on deploy VM `ubuntu@10.0.0.240`, Intel i7-3930K @ 3.20 GHz (2011). The real gateway stayed inactive. `vmstat 1`, `mpstat 1`, and `iostat -x 1` were captured next to the benchmark result.

Final selected #379 run: `/tmp/issue379-final-bincode-warm-20260529T082803`.

```text
median write_file p50: 12,099 us -> 141 us = 98.83% faster
median write_file p95: 40,411 us -> 189 us = 99.53% faster
median loop p95:       40,440 us -> 196 us = 99.52% faster
```

Strict target misses accepted as follow-up context: #278 shift transition measured about `1.455s` against `<1s`; #379 final deploy-VM median p95 is `189us` against `<100us`.

## Evidence (AC Mapping)
| AC | Result | Evidence |
|---|---|---|
| AC-1 | PASS | #278 async queue returns HTTP 202 and includes `agents_queued`; #379 FUSE mount active in daemon mount namespace. |
| AC-2 | PASS / TARGET MISS | #278 blocking LLM defect fixed and gateway-down path does not block shift completion; strict `<1s` target remains missed at about `1.455s`. |
| AC-3 | PASS | #379 dedup benchmark produced `dedup_ratio_percent = 99.2246`, above the 87% target. |
| AC-4 | OPTIMIZED / TARGET MISS | #379 same-VM p95 improved `40,411us -> 189us`; strict `<100us` target remains missed. |
| AC-5 | PASS | 10-minute FUSE soak: daemon active, gateway inactive, FUSE mounted, no daemon errors/panics, projection drift false. |

Post-merge deploy-VM smoke:

```text
ssh ubuntu@10.0.0.240 'systemctl is-active sentinel-daemon; systemctl is-active cortex-gateway || true; systemctl is-active sentinel-gateway || true; sha256sum /opt/sentinel/bin/sentinel-daemon'
active
inactive
inactive
91ef5767b810758acb02d5447b0c629a9949e62c4250c63db510f85bc251de1d  /opt/sentinel/bin/sentinel-daemon

ssh ubuntu@10.0.0.240 'sudo nsenter -t $(systemctl show -p MainPID --value sentinel-daemon) -m -- mountpoint /opt/sentinel/fs'
/opt/sentinel/fs is a mountpoint

curl -fsS http://127.0.0.1:8084/operator/security/fs-stats
{"accepted":true,"fs_mount":"/opt/sentinel/fs",...}
```

## Checklist
- [x] CI green before merge.
- [x] Merged to `main` through PR #387.
- [x] Deploy VM verified after merge; gateway services inactive.
- [x] Verification docs committed: `test-278-verification.md`, `test-379-verification.md`.
- [x] Target misses explicitly documented and accepted by user on 2026-05-29.