### PR TITLE
feat: finalize NMDA episode selection evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Finalized Issue #382 NMDA episode-selection policy for hippocampus/nightrun: calibrated threshold `0.25`, shared narrative threshold, max 10 selected episodes, selection-quality payload metrics, and Deploy-VM replay evidence for a `2/3` consolidated Night-Run.
 - Moved Issue #278 nightrun/shift evolution LLM calls out of the ECS tick loop into an async background task, with VM evidence for fake-gateway success, gateway-down fail-safe behavior, and redb `EVOLUTION_VERSION` writes.
 - Added and optimized Issue #379 live sentinel-fs FUSE/CAS verification paths for storage stats and dedup-hit benchmarking; Deploy-VM evidence shows active FUSE agent homes, 99.22% dedup savings, and same-VM median dedup-hit write p95 improved from 40,411 us to 189 us, while the strict `<100us` target remains unmet on the i7-3930K VM.
 - Updated optional `sentinel-wasm` Wasmtime dependencies to 44.0.2 to clear current RustSec advisories.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,6 +4346,7 @@ name = "sentinel-nightrun"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "clap",
  "criterion 0.8.2",
  "libc",

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -199,6 +199,24 @@ pub enum DomainEventPayload {
         /// Episodes selected by the calibrated NMDA threshold.
         #[serde(default)]
         total_episodes_consolidated: u32,
+        /// Aggregated NMDA selection rate for processed episodes.
+        #[serde(default)]
+        nmda_selection_rate: Option<f64>,
+        /// Calibrated NMDA threshold used for the run.
+        #[serde(default)]
+        nmda_threshold: Option<f64>,
+        /// Maximum episodes selected per agent during consolidation.
+        #[serde(default)]
+        nmda_max_consolidation_episodes: Option<u32>,
+        /// Minimum NMDA score across all processed episodes, including rejects.
+        #[serde(default)]
+        nmda_score_min: Option<f64>,
+        /// Average NMDA score across all processed episodes, including rejects.
+        #[serde(default)]
+        nmda_score_avg: Option<f64>,
+        /// Maximum NMDA score across all processed episodes, including rejects.
+        #[serde(default)]
+        nmda_score_max: Option<f64>,
         duration_ms: u64,
         /// Final hash of the deterministic event chain (for replay verification).
         #[serde(default)]

--- a/crates/sentinel-common/src/events.rs
+++ b/crates/sentinel-common/src/events.rs
@@ -196,6 +196,9 @@ pub enum DomainEventPayload {
         agents_failed: u32,
         agents_skipped: u32,
         total_episodes: u32,
+        /// Episodes selected by the calibrated NMDA threshold.
+        #[serde(default)]
+        total_episodes_consolidated: u32,
         duration_ms: u64,
         /// Final hash of the deterministic event chain (for replay verification).
         #[serde(default)]

--- a/crates/sentinel-hippocampus/src/lib.rs
+++ b/crates/sentinel-hippocampus/src/lib.rs
@@ -14,6 +14,7 @@ pub mod episode;
 pub mod facts;
 pub mod golf;
 pub mod narrative;
+pub mod selection;
 pub mod service;
 pub mod sleep;
 pub mod store;
@@ -23,6 +24,11 @@ pub use episode::{nmda_score, Episode};
 pub use facts::{FactRetriever, FactStore, InMemoryFactStore, FACT_TRIGGERS};
 pub use golf::{default_goals_for_role, Goal, GoalStatus, GoalType};
 pub use narrative::NarrativeMemory;
+pub use selection::{
+    selection_decision, should_consolidate, NmdaSelectionDecision, NmdaSelectionProfile,
+    CALIBRATED_NMDA_SELECTION_PROFILE, NMDA_CONSOLIDATION_THRESHOLD,
+    NMDA_MAX_CONSOLIDATION_EPISODES, NMDA_NARRATIVE_INCLUSION_THRESHOLD, NMDA_SELECTION_RATIONALE,
+};
 pub use service::{ConsolidationResult, HippocampusService};
 pub use sleep::{SleepCycle, SleepPhase};
 pub use store::{HippocampusStore, NarrativeState, RedbFactStore};

--- a/crates/sentinel-hippocampus/src/narrative.rs
+++ b/crates/sentinel-hippocampus/src/narrative.rs
@@ -1,6 +1,7 @@
 //! NarrativeMemory - Running summary of important daily events per agent.
 
 use crate::episode::{nmda_score, Episode};
+use crate::selection::NMDA_NARRATIVE_INCLUSION_THRESHOLD;
 
 /// Maintains a running summary of the most important daily events for an agent.
 ///
@@ -12,7 +13,7 @@ pub struct NarrativeMemory {
     summary: String,
     /// All episodes of the day that passed the threshold
     episodes: Vec<Episode>,
-    /// Minimum NMDA score for inclusion (default: 0.3)
+    /// Minimum NMDA score for inclusion (calibrated NMDA profile)
     inclusion_threshold: f64,
 }
 
@@ -22,7 +23,7 @@ impl NarrativeMemory {
             agent_name: agent_name.to_string(),
             summary: String::new(),
             episodes: Vec::new(),
-            inclusion_threshold: 0.3,
+            inclusion_threshold: NMDA_NARRATIVE_INCLUSION_THRESHOLD,
         }
     }
 

--- a/crates/sentinel-hippocampus/src/selection.rs
+++ b/crates/sentinel-hippocampus/src/selection.rs
@@ -1,0 +1,119 @@
+//! Calibrated NMDA episode-selection profile.
+//!
+//! The score formula stays in `episode.rs`; this module defines the policy
+//! boundary that decides which scored episodes become consolidation candidates.
+
+use crate::episode::{nmda_score, Episode};
+
+/// Final calibrated threshold for Night-Run consolidation.
+///
+/// Rationale:
+/// - A normal relevant work episode around relevance=0.8, emotion=0.7,
+///   repetitions=1, hours_ago=1 scores 0.28 and should be retained.
+/// - A medium-context meeting around relevance=0.5, emotion=0.5,
+///   repetitions=1, hours_ago=1 scores 0.125 and should stay archive-only.
+/// - Routine low-signal events stay far below 0.01.
+pub const NMDA_CONSOLIDATION_THRESHOLD: f64 = 0.25;
+
+/// Narrative inclusion follows the same calibrated boundary as consolidation.
+pub const NMDA_NARRATIVE_INCLUSION_THRESHOLD: f64 = NMDA_CONSOLIDATION_THRESHOLD;
+
+/// Keep the strongest memories only; selected episodes remain sorted by score.
+pub const NMDA_MAX_CONSOLIDATION_EPISODES: usize = 10;
+
+/// Human-readable rationale used by verification/docs.
+pub const NMDA_SELECTION_RATIONALE: &str =
+    "0.25 keeps relevant work episodes while rejecting medium-context and routine noise";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NmdaSelectionProfile {
+    pub consolidation_threshold: f64,
+    pub narrative_inclusion_threshold: f64,
+    pub max_consolidation_episodes: usize,
+    pub rationale: &'static str,
+}
+
+pub const CALIBRATED_NMDA_SELECTION_PROFILE: NmdaSelectionProfile = NmdaSelectionProfile {
+    consolidation_threshold: NMDA_CONSOLIDATION_THRESHOLD,
+    narrative_inclusion_threshold: NMDA_NARRATIVE_INCLUSION_THRESHOLD,
+    max_consolidation_episodes: NMDA_MAX_CONSOLIDATION_EPISODES,
+    rationale: NMDA_SELECTION_RATIONALE,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NmdaSelectionDecision {
+    Consolidate,
+    ArchiveOnly,
+}
+
+pub fn selection_decision(score: f64) -> NmdaSelectionDecision {
+    if score >= NMDA_CONSOLIDATION_THRESHOLD {
+        NmdaSelectionDecision::Consolidate
+    } else {
+        NmdaSelectionDecision::ArchiveOnly
+    }
+}
+
+pub fn should_consolidate(episode: &Episode) -> bool {
+    selection_decision(nmda_score(episode)) == NmdaSelectionDecision::Consolidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    fn episode(relevance: f64, emotion: f64, repetitions: u32, hours_ago: f64) -> Episode {
+        Episode {
+            id: 1,
+            agent_name: "Thomas".to_string(),
+            summary: "Test episode".to_string(),
+            relevance,
+            emotion,
+            repetitions,
+            hours_ago,
+            participants: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn calibrated_profile_documents_final_thresholds() {
+        assert_eq!(
+            CALIBRATED_NMDA_SELECTION_PROFILE.consolidation_threshold,
+            0.25
+        );
+        assert_eq!(
+            CALIBRATED_NMDA_SELECTION_PROFILE.narrative_inclusion_threshold,
+            0.25
+        );
+        assert_eq!(
+            CALIBRATED_NMDA_SELECTION_PROFILE.max_consolidation_episodes,
+            10
+        );
+        assert!(CALIBRATED_NMDA_SELECTION_PROFILE
+            .rationale
+            .contains("relevant work episodes"));
+    }
+
+    #[test]
+    fn calibrated_threshold_accepts_relevant_work_episode() {
+        let ep = episode(0.8, 0.7, 1, 1.0);
+        assert_relative_eq!(nmda_score(&ep), 0.28, epsilon = 1e-12);
+        assert!(should_consolidate(&ep));
+    }
+
+    #[test]
+    fn calibrated_threshold_rejects_medium_context_episode() {
+        let ep = episode(0.5, 0.5, 1, 1.0);
+        assert_eq!(nmda_score(&ep), 0.125);
+        assert!(!should_consolidate(&ep));
+    }
+
+    #[test]
+    fn calibrated_threshold_rejects_routine_noise() {
+        let ep = episode(0.1, 0.05, 1, 1.0);
+        assert_eq!(nmda_score(&ep), 0.0025000000000000005);
+        assert!(!should_consolidate(&ep));
+    }
+}

--- a/crates/sentinel-hippocampus/src/service.rs
+++ b/crates/sentinel-hippocampus/src/service.rs
@@ -15,6 +15,8 @@ pub struct ConsolidationResult {
     pub agent_name: String,
     pub episodes_processed: usize,
     pub episodes_consolidated: usize,
+    /// NMDA scores for all processed episodes, including rejected ones.
+    pub episode_scores: Vec<f64>,
     pub consolidated_summaries: Vec<(String, f64)>,
 }
 
@@ -74,9 +76,12 @@ impl HippocampusService {
                 agent_name: agent.to_string(),
                 episodes_processed: 0,
                 episodes_consolidated: 0,
+                episode_scores: Vec::new(),
                 consolidated_summaries: Vec::new(),
             });
         }
+
+        let episode_scores: Vec<f64> = episodes.iter().map(nmda_score).collect();
 
         // Run sleep cycle (scoring + selection + consolidation)
         let mut cycle = SleepCycle::new(agent);
@@ -107,6 +112,7 @@ impl HippocampusService {
             agent_name: agent.to_string(),
             episodes_processed,
             episodes_consolidated,
+            episode_scores,
             consolidated_summaries: selected,
         })
     }

--- a/crates/sentinel-hippocampus/src/sleep.rs
+++ b/crates/sentinel-hippocampus/src/sleep.rs
@@ -4,6 +4,7 @@
 //! from the day are scored, selected, and consolidated into long-term storage.
 
 use crate::episode::{nmda_score, Episode};
+use crate::selection::{NMDA_CONSOLIDATION_THRESHOLD, NMDA_MAX_CONSOLIDATION_EPISODES};
 
 /// Sleep cycle phases representing different stages of memory processing.
 #[derive(Debug, Clone, PartialEq)]
@@ -40,15 +41,15 @@ pub struct SleepCycle {
 impl SleepCycle {
     /// Create a new sleep cycle with default parameters.
     ///
-    /// Default threshold: 0.1, max episodes: 10
+    /// Default threshold: calibrated NMDA profile, max episodes: 10.
     pub fn new(agent_name: &str) -> Self {
         Self {
             agent_name: agent_name.to_string(),
             phase: SleepPhase::Awake,
             episodes: Vec::new(),
             selected: Vec::new(),
-            consolidation_threshold: 0.05,
-            max_consolidation_episodes: 10,
+            consolidation_threshold: NMDA_CONSOLIDATION_THRESHOLD,
+            max_consolidation_episodes: NMDA_MAX_CONSOLIDATION_EPISODES,
             consolidated_narrative: None,
         }
     }
@@ -286,10 +287,20 @@ mod tests {
     }
 
     #[test]
+    fn test_default_selection_uses_calibrated_profile() {
+        let cycle = SleepCycle::new("Thomas");
+        assert_eq!(cycle.consolidation_threshold, NMDA_CONSOLIDATION_THRESHOLD);
+        assert_eq!(
+            cycle.max_consolidation_episodes,
+            NMDA_MAX_CONSOLIDATION_EPISODES
+        );
+    }
+
+    #[test]
     fn test_wake_up_clears_state() {
         let mut cycle = SleepCycle::new("Thomas");
 
-        let episodes = vec![make_episode(1, "Test", 0.5, 0.5, 1, 1.0)];
+        let episodes = vec![make_episode(1, "Test", 0.8, 0.7, 1, 1.0)];
 
         cycle.begin_sleep();
         cycle.add_episodes(episodes);

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -34,7 +34,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | Big-Five personality model    | ✅ | `crates/sentinel-common/src/personality.rs` |
 | Bio-engine (6 differential eqs) | ✅ | `crates/sentinel-bio/src/` |
 | Mood (valence + arousal)      | ✅ | `crates/sentinel-bio/src/mood.rs` |
-| Memory (episodic + semantic)  | 🟡 | `crates/sentinel-hippocampus/`; multi-tier in place, NMDA selection still tuning |
+| Memory (episodic + semantic)  | ✅ | `crates/sentinel-hippocampus/`; calibrated NMDA selection profile finalized in #382 (`threshold=0.25`, max 10), Deploy-VM Night-Run consolidated 2/3 controlled episodes with deterministic replay evidence in `test-382-verification.md` |
 | Action ontology               | ✅ | `crates/sentinel-common/src/action.rs` |
 
 ## Cluster 03 — Infrastruktur

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -3265,11 +3265,11 @@ fn ecs_tick_loop(
                                 let episodes_consolidated = result.episodes_consolidated as u32;
                                 if episodes_processed > 0 {
                                     let nmda_scores = nmda_consolidated_scores(&result);
-                                    let agent_stats = nmda_score_stats(&nmda_scores);
+                                    let agent_stats = nmda_score_stats(&result.episode_scores);
                                     shift_episodes_processed += episodes_processed;
                                     shift_episodes_consolidated += episodes_consolidated;
                                     shift_agents_consolidated += 1;
-                                    shift_nmda_scores.extend(nmda_scores.iter().copied());
+                                    shift_nmda_scores.extend(result.episode_scores.iter().copied());
 
                                     info!(
                                         agent = name,
@@ -3440,8 +3440,8 @@ fn ecs_tick_loop(
                         }
                     }
                 }
+                let shift_stats = nmda_score_stats(&shift_nmda_scores);
                 if shift_episodes_processed > 0 {
-                    let shift_stats = nmda_score_stats(&shift_nmda_scores);
                     info!(
                         old_shift = current_shift,
                         new_shift,
@@ -3474,6 +3474,17 @@ fn ecs_tick_loop(
                             agents_skipped: 0,
                             total_episodes: shift_episodes_processed,
                             total_episodes_consolidated: shift_episodes_consolidated,
+                            nmda_selection_rate: Some(nmda_selection_rate(
+                                shift_episodes_processed,
+                                shift_episodes_consolidated,
+                            )),
+                            nmda_threshold: Some(NMDA_CONSOLIDATION_THRESHOLD),
+                            nmda_max_consolidation_episodes: Some(
+                                NMDA_MAX_CONSOLIDATION_EPISODES as u32,
+                            ),
+                            nmda_score_min: shift_stats.min,
+                            nmda_score_avg: shift_stats.avg,
+                            nmda_score_max: shift_stats.max,
                             duration_ms: shift_started.elapsed().as_millis() as u64,
                             hash_chain: Some(hash_chain_final.clone()),
                         };
@@ -3691,12 +3702,11 @@ fn ecs_tick_loop(
                     Ok(result) if result.episodes_processed > 0 => {
                         let episodes_processed = result.episodes_processed as u32;
                         let episodes_consolidated = result.episodes_consolidated as u32;
-                        let nmda_scores = nmda_consolidated_scores(&result);
-                        let agent_stats = nmda_score_stats(&nmda_scores);
+                        let agent_stats = nmda_score_stats(&result.episode_scores);
                         episodes_processed_total += episodes_processed;
                         episodes_consolidated_total += episodes_consolidated;
                         agents_consolidated_total += 1;
-                        operator_nmda_scores.extend(nmda_scores.iter().copied());
+                        operator_nmda_scores.extend(result.episode_scores.iter().copied());
 
                         info!(
                             agent = %name,
@@ -3886,6 +3896,17 @@ fn ecs_tick_loop(
                         agents_skipped: 0,
                         total_episodes: episodes_processed_total,
                         total_episodes_consolidated: episodes_consolidated_total,
+                        nmda_selection_rate: Some(nmda_selection_rate(
+                            episodes_processed_total,
+                            episodes_consolidated_total,
+                        )),
+                        nmda_threshold: Some(NMDA_CONSOLIDATION_THRESHOLD),
+                        nmda_max_consolidation_episodes: Some(
+                            NMDA_MAX_CONSOLIDATION_EPISODES as u32,
+                        ),
+                        nmda_score_min: operator_stats.min,
+                        nmda_score_avg: operator_stats.avg,
+                        nmda_score_max: operator_stats.max,
                         duration_ms: operator_started.elapsed().as_millis() as u64,
                         hash_chain: Some(hash_chain_final.clone()),
                     };
@@ -4528,6 +4549,12 @@ mod tests {
                 agents_skipped: 0,
                 total_episodes: 3,
                 total_episodes_consolidated: 1,
+                nmda_selection_rate: Some(1.0 / 3.0),
+                nmda_threshold: Some(NMDA_CONSOLIDATION_THRESHOLD),
+                nmda_max_consolidation_episodes: Some(NMDA_MAX_CONSOLIDATION_EPISODES as u32),
+                nmda_score_min: Some(0.1),
+                nmda_score_avg: Some(0.2),
+                nmda_score_max: Some(0.3),
                 duration_ms: 9,
                 hash_chain: Some(expected_hash.clone()),
             },
@@ -4560,11 +4587,26 @@ mod tests {
                 hash_chain,
                 total_episodes,
                 total_episodes_consolidated,
+                nmda_selection_rate,
+                nmda_threshold,
+                nmda_max_consolidation_episodes,
+                nmda_score_min,
+                nmda_score_avg,
+                nmda_score_max,
                 ..
             } => {
                 assert_eq!(hash_chain.as_deref(), Some(expected_hash.as_str()));
                 assert_eq!(total_episodes, 3);
                 assert_eq!(total_episodes_consolidated, 1);
+                assert_eq!(nmda_selection_rate, Some(1.0 / 3.0));
+                assert_eq!(nmda_threshold, Some(NMDA_CONSOLIDATION_THRESHOLD));
+                assert_eq!(
+                    nmda_max_consolidation_episodes,
+                    Some(NMDA_MAX_CONSOLIDATION_EPISODES as u32)
+                );
+                assert_eq!(nmda_score_min, Some(0.1));
+                assert_eq!(nmda_score_avg, Some(0.2));
+                assert_eq!(nmda_score_max, Some(0.3));
             }
             other => panic!("unexpected payload: {other:?}"),
         }

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -28,11 +28,13 @@ use sentinel_ecs::{
     apply_personality, create_simulation_world, despawn_agent_from_world, spawn_agent,
     ActionReceiver, LimboEventStore, PerceptionSender, SimulationTime,
 };
+use sentinel_hippocampus::{NMDA_CONSOLIDATION_THRESHOLD, NMDA_MAX_CONSOLIDATION_EPISODES};
 use sentinel_limbo::EventStore;
 use sentinel_redb::StateStore;
 use sentinel_runtime::RuntimeOrchestrator;
 use sentinel_sandbox::{CgroupLimits, SandboxEnforcer, SandboxHandle, SandboxWarning};
 use sentinel_zenoh::SentinelBus;
+use sha2::{Digest, Sha256};
 
 use crate::adaptive_tick::AdaptiveTickRate;
 use crate::config::DaemonConfig;
@@ -66,6 +68,107 @@ fn shift_hours(shift_set: u8) -> (u8, u8) {
 /// CPU: 1 core, Memory: 256MB, IO: 300 IOPS + 10MB/s.
 fn default_agent_limits() -> CgroupLimits {
     CgroupLimits::default()
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NmdaScoreStats {
+    min: Option<f64>,
+    avg: Option<f64>,
+    max: Option<f64>,
+}
+
+#[derive(Debug)]
+struct NightrunHashChain {
+    current: [u8; 32],
+}
+
+impl NightrunHashChain {
+    fn new(seed: &str, run_id: &str) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(run_id.as_bytes());
+        hasher.update(b":");
+        hasher.update(seed.as_bytes());
+        Self {
+            current: hasher.finalize().into(),
+        }
+    }
+
+    fn extend(&mut self, event: &DomainEvent) {
+        let mut hasher = Sha256::new();
+        hasher.update(self.current);
+        hasher.update(event.event_id.as_bytes());
+        hasher.update(event.payload.as_bytes());
+        hasher.update(event.tick.to_le_bytes());
+        self.current = hasher.finalize().into();
+    }
+
+    fn current_hash(&self) -> String {
+        hex_encode(&self.current)
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn nmda_selection_rate(episodes_processed: u32, episodes_consolidated: u32) -> f64 {
+    if episodes_processed == 0 {
+        0.0
+    } else {
+        episodes_consolidated as f64 / episodes_processed as f64
+    }
+}
+
+fn nmda_consolidated_scores(result: &sentinel_hippocampus::ConsolidationResult) -> Vec<f64> {
+    result
+        .consolidated_summaries
+        .iter()
+        .map(|(_summary, score)| *score)
+        .collect()
+}
+
+fn nmda_score_stats(scores: &[f64]) -> NmdaScoreStats {
+    let min = scores.iter().copied().reduce(f64::min);
+    let max = scores.iter().copied().reduce(f64::max);
+    let avg = if scores.is_empty() {
+        None
+    } else {
+        Some(scores.iter().sum::<f64>() / scores.len() as f64)
+    };
+
+    NmdaScoreStats { min, avg, max }
+}
+
+fn nightrun_run_id(prefix: &str, tick_count: u64, from_shift: u8, to_shift: u8) -> String {
+    format!("{prefix}-tick-{tick_count}-shift-{from_shift}-to-{to_shift}")
+}
+
+fn append_nightrun_event(
+    event_store: &EventStore,
+    payload: DomainEventPayload,
+    aggregate_id: &str,
+    run_id: &str,
+    tick_count: u64,
+    hash_chain: Option<&mut NightrunHashChain>,
+) -> Result<DomainEvent> {
+    let event = DomainEvent::new(
+        payload.event_type_str(),
+        aggregate_id,
+        &payload.to_json(),
+        run_id,
+        tick_count,
+    );
+    event_store.append_with_outbox(&event, "nightrun")?;
+    if let Some(chain) = hash_chain {
+        chain.extend(&event);
+    }
+    Ok(event)
 }
 
 fn record_security_runtime_snapshot(
@@ -3111,103 +3214,192 @@ fn ecs_tick_loop(
                 let redb_store = world
                     .get_resource::<sentinel_ecs::RedbStateStore>()
                     .map(|r| r.store.clone());
+                let nightrun_event_store = world
+                    .get_resource::<sentinel_ecs::LimboEventStore>()
+                    .map(|es| Arc::clone(&es.0));
+                let shift_run_id = nightrun_run_id("shift", tick_count, current_shift, new_shift);
+                let shift_started = Instant::now();
+                let mut shift_hash_chain = NightrunHashChain::new(&shift_run_id, &shift_run_id);
+                let mut shift_event_emission_enabled = false;
+                if let Some(ref event_store) = nightrun_event_store {
+                    let payload = DomainEventPayload::NightRunStarted {
+                        run_id: shift_run_id.clone(),
+                        trigger_shift_set: current_shift,
+                        agents_queued: removed.len() as u32,
+                    };
+                    match append_nightrun_event(
+                        event_store,
+                        payload,
+                        "nightrun",
+                        &shift_run_id,
+                        tick_count,
+                        Some(&mut shift_hash_chain),
+                    ) {
+                        Ok(_) => {
+                            shift_event_emission_enabled = true;
+                        }
+                        Err(e) => {
+                            warn!(
+                                run_id = %shift_run_id,
+                                error = %e,
+                                "Schichtwechsel-Nightrun-Start-Event fehlgeschlagen"
+                            );
+                        }
+                    }
+                }
+                let mut shift_episodes_processed = 0u32;
+                let mut shift_episodes_consolidated = 0u32;
+                let mut shift_agents_consolidated = 0u32;
+                let mut shift_agents_failed = 0u32;
+                let mut shift_nmda_scores: Vec<f64> = Vec::new();
                 for agent_id in &removed {
                     let agent_name = all_agents
                         .iter()
                         .find(|a| AgentId(a.identity.id) == *agent_id)
                         .map(|a| a.identity.name.as_str());
                     if let Some(name) = agent_name {
+                        let agent_started = Instant::now();
                         match episode_producer.hippocampus().consolidate_agent(name) {
                             Ok(result) => {
-                                if result.episodes_processed > 0 {
+                                let episodes_processed = result.episodes_processed as u32;
+                                let episodes_consolidated = result.episodes_consolidated as u32;
+                                if episodes_processed > 0 {
+                                    let nmda_scores = nmda_consolidated_scores(&result);
+                                    let agent_stats = nmda_score_stats(&nmda_scores);
+                                    shift_episodes_processed += episodes_processed;
+                                    shift_episodes_consolidated += episodes_consolidated;
+                                    shift_agents_consolidated += 1;
+                                    shift_nmda_scores.extend(nmda_scores.iter().copied());
+
                                     info!(
                                         agent = name,
-                                        episodes_processed = result.episodes_processed,
-                                        episodes_consolidated = result.episodes_consolidated,
-                                        "Schichtwechsel-Konsolidierung abgeschlossen"
+                                        episodes_processed,
+                                        episodes_consolidated,
+                                        selection_rate = format!(
+                                            "{:.3}",
+                                            nmda_selection_rate(
+                                                episodes_processed,
+                                                episodes_consolidated
+                                            )
+                                        ),
+                                        nmda_threshold = NMDA_CONSOLIDATION_THRESHOLD,
+                                        nmda_score_min = ?agent_stats.min,
+                                        nmda_score_avg = ?agent_stats.avg,
+                                        nmda_score_max = ?agent_stats.max,
+                                        "Schichtwechsel-NMDA-Agent-Selektion"
                                     );
 
-                                    let narrative: String = result
-                                        .consolidated_summaries
-                                        .iter()
-                                        .map(|(s, _score)| s.as_str())
-                                        .collect::<Vec<_>>()
-                                        .join("; ");
-
-                                    let agent_role = all_agents
-                                        .iter()
-                                        .find(|a| AgentId(a.identity.id) == *agent_id)
-                                        .map(|a| a.identity.role.as_str())
-                                        .unwrap_or("Mitarbeiter");
-                                    let queued = queue_evolution_job(
-                                        &evolution_job_tx,
-                                        EvolutionJob {
-                                            agent_id: *agent_id,
-                                            agent_name: name.to_string(),
-                                            agent_role: agent_role.to_string(),
-                                            narrative: narrative.clone(),
-                                            source: EvolutionSource::ShiftTransition,
-                                        },
-                                    );
-                                    if !queued {
-                                        write_evolution_narrative_only(
-                                            &state_store_for_sim,
-                                            *agent_id,
-                                            name,
-                                            EvolutionSource::ShiftTransition,
-                                            &narrative,
-                                        );
-                                    }
-
-                                    if let Some(ref store) = redb_store {
-                                        // NMDA scores nach redb schreiben
-                                        let scores: Vec<f64> = result
-                                            .consolidated_summaries
-                                            .iter()
-                                            .map(|(_s, score)| *score)
-                                            .collect();
-                                        if !scores.is_empty() {
-                                            let avg_score: f64 =
-                                                scores.iter().sum::<f64>() / scores.len() as f64;
-                                            match store.set_nmda_scores(*agent_id, &scores) {
-                                                Ok(()) => {
-                                                    info!(
-                                                        agent = name,
-                                                        nmda_count = scores.len(),
-                                                        nmda_avg = format!("{avg_score:.4}"),
-                                                        "NMDA scores nach redb geschrieben"
-                                                    );
-                                                }
-                                                Err(e) => {
-                                                    warn!(
-                                                        agent = name,
-                                                        error = %e,
-                                                        "NMDA scores redb-Write fehlgeschlagen"
-                                                    );
-                                                }
+                                    if shift_event_emission_enabled {
+                                        if let Some(ref event_store) = nightrun_event_store {
+                                            let payload = DomainEventPayload::AgentConsolidated {
+                                                run_id: shift_run_id.clone(),
+                                                agent_name: name.to_string(),
+                                                episodes_processed,
+                                                episodes_consolidated,
+                                                duration_ms: agent_started.elapsed().as_millis()
+                                                    as u64,
+                                            };
+                                            let aggregate_id = format!("AGENT-{:02}", agent_id.0);
+                                            if let Err(e) = append_nightrun_event(
+                                                event_store,
+                                                payload,
+                                                &aggregate_id,
+                                                &shift_run_id,
+                                                tick_count,
+                                                Some(&mut shift_hash_chain),
+                                            ) {
+                                                shift_event_emission_enabled = false;
+                                                warn!(
+                                                    run_id = %shift_run_id,
+                                                    agent = name,
+                                                    error = %e,
+                                                    "Schichtwechsel-AgentConsolidated-Event fehlgeschlagen"
+                                                );
                                             }
                                         }
+                                    }
 
-                                        // Facts aus Hippocampus FactRetriever nach state.redb bridgen
-                                        let facts =
-                                            episode_producer.hippocampus().retrieve_facts(name);
-                                        if !facts.is_empty() {
-                                            let facts_json =
-                                                serde_json::to_vec(&facts).unwrap_or_default();
-                                            match store.set_agent_facts(*agent_id, &facts_json) {
-                                                Ok(()) => {
-                                                    info!(
-                                                        agent = name,
-                                                        facts_count = facts.len(),
-                                                        "AGENT_FACTS nach state.redb geschrieben"
-                                                    );
+                                    if episodes_consolidated > 0 {
+                                        let narrative: String = result
+                                            .consolidated_summaries
+                                            .iter()
+                                            .map(|(s, _score)| s.as_str())
+                                            .collect::<Vec<_>>()
+                                            .join("; ");
+
+                                        let agent_role = all_agents
+                                            .iter()
+                                            .find(|a| AgentId(a.identity.id) == *agent_id)
+                                            .map(|a| a.identity.role.as_str())
+                                            .unwrap_or("Mitarbeiter");
+                                        let queued = queue_evolution_job(
+                                            &evolution_job_tx,
+                                            EvolutionJob {
+                                                agent_id: *agent_id,
+                                                agent_name: name.to_string(),
+                                                agent_role: agent_role.to_string(),
+                                                narrative: narrative.clone(),
+                                                source: EvolutionSource::ShiftTransition,
+                                            },
+                                        );
+                                        if !queued {
+                                            write_evolution_narrative_only(
+                                                &state_store_for_sim,
+                                                *agent_id,
+                                                name,
+                                                EvolutionSource::ShiftTransition,
+                                                &narrative,
+                                            );
+                                        }
+
+                                        if let Some(ref store) = redb_store {
+                                            // NMDA scores nach redb schreiben
+                                            if !nmda_scores.is_empty() {
+                                                let avg_score: f64 =
+                                                    nmda_scores.iter().sum::<f64>()
+                                                        / nmda_scores.len() as f64;
+                                                match store.set_nmda_scores(*agent_id, &nmda_scores)
+                                                {
+                                                    Ok(()) => {
+                                                        info!(
+                                                            agent = name,
+                                                            nmda_count = nmda_scores.len(),
+                                                            nmda_avg = format!("{avg_score:.4}"),
+                                                            "NMDA scores nach redb geschrieben"
+                                                        );
+                                                    }
+                                                    Err(e) => {
+                                                        warn!(
+                                                            agent = name,
+                                                            error = %e,
+                                                            "NMDA scores redb-Write fehlgeschlagen"
+                                                        );
+                                                    }
                                                 }
-                                                Err(e) => {
-                                                    warn!(
-                                                        agent = name,
-                                                        error = %e,
-                                                        "AGENT_FACTS redb-Write fehlgeschlagen"
-                                                    );
+                                            }
+
+                                            // Facts aus Hippocampus FactRetriever nach state.redb bridgen
+                                            let facts =
+                                                episode_producer.hippocampus().retrieve_facts(name);
+                                            if !facts.is_empty() {
+                                                let facts_json =
+                                                    serde_json::to_vec(&facts).unwrap_or_default();
+                                                match store.set_agent_facts(*agent_id, &facts_json)
+                                                {
+                                                    Ok(()) => {
+                                                        info!(
+                                                            agent = name,
+                                                            facts_count = facts.len(),
+                                                            "AGENT_FACTS nach state.redb geschrieben"
+                                                        );
+                                                    }
+                                                    Err(e) => {
+                                                        warn!(
+                                                            agent = name,
+                                                            error = %e,
+                                                            "AGENT_FACTS redb-Write fehlgeschlagen"
+                                                        );
+                                                    }
                                                 }
                                             }
                                         }
@@ -3215,8 +3407,90 @@ fn ecs_tick_loop(
                                 }
                             }
                             Err(e) => {
+                                shift_agents_failed += 1;
+                                if shift_event_emission_enabled {
+                                    if let Some(ref event_store) = nightrun_event_store {
+                                        let payload =
+                                            DomainEventPayload::AgentConsolidationFailed {
+                                                run_id: shift_run_id.clone(),
+                                                agent_name: name.to_string(),
+                                                error: e.to_string(),
+                                            };
+                                        let aggregate_id = format!("AGENT-{:02}", agent_id.0);
+                                        if let Err(event_err) = append_nightrun_event(
+                                            event_store,
+                                            payload,
+                                            &aggregate_id,
+                                            &shift_run_id,
+                                            tick_count,
+                                            Some(&mut shift_hash_chain),
+                                        ) {
+                                            shift_event_emission_enabled = false;
+                                            warn!(
+                                                run_id = %shift_run_id,
+                                                agent = name,
+                                                error = %event_err,
+                                                "Schichtwechsel-AgentConsolidationFailed-Event fehlgeschlagen"
+                                            );
+                                        }
+                                    }
+                                }
                                 warn!(agent = name, error = %e, "Schichtwechsel-Konsolidierung fehlgeschlagen");
                             }
+                        }
+                    }
+                }
+                if shift_episodes_processed > 0 {
+                    let shift_stats = nmda_score_stats(&shift_nmda_scores);
+                    info!(
+                        old_shift = current_shift,
+                        new_shift,
+                        agents_removed = removed.len(),
+                        episodes_processed = shift_episodes_processed,
+                        episodes_consolidated = shift_episodes_consolidated,
+                        selection_rate = format!(
+                            "{:.3}",
+                            nmda_selection_rate(
+                                shift_episodes_processed,
+                                shift_episodes_consolidated
+                            )
+                        ),
+                        nmda_threshold = NMDA_CONSOLIDATION_THRESHOLD,
+                        nmda_max_consolidation_episodes = NMDA_MAX_CONSOLIDATION_EPISODES,
+                        nmda_score_min = ?shift_stats.min,
+                        nmda_score_avg = ?shift_stats.avg,
+                        nmda_score_max = ?shift_stats.max,
+                        "Schichtwechsel-NMDA-Selektion abgeschlossen"
+                    );
+                }
+                if shift_event_emission_enabled {
+                    if let Some(ref event_store) = nightrun_event_store {
+                        let hash_chain_final = shift_hash_chain.current_hash();
+                        let payload = DomainEventPayload::NightRunCompleted {
+                            run_id: shift_run_id.clone(),
+                            trigger_shift_set: current_shift,
+                            agents_consolidated: shift_agents_consolidated,
+                            agents_failed: shift_agents_failed,
+                            agents_skipped: 0,
+                            total_episodes: shift_episodes_processed,
+                            total_episodes_consolidated: shift_episodes_consolidated,
+                            duration_ms: shift_started.elapsed().as_millis() as u64,
+                            hash_chain: Some(hash_chain_final.clone()),
+                        };
+                        if let Err(e) = append_nightrun_event(
+                            event_store,
+                            payload,
+                            "nightrun",
+                            &shift_run_id,
+                            tick_count,
+                            None,
+                        ) {
+                            warn!(
+                                run_id = %shift_run_id,
+                                hash_chain = %hash_chain_final,
+                                error = %e,
+                                "Schichtwechsel-Nightrun-Completed-Event fehlgeschlagen"
+                            );
                         }
                     }
                 }
@@ -3361,7 +3635,49 @@ fn ecs_tick_loop(
                     nightrun_cmd.shift_set.is_none_or(|s| set == s)
                 })
                 .collect();
-            let mut consolidated_total = 0u32;
+            let trigger_shift_set = nightrun_cmd.shift_set.unwrap_or(current_shift);
+            let operator_run_id =
+                nightrun_run_id("operator", tick_count, current_shift, trigger_shift_set);
+            let operator_started = Instant::now();
+            let operator_event_store = world
+                .get_resource::<sentinel_ecs::LimboEventStore>()
+                .map(|es| Arc::clone(&es.0));
+            let mut operator_hash_chain =
+                NightrunHashChain::new(&operator_run_id, &operator_run_id);
+            let mut operator_event_emission_enabled = false;
+            if !nightrun_cmd.dry_run {
+                if let Some(ref event_store) = operator_event_store {
+                    let payload = DomainEventPayload::NightRunStarted {
+                        run_id: operator_run_id.clone(),
+                        trigger_shift_set,
+                        agents_queued: target_agents.len() as u32,
+                    };
+                    match append_nightrun_event(
+                        event_store,
+                        payload,
+                        "nightrun",
+                        &operator_run_id,
+                        tick_count,
+                        Some(&mut operator_hash_chain),
+                    ) {
+                        Ok(_) => {
+                            operator_event_emission_enabled = true;
+                        }
+                        Err(e) => {
+                            warn!(
+                                run_id = %operator_run_id,
+                                error = %e,
+                                "Operator-Nightrun-Start-Event fehlgeschlagen"
+                            );
+                        }
+                    }
+                }
+            }
+            let mut episodes_processed_total = 0u32;
+            let mut episodes_consolidated_total = 0u32;
+            let mut agents_consolidated_total = 0u32;
+            let mut agents_failed_total = 0u32;
+            let mut operator_nmda_scores: Vec<f64> = Vec::new();
             let mut evolution_jobs_queued = 0u32;
             let mut evolution_entries: Vec<(String, u32)> = Vec::new();
             for agent_cfg in &target_agents {
@@ -3370,46 +3686,122 @@ fn ecs_tick_loop(
                     info!(agent = %name, "Nightrun dry-run: wuerde konsolidieren");
                     continue;
                 }
+                let agent_started = Instant::now();
                 match episode_producer.hippocampus().consolidate_agent(name) {
                     Ok(result) if result.episodes_processed > 0 => {
-                        consolidated_total += result.episodes_processed as u32;
-                        evolution_entries
-                            .push((name.to_string(), result.episodes_processed as u32));
-                        let narrative = result
-                            .consolidated_summaries
-                            .iter()
-                            .map(|(summary, _score)| summary.as_str())
-                            .collect::<Vec<_>>()
-                            .join("; ");
-                        let queued = queue_evolution_job(
-                            &evolution_job_tx,
-                            EvolutionJob {
-                                agent_id: AgentId(agent_cfg.identity.id),
-                                agent_name: name.to_string(),
-                                agent_role: agent_cfg.identity.role.clone(),
-                                narrative: narrative.clone(),
-                                source: EvolutionSource::Nightrun,
-                            },
-                        );
-                        if queued {
-                            evolution_jobs_queued += 1;
-                        } else {
-                            write_evolution_narrative_only(
-                                &state_store_for_sim,
-                                AgentId(agent_cfg.identity.id),
-                                name,
-                                EvolutionSource::Nightrun,
-                                &narrative,
-                            );
-                        }
+                        let episodes_processed = result.episodes_processed as u32;
+                        let episodes_consolidated = result.episodes_consolidated as u32;
+                        let nmda_scores = nmda_consolidated_scores(&result);
+                        let agent_stats = nmda_score_stats(&nmda_scores);
+                        episodes_processed_total += episodes_processed;
+                        episodes_consolidated_total += episodes_consolidated;
+                        agents_consolidated_total += 1;
+                        operator_nmda_scores.extend(nmda_scores.iter().copied());
+
                         info!(
                             agent = %name,
-                            episodes = result.episodes_processed,
-                            "Nightrun: Agent konsolidiert"
+                            episodes_processed,
+                            episodes_consolidated,
+                            selection_rate = format!(
+                                "{:.3}",
+                                nmda_selection_rate(episodes_processed, episodes_consolidated)
+                            ),
+                            nmda_threshold = NMDA_CONSOLIDATION_THRESHOLD,
+                            nmda_score_min = ?agent_stats.min,
+                            nmda_score_avg = ?agent_stats.avg,
+                            nmda_score_max = ?agent_stats.max,
+                            "Nightrun-NMDA-Agent-Selektion"
                         );
+
+                        if operator_event_emission_enabled {
+                            if let Some(ref event_store) = operator_event_store {
+                                let payload = DomainEventPayload::AgentConsolidated {
+                                    run_id: operator_run_id.clone(),
+                                    agent_name: name.to_string(),
+                                    episodes_processed,
+                                    episodes_consolidated,
+                                    duration_ms: agent_started.elapsed().as_millis() as u64,
+                                };
+                                let aggregate_id = format!("AGENT-{:02}", agent_cfg.identity.id);
+                                if let Err(e) = append_nightrun_event(
+                                    event_store,
+                                    payload,
+                                    &aggregate_id,
+                                    &operator_run_id,
+                                    tick_count,
+                                    Some(&mut operator_hash_chain),
+                                ) {
+                                    operator_event_emission_enabled = false;
+                                    warn!(
+                                        run_id = %operator_run_id,
+                                        agent = %name,
+                                        error = %e,
+                                        "Operator-AgentConsolidated-Event fehlgeschlagen"
+                                    );
+                                }
+                            }
+                        }
+
+                        if episodes_consolidated > 0 {
+                            evolution_entries.push((name.to_string(), episodes_consolidated));
+                            let narrative = result
+                                .consolidated_summaries
+                                .iter()
+                                .map(|(summary, _score)| summary.as_str())
+                                .collect::<Vec<_>>()
+                                .join("; ");
+                            let queued = queue_evolution_job(
+                                &evolution_job_tx,
+                                EvolutionJob {
+                                    agent_id: AgentId(agent_cfg.identity.id),
+                                    agent_name: name.to_string(),
+                                    agent_role: agent_cfg.identity.role.clone(),
+                                    narrative: narrative.clone(),
+                                    source: EvolutionSource::Nightrun,
+                                },
+                            );
+                            if queued {
+                                evolution_jobs_queued += 1;
+                            } else {
+                                write_evolution_narrative_only(
+                                    &state_store_for_sim,
+                                    AgentId(agent_cfg.identity.id),
+                                    name,
+                                    EvolutionSource::Nightrun,
+                                    &narrative,
+                                );
+                            }
+                        }
                     }
                     Ok(_) => {} // Keine Episodes = nichts zu tun
                     Err(e) => {
+                        agents_failed_total += 1;
+                        if operator_event_emission_enabled {
+                            if let Some(ref event_store) = operator_event_store {
+                                let payload = DomainEventPayload::AgentConsolidationFailed {
+                                    run_id: operator_run_id.clone(),
+                                    agent_name: name.to_string(),
+                                    error: e.to_string(),
+                                };
+                                let aggregate_id = format!("AGENT-{:02}", agent_cfg.identity.id);
+                                if let Err(event_err) = append_nightrun_event(
+                                    event_store,
+                                    payload,
+                                    &aggregate_id,
+                                    &operator_run_id,
+                                    tick_count,
+                                    Some(&mut operator_hash_chain),
+                                ) {
+                                    operator_event_emission_enabled = false;
+                                    warn!(
+                                        run_id = %operator_run_id,
+                                        agent = %name,
+                                        error = %event_err,
+                                        "Operator-AgentConsolidationFailed-Event fehlgeschlagen"
+                                    );
+                                }
+                            }
+                        }
                         warn!(agent = %name, error = %e, "Nightrun-Konsolidierung fehlgeschlagen");
                     }
                 }
@@ -3444,7 +3836,7 @@ fn ecs_tick_loop(
                                     "night_run",
                                     "",
                                     format!("{episodes} episodes consolidated"),
-                                    format!("Nightrun-Konsolidierung: {episodes} Episoden verarbeitet"),
+                                    format!("Nightrun-Konsolidierung: {episodes} Episoden konsolidiert"),
                                     0.0_f64,
                                     "night_run",
                                     now_ms,
@@ -3465,13 +3857,55 @@ fn ecs_tick_loop(
                 }
             }
 
+            let operator_stats = nmda_score_stats(&operator_nmda_scores);
             info!(
                 agents = target_agents.len(),
-                consolidated = consolidated_total,
+                episodes_processed = episodes_processed_total,
+                episodes_consolidated = episodes_consolidated_total,
+                selection_rate = format!(
+                    "{:.3}",
+                    nmda_selection_rate(episodes_processed_total, episodes_consolidated_total)
+                ),
+                nmda_threshold = NMDA_CONSOLIDATION_THRESHOLD,
+                nmda_max_consolidation_episodes = NMDA_MAX_CONSOLIDATION_EPISODES,
+                nmda_score_min = ?operator_stats.min,
+                nmda_score_avg = ?operator_stats.avg,
+                nmda_score_max = ?operator_stats.max,
                 evolution_jobs_queued,
                 dry_run = nightrun_cmd.dry_run,
                 "Nightrun abgeschlossen"
             );
+            if operator_event_emission_enabled {
+                if let Some(ref event_store) = operator_event_store {
+                    let hash_chain_final = operator_hash_chain.current_hash();
+                    let payload = DomainEventPayload::NightRunCompleted {
+                        run_id: operator_run_id.clone(),
+                        trigger_shift_set,
+                        agents_consolidated: agents_consolidated_total,
+                        agents_failed: agents_failed_total,
+                        agents_skipped: 0,
+                        total_episodes: episodes_processed_total,
+                        total_episodes_consolidated: episodes_consolidated_total,
+                        duration_ms: operator_started.elapsed().as_millis() as u64,
+                        hash_chain: Some(hash_chain_final.clone()),
+                    };
+                    if let Err(e) = append_nightrun_event(
+                        event_store,
+                        payload,
+                        "nightrun",
+                        &operator_run_id,
+                        tick_count,
+                        None,
+                    ) {
+                        warn!(
+                            run_id = %operator_run_id,
+                            hash_chain = %hash_chain_final,
+                            error = %e,
+                            "Operator-Nightrun-Completed-Event fehlgeschlagen"
+                        );
+                    }
+                }
+            }
         }
 
         // Time Machine: Periodische World Snapshots
@@ -4045,6 +4479,95 @@ mod tests {
 
     fn projection_service_active(_service_name: &str) -> bool {
         true
+    }
+
+    #[test]
+    fn nightrun_events_persist_replayable_hash_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let events_path = tmp.path().join("events.db");
+        let event_store = EventStore::open(events_path.to_str().unwrap()).unwrap();
+        let run_id = "shift-tick-42-shift-1-to-2";
+        let mut chain = NightrunHashChain::new(run_id, run_id);
+
+        append_nightrun_event(
+            &event_store,
+            DomainEventPayload::NightRunStarted {
+                run_id: run_id.to_string(),
+                trigger_shift_set: 1,
+                agents_queued: 1,
+            },
+            "nightrun",
+            run_id,
+            42,
+            Some(&mut chain),
+        )
+        .unwrap();
+        append_nightrun_event(
+            &event_store,
+            DomainEventPayload::AgentConsolidated {
+                run_id: run_id.to_string(),
+                agent_name: "Anna".to_string(),
+                episodes_processed: 3,
+                episodes_consolidated: 1,
+                duration_ms: 7,
+            },
+            "AGENT-01",
+            run_id,
+            42,
+            Some(&mut chain),
+        )
+        .unwrap();
+        let expected_hash = chain.current_hash();
+        append_nightrun_event(
+            &event_store,
+            DomainEventPayload::NightRunCompleted {
+                run_id: run_id.to_string(),
+                trigger_shift_set: 1,
+                agents_consolidated: 1,
+                agents_failed: 0,
+                agents_skipped: 0,
+                total_episodes: 3,
+                total_episodes_consolidated: 1,
+                duration_ms: 9,
+                hash_chain: Some(expected_hash.clone()),
+            },
+            "nightrun",
+            run_id,
+            42,
+            None,
+        )
+        .unwrap();
+
+        let events = event_store.get_events_by_correlation(run_id, 10).unwrap();
+        assert_eq!(events.len(), 3);
+
+        let mut replay_chain = NightrunHashChain::new(run_id, run_id);
+        for event in events
+            .iter()
+            .filter(|event| event.event_type != "nightrun_completed")
+        {
+            replay_chain.extend(event);
+        }
+        assert_eq!(replay_chain.current_hash(), expected_hash);
+
+        let completed = events
+            .iter()
+            .find(|event| event.event_type == "nightrun_completed")
+            .unwrap();
+        let payload: DomainEventPayload = serde_json::from_str(&completed.payload).unwrap();
+        match payload {
+            DomainEventPayload::NightRunCompleted {
+                hash_chain,
+                total_episodes,
+                total_episodes_consolidated,
+                ..
+            } => {
+                assert_eq!(hash_chain.as_deref(), Some(expected_hash.as_str()));
+                assert_eq!(total_episodes, 3);
+                assert_eq!(total_episodes_consolidated, 1);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 
     /// Erstellt EbpfCollector + tokio mpsc Sender fuer Tests (Userspace mode, kein tokio noetig).

--- a/services/sentinel-nightrun/Cargo.toml
+++ b/services/sentinel-nightrun/Cargo.toml
@@ -35,6 +35,7 @@ libc = "0.2"
 [dev-dependencies]
 tempfile = "3"
 criterion = { workspace = true }
+approx = { workspace = true }
 
 [[bench]]
 name = "nightrun_bench"

--- a/services/sentinel-nightrun/src/main.rs
+++ b/services/sentinel-nightrun/src/main.rs
@@ -12,6 +12,8 @@ use tracing::{error, info, warn};
 
 use sentinel_nightrun::config::NightrunConfig;
 use sentinel_nightrun::job_queue::JobQueue;
+use sentinel_nightrun::replay::ReplayEngine;
+use sentinel_nightrun::runner::NightrunSelectionMetrics;
 use sentinel_nightrun::runner::{NightrunResult, NightrunRunner};
 use sentinel_nightrun::shift::{current_shift_set, outgoing_shift_set};
 
@@ -37,11 +39,35 @@ struct Cli {
     /// Unvollstaendigen Run fortsetzen statt neuen zu starten.
     #[arg(long)]
     resume: bool,
+
+    /// Einen abgeschlossenen Run read-only replayen statt neu zu konsolidieren.
+    #[arg(long)]
+    replay_run_id: Option<String>,
+
+    /// Erwarteter Hash fuer Replay. Wenn nicht gesetzt, wird nightrun_completed.hash_chain genutzt.
+    #[arg(long)]
+    expected_hash: Option<String>,
+
+    /// Hash-Seed fuer Replay. Default ist die Run-ID.
+    #[arg(long)]
+    seed: Option<String>,
+
+    /// Ergebnis als JSON auf stdout ausgeben.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "mode", content = "result")]
+enum CommandOutcome {
+    Nightrun(NightrunResult),
+    Replay(sentinel_nightrun::replay::ReplayResult),
 }
 
 fn main() -> ExitCode {
     // Logging
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
@@ -49,9 +75,17 @@ fn main() -> ExitCode {
         .init();
 
     let cli = Cli::parse();
+    let json_output = cli.json;
 
     match run(cli) {
-        Ok(result) => {
+        Ok(CommandOutcome::Nightrun(result)) => {
+            if json_output {
+                if let Err(e) = print_json(&CommandOutcome::Nightrun(result.clone())) {
+                    error!(error = %e, "JSON-Ausgabe fehlgeschlagen");
+                    return ExitCode::from(2);
+                }
+            }
+
             if result.agents_failed > 0 {
                 error!(
                     run_id = %result.run_id,
@@ -66,10 +100,39 @@ fn main() -> ExitCode {
                     consolidated = result.agents_consolidated,
                     skipped = result.agents_skipped,
                     total_episodes = result.total_episodes,
+                    total_episodes_consolidated = result.total_episodes_consolidated,
+                    selection_rate = format!("{:.3}", result.selection.selection_rate),
                     duration_ms = result.duration_ms,
                     "Nightrun erfolgreich abgeschlossen"
                 );
                 ExitCode::SUCCESS
+            }
+        }
+        Ok(CommandOutcome::Replay(result)) => {
+            if json_output {
+                if let Err(e) = print_json(&CommandOutcome::Replay(result.clone())) {
+                    error!(error = %e, "JSON-Ausgabe fehlgeschlagen");
+                    return ExitCode::from(2);
+                }
+            }
+
+            if result.hash_chain_valid {
+                info!(
+                    run_id = %result.run_id,
+                    events_loaded = result.events_loaded,
+                    events_replayed = result.events_replayed,
+                    hash = %result.final_hash,
+                    "Replay erfolgreich"
+                );
+                ExitCode::SUCCESS
+            } else {
+                error!(
+                    run_id = %result.run_id,
+                    expected = %result.expected_hash,
+                    actual = %result.final_hash,
+                    "Replay-Hash stimmt nicht ueberein"
+                );
+                ExitCode::from(1)
             }
         }
         Err(e) => {
@@ -79,26 +142,47 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> Result<sentinel_nightrun::runner::NightrunResult> {
+fn print_json(outcome: &CommandOutcome) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(outcome)?);
+    Ok(())
+}
+
+fn run(cli: Cli) -> Result<CommandOutcome> {
+    // Config
+    let config = NightrunConfig::load(Path::new(&cli.config))
+        .with_context(|| format!("Config laden fehlgeschlagen: {}", cli.config))?;
+    let settings = config.nightrun;
+
+    if let Some(run_id) = cli.replay_run_id.as_deref() {
+        let event_store =
+            EventStore::open(&settings.event_store_db).context("Failed to open EventStore")?;
+        let replay = ReplayEngine::new(&event_store);
+        let expected_hash = match cli.expected_hash {
+            Some(hash) => hash,
+            None => replay.expected_hash_from_completed(run_id)?,
+        };
+        let seed = cli.seed.as_deref().unwrap_or(run_id);
+        return replay
+            .replay(run_id, seed, &expected_hash)
+            .map(CommandOutcome::Replay);
+    }
+
     // Runtime Feature Flags (Issue #233 AC-4)
     let flags = sentinel_common::feature_flags::RuntimeFlags::init();
     if !flags.nightrun_enabled {
         warn!("SENTINEL_NIGHTRUN_ENABLED=false — Nightrun uebersprungen");
-        return Ok(NightrunResult {
+        return Ok(CommandOutcome::Nightrun(NightrunResult {
             run_id: uuid::Uuid::new_v4().to_string(),
             agents_consolidated: 0,
             agents_failed: 0,
             agents_skipped: 0,
             total_episodes: 0,
+            total_episodes_consolidated: 0,
+            selection: NightrunSelectionMetrics::empty(),
             duration_ms: 0,
             hash_chain_final: String::new(),
-        });
+        }));
     }
-
-    // Config
-    let config = NightrunConfig::load(Path::new(&cli.config))
-        .with_context(|| format!("Config laden fehlgeschlagen: {}", cli.config))?;
-    let settings = config.nightrun;
 
     // Shift-Set bestimmen
     let current = current_shift_set();
@@ -123,15 +207,17 @@ fn run(cli: Cli) -> Result<sentinel_nightrun::runner::NightrunResult> {
                  Konsolidierung wird vom Daemon beim Schichtwechsel durchgefuehrt"
             );
             info!("Nightrun beendet (Daemon-Konsolidierung aktiv)");
-            return Ok(NightrunResult {
+            return Ok(CommandOutcome::Nightrun(NightrunResult {
                 run_id: uuid::Uuid::new_v4().to_string(),
                 agents_consolidated: 0,
                 agents_failed: 0,
                 agents_skipped: 0,
                 total_episodes: 0,
+                total_episodes_consolidated: 0,
+                selection: NightrunSelectionMetrics::empty(),
                 duration_ms: 0,
                 hash_chain_final: String::new(),
-            });
+            }));
         }
     };
 
@@ -168,5 +254,5 @@ fn run(cli: Cli) -> Result<sentinel_nightrun::runner::NightrunResult> {
         cli.dry_run,
     );
 
-    runner.run(trigger_shift_set)
+    runner.run(trigger_shift_set).map(CommandOutcome::Nightrun)
 }

--- a/services/sentinel-nightrun/src/replay.rs
+++ b/services/sentinel-nightrun/src/replay.rs
@@ -4,18 +4,21 @@
 //! and verifies against an expected final hash.
 //! Replay is READ-ONLY — it never mutates events or creates new ones.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
 
-use sentinel_common::DomainEvent;
+use sentinel_common::{DomainEvent, DomainEventPayload};
 use sentinel_limbo::EventStore;
 
 use crate::hash_chain::HashChain;
 
 /// Result of a replay verification.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ReplayResult {
     /// The run ID that was replayed.
     pub run_id: String,
+    /// Number of events loaded from the EventStore for this run.
+    pub events_loaded: usize,
     /// Number of events replayed.
     pub events_replayed: usize,
     /// Whether the hash chain matches the expected value.
@@ -52,12 +55,13 @@ impl<'a> ReplayEngine<'a> {
             .get_events_by_correlation(run_id, 100_000)
             .context("Failed to load events for replay")?;
 
-        let final_hash = HashChain::compute(&events, seed, run_id);
+        let (final_hash, events_replayed) = compute_replay_hash(&events, seed, run_id);
         let valid = final_hash == expected_hash;
 
         Ok(ReplayResult {
             run_id: run_id.to_string(),
-            events_replayed: events.len(),
+            events_loaded: events.len(),
+            events_replayed,
             hash_chain_valid: valid,
             final_hash,
             expected_hash: expected_hash.to_string(),
@@ -73,9 +77,34 @@ impl<'a> ReplayEngine<'a> {
             .get_events_by_correlation(run_id, 100_000)
             .context("Failed to load events for hash capture")?;
 
-        let hash = HashChain::compute(&events, seed, run_id);
-        let count = events.len();
+        let (hash, count) = compute_replay_hash(&events, seed, run_id);
         Ok((hash, count))
+    }
+
+    /// Read the expected hash from the `nightrun_completed` event for a run.
+    pub fn expected_hash_from_completed(&self, run_id: &str) -> Result<String> {
+        let events = self
+            .event_store
+            .get_events_by_correlation(run_id, 100_000)
+            .context("Failed to load events for expected hash extraction")?;
+
+        for event in events.iter().rev() {
+            if event.event_type != "nightrun_completed" {
+                continue;
+            }
+
+            let payload: DomainEventPayload = serde_json::from_str(&event.payload)
+                .context("Failed to parse nightrun_completed payload")?;
+            if let DomainEventPayload::NightRunCompleted {
+                hash_chain: Some(hash),
+                ..
+            } = payload
+            {
+                return Ok(hash);
+            }
+        }
+
+        bail!("No nightrun_completed event with hash_chain found for run_id={run_id}")
     }
 
     /// Replay from a pre-loaded event list (for testing without EventStore).
@@ -85,17 +114,34 @@ impl<'a> ReplayEngine<'a> {
         seed: &str,
         expected_hash: &str,
     ) -> ReplayResult {
-        let final_hash = HashChain::compute(events, seed, run_id);
+        let (final_hash, events_replayed) = compute_replay_hash(events, seed, run_id);
         let valid = final_hash == expected_hash;
 
         ReplayResult {
             run_id: run_id.to_string(),
-            events_replayed: events.len(),
+            events_loaded: events.len(),
+            events_replayed,
             hash_chain_valid: valid,
             final_hash,
             expected_hash: expected_hash.to_string(),
         }
     }
+}
+
+fn compute_replay_hash(events: &[DomainEvent], seed: &str, run_id: &str) -> (String, usize) {
+    let mut chain = HashChain::new(seed, run_id);
+    let mut events_replayed = 0usize;
+
+    for event in events.iter().filter(|event| is_replay_chain_event(event)) {
+        chain.extend(event);
+        events_replayed += 1;
+    }
+
+    (chain.current_hash(), events_replayed)
+}
+
+fn is_replay_chain_event(event: &DomainEvent) -> bool {
+    event.event_type != "nightrun_completed"
 }
 
 #[cfg(test)]

--- a/services/sentinel-nightrun/src/runner.rs
+++ b/services/sentinel-nightrun/src/runner.rs
@@ -7,11 +7,15 @@ use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use tracing::{error, info, warn};
 
 use sentinel_common::agent_config::load_all_agents;
 use sentinel_common::{DomainEvent, DomainEventPayload};
-use sentinel_hippocampus::HippocampusService;
+use sentinel_hippocampus::{
+    HippocampusService, NMDA_CONSOLIDATION_THRESHOLD, NMDA_MAX_CONSOLIDATION_EPISODES,
+    NMDA_SELECTION_RATIONALE,
+};
 use sentinel_limbo::EventStore;
 
 use crate::config::NightrunSettings;
@@ -20,16 +24,132 @@ use crate::hash_chain::HashChain;
 use crate::job_queue::JobQueue;
 
 /// Ergebnis eines Nightrun-Durchlaufs.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize)]
 pub struct NightrunResult {
     pub run_id: String,
     pub agents_consolidated: u32,
     pub agents_failed: u32,
     pub agents_skipped: u32,
     pub total_episodes: u32,
+    pub total_episodes_consolidated: u32,
+    pub selection: NightrunSelectionMetrics,
     pub duration_ms: u64,
     /// Final hash of the deterministic event chain (for replay verification).
     pub hash_chain_final: String,
+}
+
+/// Aggregated NMDA episode-selection evidence for one Night-Run.
+#[derive(Debug, Clone, Serialize)]
+pub struct NightrunSelectionMetrics {
+    pub episodes_processed: u32,
+    pub episodes_consolidated: u32,
+    pub selection_rate: f64,
+    pub threshold: f64,
+    pub max_consolidation_episodes: usize,
+    pub rationale: &'static str,
+    pub score_min: Option<f64>,
+    pub score_avg: Option<f64>,
+    pub score_max: Option<f64>,
+    pub agents: Vec<AgentSelectionMetrics>,
+}
+
+impl NightrunSelectionMetrics {
+    pub fn empty() -> Self {
+        Self {
+            episodes_processed: 0,
+            episodes_consolidated: 0,
+            selection_rate: 0.0,
+            threshold: NMDA_CONSOLIDATION_THRESHOLD,
+            max_consolidation_episodes: NMDA_MAX_CONSOLIDATION_EPISODES,
+            rationale: NMDA_SELECTION_RATIONALE,
+            score_min: None,
+            score_avg: None,
+            score_max: None,
+            agents: Vec::new(),
+        }
+    }
+
+    fn record_agent(&mut self, agent: AgentSelectionMetrics) {
+        self.episodes_processed += agent.episodes_processed;
+        self.episodes_consolidated += agent.episodes_consolidated;
+        self.agents.push(agent);
+        self.recompute();
+    }
+
+    fn recompute(&mut self) {
+        self.selection_rate = if self.episodes_processed == 0 {
+            0.0
+        } else {
+            self.episodes_consolidated as f64 / self.episodes_processed as f64
+        };
+
+        let mut min_score: Option<f64> = None;
+        let mut max_score: Option<f64> = None;
+        let mut sum = 0.0;
+        let mut count = 0u32;
+
+        for agent in &self.agents {
+            if let Some(score) = agent.score_min {
+                min_score = Some(min_score.map_or(score, |current| current.min(score)));
+            }
+            if let Some(score) = agent.score_max {
+                max_score = Some(max_score.map_or(score, |current| current.max(score)));
+            }
+            if let Some(avg) = agent.score_avg {
+                sum += avg * agent.episodes_consolidated as f64;
+                count += agent.episodes_consolidated;
+            }
+        }
+
+        self.score_min = min_score;
+        self.score_max = max_score;
+        self.score_avg = if count == 0 {
+            None
+        } else {
+            Some(sum / count as f64)
+        };
+    }
+}
+
+/// NMDA selection evidence for one agent.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentSelectionMetrics {
+    pub agent_name: String,
+    pub episodes_processed: u32,
+    pub episodes_consolidated: u32,
+    pub selection_rate: f64,
+    pub score_min: Option<f64>,
+    pub score_avg: Option<f64>,
+    pub score_max: Option<f64>,
+}
+
+impl AgentSelectionMetrics {
+    fn new(agent_name: &str, episodes_processed: u32, scores: &[f64]) -> Self {
+        let episodes_consolidated = scores.len() as u32;
+        let selection_rate = if episodes_processed == 0 {
+            0.0
+        } else {
+            episodes_consolidated as f64 / episodes_processed as f64
+        };
+
+        let score_min = scores.iter().copied().reduce(f64::min);
+        let score_max = scores.iter().copied().reduce(f64::max);
+        let score_avg = if scores.is_empty() {
+            None
+        } else {
+            Some(scores.iter().sum::<f64>() / scores.len() as f64)
+        };
+
+        Self {
+            agent_name: agent_name.to_string(),
+            episodes_processed,
+            episodes_consolidated,
+            selection_rate,
+            score_min,
+            score_avg,
+            score_max,
+        }
+    }
 }
 
 /// Kern-Pipeline fuer Schichtwechsel-Konsolidierung.
@@ -90,6 +210,8 @@ impl NightrunRunner {
                 agents_failed: 0,
                 agents_skipped: 0,
                 total_episodes: 0,
+                total_episodes_consolidated: 0,
+                selection: NightrunSelectionMetrics::empty(),
                 duration_ms: start.elapsed().as_millis() as u64,
                 hash_chain_final: hash_chain.current_hash(),
             });
@@ -122,6 +244,8 @@ impl NightrunRunner {
         let mut failed = 0u32;
         let mut skipped = 0u32;
         let mut total_episodes = 0u32;
+        let mut total_episodes_consolidated = 0u32;
+        let mut selection = NightrunSelectionMetrics::empty();
 
         let pending_jobs = self.job_queue.get_pending(&self.run_id)?;
 
@@ -173,12 +297,22 @@ impl NightrunRunner {
 
             let agent_start = Instant::now();
             match self.consolidate_single_agent(agent) {
-                Ok((processed, cons)) => {
+                Ok(result) => {
+                    let processed = result.episodes_processed as u32;
+                    let cons = result.episodes_consolidated as u32;
+                    let scores: Vec<f64> = result
+                        .consolidated_summaries
+                        .iter()
+                        .map(|(_, score)| *score)
+                        .collect();
+                    let agent_selection = AgentSelectionMetrics::new(agent, processed, &scores);
+                    selection.record_agent(agent_selection);
                     let duration_ms = agent_start.elapsed().as_millis() as u64;
                     info!(
                         agent,
                         episodes_processed = processed,
                         episodes_consolidated = cons,
+                        selection_rate = format!("{:.3}", selection.selection_rate),
                         duration_ms,
                         "Agent konsolidiert"
                     );
@@ -188,6 +322,7 @@ impl NightrunRunner {
                     hash_chain.extend(&ev);
                     consolidated += 1;
                     total_episodes += processed;
+                    total_episodes_consolidated += cons;
                 }
                 Err(e) => {
                     let err_msg = format!("{e:#}");
@@ -217,6 +352,7 @@ impl NightrunRunner {
             failed,
             skipped,
             total_episodes,
+            total_episodes_consolidated,
             duration_ms,
             &hash_chain_final,
         )?;
@@ -227,6 +363,8 @@ impl NightrunRunner {
             agents_failed: failed,
             agents_skipped: skipped,
             total_episodes,
+            total_episodes_consolidated,
+            selection,
             duration_ms,
             hash_chain_final,
         };
@@ -237,6 +375,8 @@ impl NightrunRunner {
             failed,
             skipped,
             total_episodes,
+            total_episodes_consolidated,
+            selection_rate = format!("{:.3}", result.selection.selection_rate),
             duration_ms,
             hash_chain = %result.hash_chain_final,
             "Nightrun abgeschlossen"
@@ -296,16 +436,16 @@ impl NightrunRunner {
     }
 
     /// Konsolidiert einen einzelnen Agent ueber HippocampusService.
-    fn consolidate_single_agent(&self, agent: &str) -> Result<(u32, u32)> {
+    fn consolidate_single_agent(
+        &self,
+        agent: &str,
+    ) -> Result<sentinel_hippocampus::ConsolidationResult> {
         let result = self
             .hippocampus
             .consolidate_agent(agent)
             .with_context(|| format!("Consolidation failed for agent: {agent}"))?;
 
-        Ok((
-            result.episodes_processed as u32,
-            result.episodes_consolidated as u32,
-        ))
+        Ok(result)
     }
 
     /// Ermittelt die Episode-Anzahl fuer einen Agent.
@@ -342,6 +482,7 @@ impl NightrunRunner {
         agents_failed: u32,
         agents_skipped: u32,
         total_episodes: u32,
+        total_episodes_consolidated: u32,
         duration_ms: u64,
         hash_chain_final: &str,
     ) -> Result<()> {
@@ -352,6 +493,7 @@ impl NightrunRunner {
             agents_failed,
             agents_skipped,
             total_episodes,
+            total_episodes_consolidated,
             duration_ms,
             hash_chain: Some(hash_chain_final.to_string()),
         };

--- a/services/sentinel-nightrun/src/runner.rs
+++ b/services/sentinel-nightrun/src/runner.rs
@@ -96,8 +96,8 @@ impl NightrunSelectionMetrics {
                 max_score = Some(max_score.map_or(score, |current| current.max(score)));
             }
             if let Some(avg) = agent.score_avg {
-                sum += avg * agent.episodes_consolidated as f64;
-                count += agent.episodes_consolidated;
+                sum += avg * agent.episodes_processed as f64;
+                count += agent.episodes_processed;
             }
         }
 
@@ -124,8 +124,12 @@ pub struct AgentSelectionMetrics {
 }
 
 impl AgentSelectionMetrics {
-    fn new(agent_name: &str, episodes_processed: u32, scores: &[f64]) -> Self {
-        let episodes_consolidated = scores.len() as u32;
+    fn new(
+        agent_name: &str,
+        episodes_processed: u32,
+        episodes_consolidated: u32,
+        scores: &[f64],
+    ) -> Self {
         let selection_rate = if episodes_processed == 0 {
             0.0
         } else {
@@ -300,12 +304,8 @@ impl NightrunRunner {
                 Ok(result) => {
                     let processed = result.episodes_processed as u32;
                     let cons = result.episodes_consolidated as u32;
-                    let scores: Vec<f64> = result
-                        .consolidated_summaries
-                        .iter()
-                        .map(|(_, score)| *score)
-                        .collect();
-                    let agent_selection = AgentSelectionMetrics::new(agent, processed, &scores);
+                    let agent_selection =
+                        AgentSelectionMetrics::new(agent, processed, cons, &result.episode_scores);
                     selection.record_agent(agent_selection);
                     let duration_ms = agent_start.elapsed().as_millis() as u64;
                     info!(
@@ -355,6 +355,7 @@ impl NightrunRunner {
             total_episodes_consolidated,
             duration_ms,
             &hash_chain_final,
+            &selection,
         )?;
 
         let result = NightrunResult {
@@ -485,6 +486,7 @@ impl NightrunRunner {
         total_episodes_consolidated: u32,
         duration_ms: u64,
         hash_chain_final: &str,
+        selection: &NightrunSelectionMetrics,
     ) -> Result<()> {
         let payload = DomainEventPayload::NightRunCompleted {
             run_id: self.run_id.clone(),
@@ -494,6 +496,12 @@ impl NightrunRunner {
             agents_skipped,
             total_episodes,
             total_episodes_consolidated,
+            nmda_selection_rate: Some(selection.selection_rate),
+            nmda_threshold: Some(selection.threshold),
+            nmda_max_consolidation_episodes: Some(selection.max_consolidation_episodes as u32),
+            nmda_score_min: selection.score_min,
+            nmda_score_avg: selection.score_avg,
+            nmda_score_max: selection.score_max,
             duration_ms,
             hash_chain: Some(hash_chain_final.to_string()),
         };

--- a/services/sentinel-nightrun/tests/integration.rs
+++ b/services/sentinel-nightrun/tests/integration.rs
@@ -3,8 +3,9 @@
 //! Testet die gesamte Pipeline end-to-end:
 //! HippocampusService + EventStore + JobQueue + Runner
 
+use approx::assert_relative_eq;
 use sentinel_common::DomainEvent;
-use sentinel_hippocampus::{Episode, HippocampusService};
+use sentinel_hippocampus::{Episode, HippocampusService, NMDA_CONSOLIDATION_THRESHOLD};
 use sentinel_limbo::EventStore;
 use sentinel_nightrun::config::NightrunSettings;
 use sentinel_nightrun::guardrails::{GuardrailController, GuardrailDecision};
@@ -108,6 +109,36 @@ fn ac1_consolidation_completes_for_all_agents() {
     assert_eq!(result.agents_failed, 0);
     assert_eq!(result.agents_skipped, 0);
     assert!(result.total_episodes > 0);
+    assert_eq!(result.total_episodes, result.total_episodes_consolidated);
+    assert_relative_eq!(result.selection.selection_rate, 1.0, epsilon = 1e-12);
+}
+
+// === Issue #382: NMDA selection quality evidence ===
+
+#[test]
+fn issue382_selection_metrics_report_processed_vs_consolidated() {
+    let h = TestHarness::new();
+    let episodes = vec![
+        make_episode(1, "Thomas", "Relevant work episode", 0.8, 0.7),
+        make_episode(2, "Thomas", "Medium context", 0.5, 0.5),
+        make_episode(3, "Thomas", "Routine noise", 0.1, 0.05),
+    ];
+    h.hippocampus.record_episodes("Thomas", &episodes).unwrap();
+
+    let (runner, _es, _dir) = h.runner("run-issue382-selection", false);
+    let result = runner.run(1).unwrap();
+
+    assert_eq!(result.total_episodes, 3);
+    assert_eq!(result.total_episodes_consolidated, 1);
+    assert_eq!(result.selection.episodes_processed, 3);
+    assert_eq!(result.selection.episodes_consolidated, 1);
+    assert_eq!(result.selection.threshold, NMDA_CONSOLIDATION_THRESHOLD);
+    assert_relative_eq!(result.selection.selection_rate, 1.0 / 3.0, epsilon = 1e-12);
+    assert_relative_eq!(result.selection.score_min.unwrap(), 0.28, epsilon = 1e-12);
+    assert_relative_eq!(result.selection.score_avg.unwrap(), 0.28, epsilon = 1e-12);
+    assert_relative_eq!(result.selection.score_max.unwrap(), 0.28, epsilon = 1e-12);
+    assert_eq!(result.selection.agents.len(), 1);
+    assert_eq!(result.selection.agents[0].agent_name, "Thomas");
 }
 
 // === AC-2: Konsolidierte Daten persistent ===
@@ -369,6 +400,16 @@ fn ac18_1_replay_same_hash() {
         event_count >= 3,
         "Mindestens 3 Events erwartet, gefunden: {event_count}"
     );
+    assert_eq!(
+        captured_hash, result.hash_chain_final,
+        "Replay muss den im Night-Run gespeicherten Hash reproduzieren"
+    );
+
+    let replay_result = replay_engine
+        .replay("run-replay-1", "run-replay-1", &result.hash_chain_final)
+        .unwrap();
+    assert!(replay_result.hash_chain_valid);
+    assert!(replay_result.events_loaded > replay_result.events_replayed);
 
     // Hash muss konsistent sein (gleicher Seed + gleiche Events = gleicher Hash)
     let (captured_hash_2, _) = replay_engine

--- a/services/sentinel-nightrun/tests/integration.rs
+++ b/services/sentinel-nightrun/tests/integration.rs
@@ -134,8 +134,12 @@ fn issue382_selection_metrics_report_processed_vs_consolidated() {
     assert_eq!(result.selection.episodes_consolidated, 1);
     assert_eq!(result.selection.threshold, NMDA_CONSOLIDATION_THRESHOLD);
     assert_relative_eq!(result.selection.selection_rate, 1.0 / 3.0, epsilon = 1e-12);
-    assert_relative_eq!(result.selection.score_min.unwrap(), 0.28, epsilon = 1e-12);
-    assert_relative_eq!(result.selection.score_avg.unwrap(), 0.28, epsilon = 1e-12);
+    assert_relative_eq!(result.selection.score_min.unwrap(), 0.0025, epsilon = 1e-12);
+    assert_relative_eq!(
+        result.selection.score_avg.unwrap(),
+        (0.28 + 0.125 + 0.0025) / 3.0,
+        epsilon = 1e-12
+    );
     assert_relative_eq!(result.selection.score_max.unwrap(), 0.28, epsilon = 1e-12);
     assert_eq!(result.selection.agents.len(), 1);
     assert_eq!(result.selection.agents[0].agent_name, "Thomas");

--- a/test-382-verification.md
+++ b/test-382-verification.md
@@ -1,0 +1,218 @@
+# Issue #382 Verification - NMDA Episode Selection
+
+Date: 2026-05-29
+
+Scope: finalize NMDA episode-selection threshold policy, expose selection-quality metrics, and prove deterministic replay for a real Night-Run path on the Deploy-VM.
+
+## Environment
+
+Runtime host:
+
+```text
+ubuntu@10.0.0.240
+Model name: Intel(R) Core(TM) i7-3930K CPU @ 3.20GHz
+CPU(s): 8
+Thread(s) per core: 1
+Core(s) per socket: 8
+Socket(s): 1
+Linux sentinel-ubuntu-2404 6.17.0-22-generic
+```
+
+Service state before and after the final measurement:
+
+```text
+sentinel-daemon: active
+sentinel-projection: active
+sentinel-gateway: inactive
+time_scale = 1.0
+```
+
+Evidence directory on the VM:
+
+```text
+/tmp/issue-382-20260529T112955Z-controlled-actions
+```
+
+The final measurement used controlled `AgentActionReceived` events inserted into the VM event store because the organic pending episode queue had already been drained by earlier Night-Run attempts. The real daemon `EpisodeProducer` consumed those events, and the real operator Night-Run consolidated them. No cortex/gateway token path was started.
+
+## AC Matrix
+
+| AC | Requirement | Result | Evidence |
+|---|---|---|---|
+| AC-1 | Score thresholds documented and reasoned, not "tuning" | PASS | `crates/sentinel-hippocampus/src/selection.rs` defines the calibrated profile: threshold `0.25`, narrative threshold `0.25`, max episodes `10`, and rationale. Boundary tests cover accept/reject cases. |
+| AC-2 | Real Night-Run on Deploy-VM measures X/Y episodes consolidated and plausibility | PASS | Operator Night-Run `operator-tick-1467901-shift-1-to-1`: `2/3` episodes consolidated, selection rate `0.666666666666667`, score range `0.00491937687892867..0.550970210440011`, threshold `0.25`. |
+| AC-3 | Deterministic replay of Night-Run gives identical hash-chain | PASS | Replay loaded 5 events, replayed 4, and matched hash `2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751`. |
+| AC-4 | Gap-doc Cluster 02 updated to done with evidence | PASS | `docs/togaf-gap-v22.md` Cluster 02 Memory row now references #382 and this verification file. |
+
+## AC-1 Threshold Policy
+
+Code evidence:
+
+```text
+NMDA_CONSOLIDATION_THRESHOLD = 0.25
+NMDA_NARRATIVE_INCLUSION_THRESHOLD = 0.25
+NMDA_MAX_CONSOLIDATION_EPISODES = 10
+NMDA_SELECTION_RATIONALE = "0.25 keeps relevant work episodes while rejecting medium-context and routine noise"
+```
+
+The threshold rationale is based on the score formula:
+
+```text
+score = relevance * emotion * repetitions * (1 / (1 + hours_ago))
+```
+
+Boundary coverage:
+
+```text
+relevant work episode: 0.8 * 0.7 * 1 * 0.5 = 0.28 -> consolidate
+medium-context episode: 0.5 * 0.5 * 1 * 0.5 = 0.125 -> archive-only
+routine noise: 0.1 * 0.05 * 1 * 0.5 = 0.0025 -> archive-only
+```
+
+## AC-2 VM Night-Run
+
+Controlled events consumed by the real daemon `EpisodeProducer`:
+
+```text
+fixture_correlation_id=issue-382-controlled-20260529T112955Z
+inserted_max_event_id=10725615
+episode_producer_offset_seen_after_seconds=22
+episode_producer_offset=10725668
+```
+
+Seeded events:
+
+```text
+10725613 AGENT-01 talk "konflikt deadline fehler escalation issue 382 controlled evidence"
+10725614 AGENT-02 talk "meeting konflikt problem deadline issue 382 controlled evidence"
+10725615 AGENT-03 move "routine hallway movement issue 382 low relevance control"
+```
+
+Operator trigger:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8084/operator/nightrun \
+  -H 'Content-Type: application/json' \
+  -d '{"dry_run":false}'
+```
+
+Response:
+
+```json
+{"accepted":true,"agents_queued":51,"message":"Nightrun-Konsolidierung gestartet"}
+```
+
+Completed event:
+
+```text
+new_nightrun_completed_id=10725673
+run_id=operator-tick-1467901-shift-1-to-1
+hash_chain=2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751
+total_episodes=3
+consolidated=2
+selection_rate=0.666666666666667
+threshold=0.25
+max_per_agent=10
+score_min=0.00491937687892867
+score_avg=0.36895326591965
+score_max=0.550970210440011
+duration_ms=196
+```
+
+Per-agent selection:
+
+```text
+AGENT-01 Thomas Mueller processed=1 consolidated=1 duration_ms=19
+AGENT-02 Lisa Brenner   processed=1 consolidated=1 duration_ms=8
+AGENT-03 Max Richter    processed=1 consolidated=0 duration_ms=8
+```
+
+Plausibility:
+
+```text
+Thomas/Lisa talk+conflict+deadline episodes scored ~0.551, above threshold 0.25, so they were consolidated.
+Max routine movement scored ~0.0049, below threshold 0.25, so it stayed archive-only.
+```
+
+System metrics captured during the VM run:
+
+```text
+vmstat_samples=23 avg_idle=99.48 avg_cpu_used=0.52
+mpstat_samples=22 avg_idle=99.34 avg_cpu_used=0.66
+iostat_device_samples=91 avg_util_pct=24.55
+```
+
+## AC-3 Replay
+
+Replay command:
+
+```bash
+cd /opt/sentinel
+/opt/sentinel/bin/sentinel-nightrun \
+  --config /opt/sentinel/config/nightrun.toml \
+  --replay-run-id operator-tick-1467901-shift-1-to-1 \
+  --expected-hash 2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751 \
+  --json
+```
+
+Replay output:
+
+```json
+{
+  "mode": "Replay",
+  "result": {
+    "run_id": "operator-tick-1467901-shift-1-to-1",
+    "events_loaded": 5,
+    "events_replayed": 4,
+    "hash_chain_valid": true,
+    "final_hash": "2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751",
+    "expected_hash": "2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751"
+  }
+}
+```
+
+## Test Gates
+
+Commands run before the VM deployment:
+
+```bash
+cargo fmt --check
+git diff --check
+cargo remote -c -- test -p sentinel-hippocampus --lib
+cargo remote -c -- test -p sentinel-hippocampus --test acceptance
+cargo remote -c -- test -p sentinel-common --lib
+cargo remote -c -- test -p sentinel-nightrun --lib
+cargo remote -c -- test -p sentinel-nightrun --test integration
+cargo remote -c -- test -p sentinel-daemon --lib
+cargo remote -c -- clippy -p sentinel-hippocampus --all-targets -- -D warnings
+cargo remote -c -- clippy -p sentinel-common --all-targets -- -D warnings
+cargo remote -c -- clippy -p sentinel-nightrun --all-targets -- -D warnings
+cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings
+```
+
+Results:
+
+```text
+sentinel-hippocampus --lib: 106 passed / 0 failed
+sentinel-hippocampus acceptance: 4 passed / 0 failed
+sentinel-common --lib: 52 passed / 0 failed
+sentinel-nightrun --lib: 37 passed / 0 failed
+sentinel-nightrun integration: 14 passed / 0 failed
+sentinel-daemon --lib: 204 passed / 0 failed
+all listed clippy gates: PASS
+cargo fmt --check: PASS
+git diff --check: PASS
+```
+
+Release build and deployed VM hashes:
+
+```text
+316344ee37ccbc33374058f5d08e86919bb6aa336a472d4c381234dc61e4c174  /opt/sentinel/bin/sentinel-daemon
+6c8ce99acb86cb00fa23152117171dcb11c5fbbe25b31fa7b9076ab9da73482d  /opt/sentinel/bin/sentinel-nightrun
+```
+
+## Notes
+
+- MainRag was unavailable during the run: `localhost:3001` connection refused.
+- The first post-deploy payload smoke run produced a valid `0/0` Night-Run with replay, but it was not used as AC-2 evidence because the queue was empty.
+- The final AC-2 evidence is the controlled-action VM run above: `2/3` consolidated with threshold/score proof and hash replay.


### PR DESCRIPTION
## Summary

Finalizes Issue #382 by replacing the open-ended NMDA "still tuning" state with a documented calibrated selection profile and measured Night-Run evidence on the Deploy-VM.

## Changes

- Added a centralized calibrated NMDA selection profile in `sentinel-hippocampus`:
  - consolidation threshold `0.25`
  - narrative inclusion threshold `0.25`
  - max selected episodes per agent `10`
  - explicit threshold rationale and boundary tests.
- Exposed NMDA selection-quality metrics in Night-Run result/event paths:
  - `total_episodes_consolidated`
  - selection rate
  - threshold and max-per-agent
  - score min/avg/max over all processed episodes, including rejected episodes.
- Extended daemon shift/operator Night-Run paths to persist replayable `nightrun_started`, `agent_consolidated`, and `nightrun_completed` evidence with hash-chain replay support.
- Updated `docs/togaf-gap-v22.md`, `CHANGELOG.md`, and added `test-382-verification.md` with command/output evidence.

## Linked Issues

Addresses #382

## Test Plan

```bash
cargo fmt --check
git diff --check
cargo remote -c -- test -p sentinel-hippocampus --lib
cargo remote -c -- test -p sentinel-hippocampus --test acceptance
cargo remote -c -- test -p sentinel-common --lib
cargo remote -c -- test -p sentinel-nightrun --lib
cargo remote -c -- test -p sentinel-nightrun --test integration
cargo remote -c -- test -p sentinel-daemon --lib
cargo remote -c -- clippy -p sentinel-hippocampus --all-targets -- -D warnings
cargo remote -c -- clippy -p sentinel-common --all-targets -- -D warnings
cargo remote -c -- clippy -p sentinel-nightrun --all-targets -- -D warnings
cargo remote -c -- clippy -p sentinel-daemon --all-targets -- -D warnings
```

Results:

```text
sentinel-hippocampus --lib: 106 passed / 0 failed
sentinel-hippocampus acceptance: 4 passed / 0 failed
sentinel-common --lib: 52 passed / 0 failed
sentinel-nightrun --lib: 37 passed / 0 failed
sentinel-nightrun integration: 14 passed / 0 failed
sentinel-daemon --lib: 204 passed / 0 failed
all listed clippy gates: PASS
cargo fmt --check: PASS
git diff --check: PASS
```

## Benchmarks

Deploy-VM evidence, not local and not cargo-remote runtime:

```text
Host: ubuntu@10.0.0.240
CPU: Intel i7-3930K @ 3.20 GHz (2011), 8 cores, 1 thread/core
Evidence dir: /tmp/issue-382-20260529T112955Z-controlled-actions
Services: sentinel-daemon=active, sentinel-projection=active, sentinel-gateway=inactive, time_scale = 1.0
Final Night-Run: operator-tick-1467901-shift-1-to-1
Episodes consolidated: 2/3
Selection rate: 0.666666666666667
Threshold: 0.25
Score range: 0.00491937687892867 .. 0.550970210440011
Replay: events_loaded=5, events_replayed=4, hash_chain_valid=true
Final hash: 2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751
System metrics: vmstat avg_cpu_used=0.52%, mpstat avg_cpu_used=0.66%, iostat avg_util_pct=24.55
```

Deployed VM binary hashes:

```text
316344ee37ccbc33374058f5d08e86919bb6aa336a472d4c381234dc61e4c174  /opt/sentinel/bin/sentinel-daemon
6c8ce99acb86cb00fa23152117171dcb11c5fbbe25b31fa7b9076ab9da73482d  /opt/sentinel/bin/sentinel-nightrun
```

## Evidence (AC Mapping)

| AC | Requirement | Evidence |
|---|---|---|
| AC-1 | Score thresholds are documented and justified, not "tuning" | `crates/sentinel-hippocampus/src/selection.rs` defines `NMDA_CONSOLIDATION_THRESHOLD=0.25`, narrative threshold `0.25`, max selected episodes `10`, and rationale. Boundary tests cover accept/reject behavior. |
| AC-2 | Real Night-Run measures X/Y consolidated episodes and plausibility | VM operator Night-Run `operator-tick-1467901-shift-1-to-1` consolidated `2/3`; high talk/conflict episodes scored `0.550970210440011` above `0.25`, routine movement scored `0.00491937687892867` below threshold. |
| AC-3 | Deterministic replay gives identical hash-chain | `/opt/sentinel/bin/sentinel-nightrun --config /opt/sentinel/config/nightrun.toml --replay-run-id operator-tick-1467901-shift-1-to-1 --expected-hash 2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751 --json` returned `hash_chain_valid=true`. |
| AC-4 | Gap-doc Cluster 02 updated with evidence | `docs/togaf-gap-v22.md` Cluster 02 Memory row now marks NMDA selection done and references `test-382-verification.md`. |

Replay output:

```json
{
  "mode": "Replay",
  "result": {
    "run_id": "operator-tick-1467901-shift-1-to-1",
    "events_loaded": 5,
    "events_replayed": 4,
    "hash_chain_valid": true,
    "final_hash": "2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751",
    "expected_hash": "2b41609c53b17955beb7bbfd1656b1f5aeac2e996933926d516a001d7fc23751"
  }
}
```

## Checklist

- [x] Issue #382 body includes Benchmark/Evidence section.
- [x] Issue #382 labels updated to `quality:ready` and `status:review`.
- [x] Gateway/cortex remained inactive during VM verification.
- [x] Systemd `ExecStart` checked before deployment.
- [x] VM evidence captured with `vmstat 1`, `mpstat 1`, and `iostat -x 1`.
- [x] `test-382-verification.md` is committed even though `test-*-verification.md` is ignored by default.
- [ ] Merge to `main` after required checks pass.
- [ ] Post-merge Deploy-VM smoke and `status:verified`/issue close.

