### PR TITLE
feat: Time-Travel Debugging UI im Dashboard (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added Issue #390 security threat model at `docs/security/threat-model.md`, covering compromised-agent, external-attacker, and supply-chain attacker classes with asset inventory and prioritized follow-up gaps.
 - Recorded Issue #396 Cluster 12 runtime-contract decision as DEV-006 in the Deviation Register: WASM/WASI on Wasmtime is the default Nano-Container contract, while native code is limited to an explicit Escape-Hatch-Pool.
+- Implemented Issue #384 Time-Travel Debugging UI (TOGAF Cluster 11): new dashboard "Zeitreise" view with a visual snapshot timeline (tier badge, timestamp, tick, size), point-in-time world-state preview (active agents from `tick_snapshot`, present agents and per-room occupancy derived from EventStore lifecycle replay up to the snapshot boundary via new `GET /api/control/snapshot-state`), and a hot-swap Restore flow with confirmation dialog. Fixed the broken `snapshot_restored` WebSocket handler (`loadAgents`/`loadRooms` ReferenceError) so the dashboard live-refreshes after a restore. Verified end to end on the Deploy-VM with Playwright (all five ACs).
 - Added `ebpf-mode-smoke` for focused kernel-mode/userspace-fallback runtime checks and committed Issue #380 dashboard screenshot evidence at `docs/screenshots/issue380-dashboard-ebpf.png`.
 - Added dashboard exposure for Issue #276 benchmark evidence at `/api/metrics/benchmarks`, including hardware scope, relative-only comparison notes, and system-metric log labels.
 

--- a/dashboard/public/css/style.css
+++ b/dashboard/public/css/style.css
@@ -1275,3 +1275,183 @@ main { padding: 2rem; }
   padding: 4px 10px;
   font-size: 0.75rem;
 }
+
+/* ── Time-Travel / Zeitreise View (#384) ── */
+.tt-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 0.5rem 0 1rem;
+  color: var(--text-primary);
+}
+.tt-subtitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+}
+.tt-actionbar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.tt-actionbar .control-input { max-width: 260px; }
+
+/* Visuelle Zeitachse */
+.tt-timeline-wrap {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+.tt-axis-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+.tt-rail {
+  position: relative;
+  height: 28px;
+  margin: 0.5rem 0 1rem;
+  background: linear-gradient(to right, var(--border), var(--border));
+  background-size: 100% 2px;
+  background-position: 0 center;
+  background-repeat: no-repeat;
+}
+.tt-marker {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-primary);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+.tt-marker:hover { transform: translateY(-50%) scale(1.35); }
+.tt-marker.selected {
+  transform: translateY(-50%) scale(1.5);
+  box-shadow: 0 0 0 3px var(--accent);
+  z-index: 2;
+}
+/* Tier-Farben fuer Marker und Legende-Dots */
+.tt-marker.tier-live, .tt-legend-dot.tier-live { background: #00ff9d; }
+.tt-marker.tier-hourly, .tt-legend-dot.tier-hourly { background: var(--accent); }
+.tt-marker.tier-daily, .tt-legend-dot.tier-daily { background: #6496ff; }
+.tt-marker.tier-weekly, .tt-legend-dot.tier-weekly { background: #c878ff; }
+.tt-marker.tier-monthly, .tt-legend-dot.tier-monthly { background: #ffb432; }
+.tt-legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+}
+.tt-legend-item { display: inline-flex; align-items: center; gap: 0.35rem; }
+.tt-legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+/* Split: Liste + Detail */
+.tt-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+@media (max-width: 900px) {
+  .tt-split { grid-template-columns: 1fr; }
+}
+.tt-list-row { cursor: pointer; }
+.tt-list-row:hover td { background: rgba(0, 255, 157, 0.06); }
+.tt-list-row.selected td {
+  background: rgba(0, 255, 157, 0.12);
+  border-left: 2px solid var(--accent);
+}
+
+.tt-detail-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+.tt-detail-hint, .tt-loading, .tt-empty {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+.tt-error { color: #ff6b6b; font-size: 0.85rem; }
+.tt-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.tt-detail-time { color: var(--text-secondary); font-size: 0.82rem; }
+.tt-meta-box { margin-bottom: 1rem; }
+.tt-meta-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  padding: 0.2rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.tt-meta-label { color: var(--text-secondary); }
+.tt-meta-value { color: var(--text-primary); font-family: 'JetBrains Mono', monospace; }
+.tt-stats-row {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+}
+.tt-stat {
+  flex: 1;
+  text-align: center;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+.tt-stat-num {
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+}
+.tt-stat-lbl { font-size: 0.72rem; color: var(--text-secondary); margin-top: 0.2rem; }
+.tt-note {
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+.tt-room-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin: 0.75rem 0 0.25rem;
+  color: var(--text-primary);
+}
+.tt-restore-btn {
+  margin-top: 1rem;
+  width: 100%;
+  background: rgba(255, 180, 50, 0.15);
+  border-color: #ffb432;
+  color: #ffb432;
+}
+.tt-restore-btn:hover:not(:disabled) {
+  background: rgba(255, 180, 50, 0.28);
+}
+.tt-restore-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.tt-feedback-slot {
+  margin-top: 0.75rem;
+  font-size: 0.82rem;
+  min-height: 1rem;
+}
+.tt-feedback-slot.success { color: var(--accent); }
+.tt-feedback-slot.error { color: #ff6b6b; }

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -21,6 +21,7 @@
       <button class="nav-btn" data-view="chat">Chat</button>
       <button class="nav-btn" data-view="metrics">Metriken</button>
       <button class="nav-btn" data-view="cockpit">Cockpit</button>
+      <button class="nav-btn" data-view="timetravel">Zeitreise</button>
       <button class="nav-btn" data-view="control">Control</button>
     </nav>
     <div id="projection-lag">Lag: --</div>
@@ -34,6 +35,7 @@
     <section id="view-chat" class="view"></section>
     <section id="view-metrics" class="view"></section>
     <section id="view-cockpit" class="view"></section>
+    <section id="view-timetravel" class="view"></section>
     <section id="view-control" class="view"></section>
   </main>
   <script type="module" src="/public/js/app.js"></script>

--- a/dashboard/public/js/app.js
+++ b/dashboard/public/js/app.js
@@ -7,6 +7,7 @@ import { renderCockpit, updateCockpit } from './cockpit.js';
 import { renderChaos, updateChaos } from './chaos.js';
 import { renderChat, initChat } from './chat.js';
 import { initControl } from './control.js';
+import { initTimeTravel, refreshTimeTravel } from './timetravel.js';
 
 let ws = null;
 
@@ -20,9 +21,13 @@ function initNavigation() {
       btn.classList.add('active');
 
       document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
-      const viewId = 'view-' + btn.getAttribute('data-view');
+      const viewName = btn.getAttribute('data-view');
+      const viewId = 'view-' + viewName;
       const view = document.getElementById(viewId);
       if (view) view.classList.add('active');
+
+      // Zeitreise-View bei Aktivierung mit frischer Snapshot-Liste laden
+      if (viewName === 'timetravel') refreshTimeTravel();
     });
   });
 }
@@ -32,6 +37,27 @@ function updateLagDisplay(lag) {
   if (!lagEl) return;
   lagEl.textContent = 'Lag: ' + lag;
   lagEl.className = lag > 100 ? 'lag-high' : lag > 10 ? 'lag-medium' : 'lag-ok';
+}
+
+// Nach Snapshot-Restore: World-State wurde ersetzt — Agents/Raeume aus REST
+// neu laden (Projection ist nach resetWatermarks frisch) und abhaengige Views
+// aktualisieren. (AC-4, #384)
+async function reloadAfterRestore() {
+  try {
+    const [agentsRes, roomsRes] = await Promise.all([
+      fetch('/api/agents'),
+      fetch('/api/rooms'),
+    ]);
+    if (agentsRes.ok) renderAgents(await agentsRes.json());
+    if (roomsRes.ok) {
+      renderFloorplan(await roomsRes.json());
+      refreshActiveRoomDetail();
+    }
+  } catch { /* ignore — naechster WS-Poll holt nach */ }
+  updateCockpit();
+  updateChaos();
+  updateActivity();
+  refreshTimeTravel();
 }
 
 function connectWebSocket() {
@@ -63,12 +89,8 @@ function connectWebSocket() {
       } else if (data.type === 'activity_update') {
         updateActivity();
       } else if (data.type === 'snapshot_restored') {
-        // Restore hat World-State ersetzt — alles neu laden
-        loadAgents();
-        loadRooms();
-        updateCockpit();
-        updateChaos();
-        updateActivity();
+        // Restore hat World-State ersetzt — Views aus REST neu laden (AC-4, #384)
+        reloadAfterRestore();
       }
     } catch { /* ignore parse errors */ }
   };
@@ -116,6 +138,9 @@ async function init() {
 
     // Control Panel async laden
     initControl();
+
+    // Zeitreise-View async laden
+    initTimeTravel();
 
     // Initiales Lag laden
     try {

--- a/dashboard/public/js/timetravel.js
+++ b/dashboard/public/js/timetravel.js
@@ -1,0 +1,474 @@
+// Zeitreise-View (Time-Travel Debugging UI, #384)
+// Visuelle Snapshot-Navigation entlang der Zeitachse + Welt-Zustand-Preview +
+// Hot-Swap-Restore via bestehende Operator-API.
+// KEIN innerHTML — ausschliesslich textContent + DOM-API.
+
+let snapshots = [];
+let selectedId = null;
+let loadError = false;
+
+const TIER_ORDER = ['live', 'hourly', 'daily', 'weekly', 'monthly'];
+
+// ── API-Key (geteilt mit Control-Tab via sessionStorage) ──
+
+function ttApiKey() {
+  return sessionStorage.getItem('sentinel_api_key') || '';
+}
+
+function ttAuthHeaders() {
+  const key = ttApiKey();
+  return key ? { 'Authorization': 'Bearer ' + key } : {};
+}
+
+// ── Helpers ──
+
+function ttEl(tag, className) {
+  const e = document.createElement(tag);
+  if (className) e.className = className;
+  return e;
+}
+
+function formatBytes(bytes) {
+  if (bytes == null) return '--';
+  if (bytes > 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+  if (bytes > 1024) return (bytes / 1024).toFixed(0) + ' KB';
+  return bytes + ' B';
+}
+
+function formatTime(ms) {
+  if (ms == null) return '--';
+  return new Date(ms).toLocaleString('de-DE');
+}
+
+// ── Daten laden ──
+
+async function loadSnapshotList() {
+  try {
+    const res = await fetch('/api/control/snapshots');
+    if (!res.ok) {
+      loadError = true;
+      return [];
+    }
+    const data = await res.json();
+    loadError = false;
+    return Array.isArray(data) ? data : [];
+  } catch (_) {
+    loadError = true;
+    return [];
+  }
+}
+
+async function loadSnapshotState(snapshotId) {
+  const res = await fetch(
+    '/api/control/snapshot-state?snapshot_id=' + encodeURIComponent(snapshotId),
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || ('HTTP ' + res.status));
+  }
+  return res.json();
+}
+
+// ── AC-1: Visuelle Zeitachse ──
+
+function renderTimeline(container) {
+  const wrap = ttEl('div', 'tt-timeline-wrap');
+
+  if (snapshots.length === 0) {
+    const empty = ttEl('div', 'tt-empty');
+    empty.textContent = loadError
+      ? 'Snapshots konnten nicht geladen werden (Operator-API nicht erreichbar)'
+      : 'Keine Snapshots vorhanden';
+    wrap.appendChild(empty);
+    container.appendChild(wrap);
+    return;
+  }
+
+  // Sortiert nach Zeit aufsteigend fuer Achsen-Positionierung
+  const sorted = snapshots.slice().sort((a, b) => a.created_at_ms - b.created_at_ms);
+  const minT = sorted[0].created_at_ms;
+  const maxT = sorted[sorted.length - 1].created_at_ms;
+  const span = maxT - minT;
+
+  // Achsen-Beschriftung
+  const axisLabels = ttEl('div', 'tt-axis-labels');
+  const leftLabel = ttEl('span', 'tt-axis-label');
+  leftLabel.textContent = formatTime(minT);
+  const rightLabel = ttEl('span', 'tt-axis-label');
+  rightLabel.textContent = formatTime(maxT);
+  axisLabels.appendChild(leftLabel);
+  axisLabels.appendChild(rightLabel);
+  wrap.appendChild(axisLabels);
+
+  // Rail mit Markern
+  const rail = ttEl('div', 'tt-rail');
+  sorted.forEach((snap, idx) => {
+    const pct = span > 0
+      ? ((snap.created_at_ms - minT) / span) * 100
+      : (sorted.length > 1 ? (idx / (sorted.length - 1)) * 100 : 50);
+    const marker = ttEl('button', 'tt-marker tier-' + snap.tier);
+    marker.style.left = 'calc(' + pct.toFixed(2) + '% - 7px)';
+    marker.setAttribute('data-snapshot-id', snap.id);
+    marker.setAttribute('aria-label',
+      snap.tier + ' Snapshot, Tick ' + snap.tick + ', ' + formatTime(snap.created_at_ms));
+    marker.title = snap.tier + ' | Tick ' + snap.tick + ' | ' + formatTime(snap.created_at_ms);
+    if (snap.id === selectedId) marker.classList.add('selected');
+    marker.addEventListener('click', () => selectSnapshot(snap.id));
+    rail.appendChild(marker);
+  });
+  wrap.appendChild(rail);
+
+  // Tier-Legende
+  const legend = ttEl('div', 'tt-legend');
+  TIER_ORDER.forEach((tier) => {
+    if (!snapshots.some((s) => s.tier === tier)) return;
+    const item = ttEl('span', 'tt-legend-item');
+    const dot = ttEl('span', 'tt-legend-dot tier-' + tier);
+    const txt = ttEl('span', 'tt-legend-text');
+    txt.textContent = tier;
+    item.appendChild(dot);
+    item.appendChild(txt);
+    legend.appendChild(item);
+  });
+  wrap.appendChild(legend);
+
+  container.appendChild(wrap);
+}
+
+// ── AC-1: Snapshot-Liste (chronologisch, auswaehlbar) ──
+
+function renderSnapshotList(container) {
+  if (snapshots.length === 0) return;
+
+  const section = ttEl('div', 'tt-list-section');
+  const title = ttEl('h3', 'tt-subtitle');
+  title.textContent = 'Snapshots (' + snapshots.length + ')';
+  section.appendChild(title);
+
+  const table = ttEl('table', 'snapshot-table');
+  const thead = ttEl('thead');
+  const headRow = ttEl('tr');
+  ['Tier', 'Zeitstempel', 'Tick', 'Sim Hour', 'Groesse'].forEach((text) => {
+    const th = ttEl('th');
+    th.textContent = text;
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = ttEl('tbody');
+  // Neueste zuerst
+  const sorted = snapshots.slice().sort((a, b) => b.created_at_ms - a.created_at_ms);
+  for (const snap of sorted) {
+    const row = ttEl('tr', 'tt-list-row');
+    row.setAttribute('data-snapshot-id', snap.id);
+    if (snap.id === selectedId) row.classList.add('selected');
+    row.addEventListener('click', () => selectSnapshot(snap.id));
+
+    const tdTier = ttEl('td');
+    const badge = ttEl('span', 'tier-badge tier-' + snap.tier);
+    badge.textContent = snap.tier;
+    tdTier.appendChild(badge);
+    row.appendChild(tdTier);
+
+    const tdTime = ttEl('td');
+    tdTime.textContent = formatTime(snap.created_at_ms);
+    row.appendChild(tdTime);
+
+    const tdTick = ttEl('td');
+    tdTick.textContent = String(snap.tick);
+    row.appendChild(tdTick);
+
+    const tdHour = ttEl('td');
+    tdHour.textContent = (snap.sim_hour || 0).toFixed(1) + 'h';
+    row.appendChild(tdHour);
+
+    const tdSize = ttEl('td');
+    tdSize.textContent = formatBytes(snap.payload_size_bytes);
+    row.appendChild(tdSize);
+
+    tbody.appendChild(row);
+  }
+  table.appendChild(tbody);
+  section.appendChild(table);
+  container.appendChild(section);
+}
+
+// ── AC-2 + AC-3: Detail-Panel mit Welt-Zustand + Restore ──
+
+async function renderDetailPanel(container) {
+  const panel = ttEl('div', 'tt-detail-panel');
+  panel.id = 'tt-detail-panel';
+
+  if (!selectedId) {
+    const hint = ttEl('div', 'tt-detail-hint');
+    hint.textContent = 'Snapshot auf der Zeitachse oder in der Liste auswaehlen, um den Welt-Zustand zu diesem Zeitpunkt anzuzeigen.';
+    panel.appendChild(hint);
+    container.appendChild(panel);
+    return;
+  }
+
+  const snap = snapshots.find((s) => s.id === selectedId);
+  const title = ttEl('h3', 'tt-subtitle');
+  title.textContent = 'Welt-Zustand zum Snapshot-Zeitpunkt';
+  panel.appendChild(title);
+
+  const loading = ttEl('div', 'tt-loading');
+  loading.textContent = 'Lade Welt-Zustand...';
+  panel.appendChild(loading);
+  container.appendChild(panel);
+
+  let state;
+  try {
+    state = await loadSnapshotState(selectedId);
+  } catch (e) {
+    loading.textContent = 'Fehler: ' + e.message;
+    loading.className = 'tt-error';
+    return;
+  }
+
+  // Nur rendern, wenn die Auswahl waehrenddessen nicht gewechselt hat
+  if (selectedId !== state.snapshot_id) return;
+  panel.removeChild(loading);
+
+  // Kopfzeile: Tier + Zeit
+  const header = ttEl('div', 'tt-detail-header');
+  const badge = ttEl('span', 'tier-badge tier-' + state.tier);
+  badge.textContent = state.tier;
+  header.appendChild(badge);
+  const when = ttEl('span', 'tt-detail-time');
+  when.textContent = formatTime(state.created_at_ms);
+  header.appendChild(when);
+  panel.appendChild(header);
+
+  // Kennzahlen
+  const metaRows = [
+    ['Tick', String(state.tick)],
+    ['Sim Hour', (state.sim_hour || 0).toFixed(2) + 'h'],
+    ['Last Event ID', String(state.last_event_id)],
+    ['Groesse', formatBytes(snap ? snap.payload_size_bytes : null)],
+  ];
+  const metaBox = ttEl('div', 'tt-meta-box');
+  for (const [label, value] of metaRows) {
+    const r = ttEl('div', 'tt-meta-row');
+    const l = ttEl('span', 'tt-meta-label');
+    l.textContent = label + ':';
+    const v = ttEl('span', 'tt-meta-value');
+    v.textContent = value;
+    r.appendChild(l);
+    r.appendChild(v);
+    metaBox.appendChild(r);
+  }
+  panel.appendChild(metaBox);
+
+  // Welt-Zustand-Counts (AC-2): aktive Agents (authoritative) + belegte Raeume
+  const stats = ttEl('div', 'tt-stats-row');
+
+  const agentStat = ttEl('div', 'tt-stat');
+  const agentNum = ttEl('div', 'tt-stat-num');
+  agentNum.textContent = state.active_agent_count != null
+    ? String(state.active_agent_count)
+    : String(state.present_agent_count);
+  const agentLbl = ttEl('div', 'tt-stat-lbl');
+  agentLbl.textContent = state.active_agent_count != null ? 'aktive Agents' : 'Agents';
+  agentStat.appendChild(agentNum);
+  agentStat.appendChild(agentLbl);
+  stats.appendChild(agentStat);
+
+  const presentStat = ttEl('div', 'tt-stat');
+  const presentNum = ttEl('div', 'tt-stat-num');
+  presentNum.textContent = String(state.present_agent_count);
+  const presentLbl = ttEl('div', 'tt-stat-lbl');
+  presentLbl.textContent = 'im Gebaeude';
+  presentStat.appendChild(presentNum);
+  presentStat.appendChild(presentLbl);
+  stats.appendChild(presentStat);
+
+  const roomStat = ttEl('div', 'tt-stat');
+  const roomNum = ttEl('div', 'tt-stat-num');
+  roomNum.textContent = String(state.room_count);
+  const roomLbl = ttEl('div', 'tt-stat-lbl');
+  roomLbl.textContent = 'belegte Raeume';
+  roomStat.appendChild(roomNum);
+  roomStat.appendChild(roomLbl);
+  stats.appendChild(roomStat);
+  panel.appendChild(stats);
+
+  const note = ttEl('div', 'tt-note');
+  note.textContent = '"aktive Agents" = schicht-aktive Agents zu diesem Tick (tick_snapshot, ' +
+    'deckt sich mit der Live-Ansicht). "im Gebaeude" = alle anwesenden Agents inkl. ' +
+    'Off-Shift, abgeleitet aus den Lifecycle-Events bis zur Snapshot-Grenze.';
+  panel.appendChild(note);
+
+  // Pro-Raum-Belegung der anwesenden Agents
+  if (state.rooms && state.rooms.length > 0) {
+    const roomTitle = ttEl('div', 'tt-room-title');
+    roomTitle.textContent = 'Raum-Belegung (anwesende Agents)';
+    panel.appendChild(roomTitle);
+
+    const roomTable = ttEl('table', 'snapshot-table');
+    const rt = ttEl('tbody');
+    for (const room of state.rooms) {
+      const tr = ttEl('tr');
+      const tdName = ttEl('td');
+      tdName.textContent = room.name;
+      const tdCount = ttEl('td');
+      tdCount.textContent = String(room.occupant_count);
+      tr.appendChild(tdName);
+      tr.appendChild(tdCount);
+      rt.appendChild(tr);
+    }
+    roomTable.appendChild(rt);
+    panel.appendChild(roomTable);
+  }
+
+  // AC-3: Restore-Button mit Confirm-Dialog
+  const restoreBtn = ttEl('button', 'control-btn tt-restore-btn');
+  restoreBtn.textContent = 'Auf diesen Snapshot zuruecksetzen (Restore)';
+  restoreBtn.setAttribute('data-snapshot-id', state.snapshot_id);
+  restoreBtn.addEventListener('click', () => triggerRestore(state, panel, restoreBtn));
+  panel.appendChild(restoreBtn);
+
+  const feedbackSlot = ttEl('div', 'tt-feedback-slot');
+  feedbackSlot.id = 'tt-feedback-slot';
+  panel.appendChild(feedbackSlot);
+}
+
+async function triggerRestore(state, panel, btn) {
+  const ok = confirm(
+    'Hot-Swap-Restore ausfuehren?\n\n' +
+    'Die laufende Simulation wird auf diesen Snapshot zurueckgesetzt:\n' +
+    'Tier: ' + state.tier + '\n' +
+    'Tick: ' + state.tick + '\n' +
+    'Zeit: ' + formatTime(state.created_at_ms) + '\n' +
+    'Aktive Agents: ' + (state.active_agent_count != null ? state.active_agent_count : state.present_agent_count) +
+    ' | belegte Raeume: ' + state.room_count + '\n\n' +
+    'Snapshot-ID: ' + state.snapshot_id,
+  );
+  if (!ok) return;
+
+  btn.disabled = true;
+  btn.textContent = 'Restore laeuft...';
+  const slot = panel.querySelector('#tt-feedback-slot');
+  try {
+    const res = await fetch('/api/control/restore', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, ttAuthHeaders()),
+      body: JSON.stringify({ snapshot_id: state.snapshot_id }),
+    });
+    if (res.ok) {
+      if (slot) {
+        slot.textContent = 'Restore erfolgreich ausgeloest — Dashboard aktualisiert sich live.';
+        slot.className = 'tt-feedback-slot success';
+      }
+    } else {
+      const err = await res.json().catch(() => ({}));
+      const msg = res.status === 401
+        ? 'Nicht autorisiert — API-Key im Control-Tab oder unten eingeben.'
+        : ('Fehler: ' + (err.error || res.statusText));
+      if (slot) {
+        slot.textContent = msg;
+        slot.className = 'tt-feedback-slot error';
+      }
+    }
+  } catch (e) {
+    if (slot) {
+      slot.textContent = 'Verbindungsfehler: ' + e.message;
+      slot.className = 'tt-feedback-slot error';
+    }
+  }
+  btn.disabled = false;
+  btn.textContent = 'Auf diesen Snapshot zuruecksetzen (Restore)';
+}
+
+// ── Auswahl wechseln ──
+
+function selectSnapshot(id) {
+  selectedId = id;
+  renderTimeTravel();
+}
+
+// ── Aktionsleiste (API-Key + Snapshot erstellen) ──
+
+function renderActionBar(container) {
+  const bar = ttEl('div', 'tt-actionbar');
+
+  const keyInput = document.createElement('input');
+  keyInput.type = 'password';
+  keyInput.id = 'tt-api-key-input';
+  keyInput.className = 'control-input';
+  keyInput.placeholder = 'API-Key (fuer Restore)';
+  keyInput.value = ttApiKey();
+  keyInput.addEventListener('change', () => {
+    sessionStorage.setItem('sentinel_api_key', keyInput.value);
+  });
+  bar.appendChild(keyInput);
+
+  const createBtn = ttEl('button', 'control-btn');
+  createBtn.id = 'tt-create-btn';
+  createBtn.textContent = 'Jetzt Snapshot erstellen';
+  createBtn.addEventListener('click', async () => {
+    createBtn.disabled = true;
+    createBtn.textContent = 'Erstelle...';
+    try {
+      await fetch('/api/control/snapshot', {
+        method: 'POST',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, ttAuthHeaders()),
+        body: '{}',
+      });
+      await refreshTimeTravel();
+    } catch (_) { /* ignore */ }
+    createBtn.disabled = false;
+    createBtn.textContent = 'Jetzt Snapshot erstellen';
+  });
+  bar.appendChild(createBtn);
+
+  const refreshBtn = ttEl('button', 'control-btn');
+  refreshBtn.id = 'tt-refresh-btn';
+  refreshBtn.textContent = 'Aktualisieren';
+  refreshBtn.addEventListener('click', refreshTimeTravel);
+  bar.appendChild(refreshBtn);
+
+  container.appendChild(bar);
+}
+
+// ── Haupt-Render ──
+
+function renderTimeTravel() {
+  const container = document.getElementById('view-timetravel');
+  if (!container) return;
+  container.textContent = '';
+
+  const title = ttEl('h2', 'tt-title');
+  title.textContent = 'Time Machine — Zeitreise & Restore';
+  container.appendChild(title);
+
+  renderActionBar(container);
+  renderTimeline(container);
+
+  const split = ttEl('div', 'tt-split');
+  const listCol = ttEl('div', 'tt-list-col');
+  renderSnapshotList(listCol);
+  split.appendChild(listCol);
+
+  const detailCol = ttEl('div', 'tt-detail-col');
+  renderDetailPanel(detailCol);
+  split.appendChild(detailCol);
+
+  container.appendChild(split);
+}
+
+async function refreshTimeTravel() {
+  snapshots = await loadSnapshotList();
+  // Auswahl beibehalten, falls Snapshot noch existiert
+  if (selectedId && !snapshots.some((s) => s.id === selectedId)) {
+    selectedId = null;
+  }
+  renderTimeTravel();
+}
+
+async function initTimeTravel() {
+  await refreshTimeTravel();
+}
+
+export { initTimeTravel, refreshTimeTravel };

--- a/dashboard/src/__tests__/control.test.ts
+++ b/dashboard/src/__tests__/control.test.ts
@@ -413,4 +413,111 @@ describe("Control Routes", () => {
       expect(body.accepted).toBe(true);
     });
   });
+
+  describe("GET /api/control/snapshot-state (#384)", () => {
+    function buildEventStore(): Database {
+      const esDb = new Database(":memory:");
+      esDb.exec(`
+        CREATE TABLE events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          event_id TEXT NOT NULL UNIQUE,
+          event_type TEXT NOT NULL,
+          aggregate_id TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          correlation_id TEXT NOT NULL DEFAULT '',
+          causation_id TEXT,
+          tick INTEGER NOT NULL DEFAULT 0,
+          timestamp_ms INTEGER NOT NULL
+        );
+        CREATE TABLE world_snapshots (
+          id TEXT PRIMARY KEY,
+          tier TEXT NOT NULL,
+          tick INTEGER NOT NULL,
+          sim_hour REAL NOT NULL,
+          last_event_id INTEGER NOT NULL,
+          payload_size INTEGER NOT NULL DEFAULT 0,
+          payload BLOB NOT NULL,
+          created_at INTEGER NOT NULL
+        );
+      `);
+      const ins = esDb.prepare(
+        `INSERT INTO events (event_id, event_type, aggregate_id, payload, tick, timestamp_ms)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      );
+      // id 1..7 — Lifecycle/Transit-Verlauf bis tick 100
+      ins.run("e1", "agent_spawned", "AGENT-01", '{"agent_id":1,"room_id":"buero-dev-1"}', 10, 1000);
+      ins.run("e2", "agent_spawned", "AGENT-02", '{"agent_id":2,"room_id":"buero-dev-1"}', 11, 1100);
+      ins.run("e3", "agent_spawned", "AGENT-03", '{"agent_id":3,"room_id":"kueche"}', 12, 1200);
+      ins.run("e4", "tick_snapshot", "world", '{"type":"TickSnapshot","tick":50,"agent_count":3}', 50, 1300);
+      ins.run("e5", "transit_completed", "AGENT-02", '{"agent_id":2,"room_id":"kueche"}', 60, 1400);
+      ins.run("e6", "agent_despawned", "AGENT-03", '{"agent_id":3,"reason":"shift_end"}', 70, 1500);
+      // id 7: nach der Snapshot-Grenze (last_event_id=6) — darf NICHT zaehlen
+      ins.run("e7", "agent_spawned", "AGENT-04", '{"agent_id":4,"room_id":"empfang"}', 90, 1600);
+
+      // Snapshot mit Grenze last_event_id=6, tick=80
+      esDb
+        .prepare(
+          `INSERT INTO world_snapshots (id, tier, tick, sim_hour, last_event_id, payload_size, payload, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("snap-1", "hourly", 80, 13.5, 6, 4096, Buffer.from([0]), 1_700_000_000_000);
+      return esDb;
+    }
+
+    it("derives agent and room counts at the snapshot boundary", async () => {
+      const projDb = new Database(":memory:");
+      const esDb = buildEventStore();
+      setDatabases(projDb, esDb);
+      try {
+        const res = await app.request("/api/control/snapshot-state?snapshot_id=snap-1");
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.snapshot_id).toBe("snap-1");
+        expect(body.tier).toBe("hourly");
+        expect(body.tick).toBe(80);
+        // AGENT-01 (dev-1), AGENT-02 (in kueche nach transit), AGENT-03 despawned,
+        // AGENT-04 liegt hinter der Grenze (id 7 > 6) -> 2 anwesende Agents.
+        expect(body.present_agent_count).toBe(2);
+        // Belegte Raeume: buero-dev-1 (1) + kueche (1) = 2
+        expect(body.room_count).toBe(2);
+        // tick_snapshot (tick 50 <= 80) meldete 3 aktive Agents
+        expect(body.active_agent_count).toBe(3);
+        const dev1 = body.rooms.find((r: { room_id: string }) => r.room_id === "buero-dev-1");
+        const kueche = body.rooms.find((r: { room_id: string }) => r.room_id === "kueche");
+        expect(dev1.occupant_count).toBe(1);
+        expect(kueche.occupant_count).toBe(1);
+        // Raum-Name aus ROOM_METADATA aufgeloest
+        expect(kueche.name).toBe("Küche / Pausenraum");
+      } finally {
+        projDb.close();
+        esDb.close();
+      }
+    });
+
+    it("returns 404 for unknown snapshot id", async () => {
+      const projDb = new Database(":memory:");
+      const esDb = buildEventStore();
+      setDatabases(projDb, esDb);
+      try {
+        const res = await app.request("/api/control/snapshot-state?snapshot_id=nope");
+        expect(res.status).toBe(404);
+      } finally {
+        projDb.close();
+        esDb.close();
+      }
+    });
+
+    it("returns 400 when snapshot_id is missing", async () => {
+      const projDb = new Database(":memory:");
+      const esDb = buildEventStore();
+      setDatabases(projDb, esDb);
+      try {
+        const res = await app.request("/api/control/snapshot-state");
+        expect(res.status).toBe(400);
+      } finally {
+        projDb.close();
+        esDb.close();
+      }
+    });
+  });
 });

--- a/dashboard/src/db.ts
+++ b/dashboard/src/db.ts
@@ -14,7 +14,9 @@ import type {
   RoomPhysicsHistoryPoint,
   RoomReactionItem,
   RoomStimulusHistoryItem,
+  SnapshotWorldState,
 } from "./types";
+import { ROOM_METADATA } from "./rooms-meta";
 
 let projectionDb: Database;
 let eventStoreDb: Database;
@@ -1212,4 +1214,115 @@ export function getEventRatePerMinute(): number {
     )
     .get(fiveMinAgo);
   return Math.round(((row?.cnt ?? 0) / 5) * 10) / 10;
+}
+
+// ── Time Machine: Welt-Zustand zum Snapshot-Zeitpunkt (#384) ──
+// Leitet Agent- und Raum-Belegung zum Snapshot-Zeitpunkt aus dem EventStore ab.
+// Kein Payload-Decode (Payload ist bincode-2 BLOB) — stattdessen deterministischer
+// Replay der Lifecycle-/Transit-Events bis zur Snapshot-Grenze `last_event_id`.
+
+interface SnapshotMetaRow {
+  id: string;
+  tier: string;
+  tick: number;
+  sim_hour: number;
+  last_event_id: number;
+  payload_size: number;
+  created_at: number;
+}
+
+/// Berechnet den Welt-Zustand eines Snapshots oder null, wenn kein Snapshot
+/// mit dieser ID existiert.
+export function getSnapshotWorldState(
+  snapshotId: string,
+): SnapshotWorldState | null {
+  const meta = eventStoreDb
+    .query<SnapshotMetaRow, [string]>(
+      `SELECT id, tier, tick, sim_hour, last_event_id, payload_size, created_at
+       FROM world_snapshots
+       WHERE id = ?`,
+    )
+    .get(snapshotId);
+
+  if (!meta) return null;
+
+  // Lifecycle-/Transit-Events bis zur Snapshot-Grenze in chronologischer
+  // Reihenfolge replayen. Nur drei Event-Typen sind relevant (Index: idx_events_type).
+  const rows = eventStoreDb
+    .query<{ event_type: string; payload: string }, [number]>(
+      `SELECT event_type, payload
+       FROM events
+       WHERE id <= ?
+         AND event_type IN ('agent_spawned', 'transit_completed', 'agent_despawned')
+       ORDER BY id ASC`,
+    )
+    .all(meta.last_event_id);
+
+  // agent_id -> aktueller room_id (nur lebende Agents enthalten)
+  const agentRoom = new Map<number, string>();
+  for (const row of rows) {
+    let payload: { agent_id?: number; room_id?: string };
+    try {
+      payload = JSON.parse(row.payload);
+    } catch {
+      continue;
+    }
+    if (typeof payload.agent_id !== "number") continue;
+
+    if (row.event_type === "agent_despawned") {
+      agentRoom.delete(payload.agent_id);
+    } else if (typeof payload.room_id === "string") {
+      // agent_spawned + transit_completed tragen beide room_id
+      agentRoom.set(payload.agent_id, payload.room_id);
+    }
+  }
+
+  // Pro-Raum-Belegung aggregieren
+  const roomCounts = new Map<string, number>();
+  for (const roomId of agentRoom.values()) {
+    roomCounts.set(roomId, (roomCounts.get(roomId) ?? 0) + 1);
+  }
+
+  const rooms = Array.from(roomCounts.entries())
+    .map(([roomId, count]) => ({
+      room_id: roomId,
+      name: ROOM_METADATA[roomId]?.name ?? roomId,
+      occupant_count: count,
+    }))
+    .sort((a, b) => b.occupant_count - a.occupant_count);
+
+  // Authoritative Anzahl der schicht-aktiven Agents aus dem naechsten
+  // tick_snapshot-Event bei/vor tick (deckt sich mit der Live-Agents-View).
+  const tickSnap = eventStoreDb
+    .query<{ payload: string }, [number]>(
+      `SELECT payload
+       FROM events
+       WHERE event_type = 'tick_snapshot' AND tick <= ?
+       ORDER BY tick DESC
+       LIMIT 1`,
+    )
+    .get(meta.tick);
+
+  let activeAgentCount: number | null = null;
+  if (tickSnap) {
+    try {
+      const p = JSON.parse(tickSnap.payload) as { agent_count?: number };
+      if (typeof p.agent_count === "number") activeAgentCount = p.agent_count;
+    } catch {
+      // ignore malformed payload
+    }
+  }
+
+  return {
+    snapshot_id: meta.id,
+    tier: meta.tier,
+    tick: meta.tick,
+    sim_hour: meta.sim_hour,
+    last_event_id: meta.last_event_id,
+    created_at_ms: meta.created_at,
+    active_agent_count: activeAgentCount,
+    present_agent_count: agentRoom.size,
+    room_count: roomCounts.size,
+    rooms,
+  };
 }

--- a/dashboard/src/routes/control.ts
+++ b/dashboard/src/routes/control.ts
@@ -4,7 +4,7 @@
 
 import { Hono } from "hono";
 import { requireAuth } from "../middleware/auth";
-import { getRecentPlatformAnalyses, resetCaches } from "../db";
+import { getRecentPlatformAnalyses, getSnapshotWorldState, resetCaches } from "../db";
 import { resetWatermarks, broadcast } from "../ws";
 
 export const controlRoutes = new Hono();
@@ -281,6 +281,27 @@ controlRoutes.post("/control/snapshot", async (c) => {
     );
   } catch (err) {
     return c.json({ error: "Operator-API nicht erreichbar", detail: String(err) }, 502);
+  }
+});
+
+// ── GET /api/control/snapshot-state — Welt-Zustand zum Snapshot-Zeitpunkt (#384) ──
+// Liest den EventStore lokal (kein Proxy) und leitet Agent-/Raum-Counts ab.
+controlRoutes.get("/control/snapshot-state", (c) => {
+  const snapshotId = c.req.query("snapshot_id");
+  if (!snapshotId) {
+    return c.json({ error: "snapshot_id Query-Parameter erforderlich" }, 400);
+  }
+  try {
+    const state = getSnapshotWorldState(snapshotId);
+    if (!state) {
+      return c.json({ error: "Snapshot nicht gefunden" }, 404);
+    }
+    return c.json(state);
+  } catch (err) {
+    return c.json(
+      { error: "Snapshot-Zustand nicht abrufbar", detail: String(err) },
+      500,
+    );
   }
 });
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -286,6 +286,37 @@ export interface EventRow {
   compensation_type: string;
 }
 
+// ── Time Machine: Snapshot World State (#384) ─────
+
+/// Belegung eines einzelnen Raums zum Snapshot-Zeitpunkt.
+export interface SnapshotRoomOccupancy {
+  room_id: string;
+  name: string;
+  occupant_count: number;
+}
+
+/// Aus dem EventStore abgeleiteter Welt-Zustand zum Zeitpunkt eines Snapshots.
+/// Wird durch Event-Replay bis `last_event_id` berechnet (kein Payload-Decode).
+export interface SnapshotWorldState {
+  snapshot_id: string;
+  tier: string;
+  tick: number;
+  sim_hour: number;
+  last_event_id: number;
+  created_at_ms: number;
+  /// Authoritative Anzahl der zur Schicht AKTIVEN Agents aus dem naechsten
+  /// tick_snapshot-Event bei/vor `tick` (deckt sich mit der Live-Agents-View).
+  /// null, wenn kein tick_snapshot-Event bis zu diesem Tick existiert.
+  active_agent_count: number | null;
+  /// Anzahl der im Gebaeude ANWESENDEN Agents (spawned, nicht despawned bis
+  /// `last_event_id`) — inkl. Off-Shift-Agents. Basis fuer die Raum-Belegung.
+  present_agent_count: number;
+  /// Anzahl zum Zeitpunkt belegter Raeume (aus anwesenden Agents).
+  room_count: number;
+  /// Pro-Raum-Belegung der anwesenden Agents, absteigend nach Belegung sortiert.
+  rooms: SnapshotRoomOccupancy[];
+}
+
 // ── Personality Evolution Row ─────────────────────
 
 export interface EvolutionRow {

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -139,7 +139,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | Hot-swap restore              | ✅ | `services/sentinel-daemon/src/runtime_health.rs` (snapshot reload path) |
 | Deterministic replay          | ✅ | `services/sentinel-nightrun/` |
 | Non-blocking evolution LLM (#278) | 🟡 | Async `evolution_task` moves nightrun/shift LLM calls out of the ECS tick loop; Deploy-VM nightrun returned in 0.669 ms and gateway-down shift jobs failed safe, but total shift transition measured ~1.455 s on the i7-3930K VM, above the strict `<1s` AC target due remaining Hippocampus/sandbox work |
-| Time-travel debugging UI      | ⏳ | dashboard hook designed, frontend deferred |
+| Time-travel debugging UI      | ✅ | Issue #384: dashboard "Zeitreise" view — visual snapshot timeline, point-in-time world-state preview (`GET /api/control/snapshot-state`), hot-swap restore with confirm + live WebSocket refresh; Deploy-VM Playwright evidence in `test-384-verification.md` |
 
 ## Cluster 12 — Zielarchitektur / Nano-Container Platform
 

--- a/test-384-verification.md
+++ b/test-384-verification.md
@@ -1,0 +1,159 @@
+# Verifikations-Report — Issue #384: Time-Travel Debugging UI
+
+**Issue:** #384 — Time-Travel Debugging UI: Snapshot-Navigation + Restore-Flow im Dashboard (TOGAF Cluster 11)
+**Branch:** `feat/issue-384-timetravel-ui`
+**Datum:** 2026-05-29
+**Scope:** Reine Frontend-/Dashboard-Arbeit (`dashboard/`). Backend (WorldSnapshot,
+Hot-Swap-Restore, Tiered Retention) existiert bereits und wurde nicht angefasst.
+
+## Zusammenfassung der Aenderungen
+
+| Datei | Aenderung |
+|-------|-----------|
+| `dashboard/src/types.ts` | Typen `SnapshotWorldState`, `SnapshotRoomOccupancy` |
+| `dashboard/src/db.ts` | `getSnapshotWorldState()` — Welt-Zustand per Event-Replay bis `last_event_id` |
+| `dashboard/src/routes/control.ts` | `GET /api/control/snapshot-state` |
+| `dashboard/public/js/timetravel.js` | **NEU** — Zeitreise-View: Timeline, Welt-Zustand, Restore |
+| `dashboard/public/index.html` | Nav-Button + `<section id="view-timetravel">` |
+| `dashboard/public/js/app.js` | Wiring + Fix des kaputten `snapshot_restored`-Handlers (AC-4) |
+| `dashboard/public/css/style.css` | Timeline-/Detail-Panel-Styles |
+| `dashboard/src/__tests__/control.test.ts` | 3 Tests fuer `snapshot-state` |
+
+## Statische Verifikation
+
+```
+$ bun run typecheck     → tsc --noEmit, EXIT 0 (keine Fehler)
+$ bun test              → 78 pass, 0 fail, 673 expect() calls (11 Dateien)
+```
+Auf der Deploy-VM nach Deploy ebenfalls `bun run typecheck` → EXIT 0.
+
+## Architektur-Entscheidung AC-2 (Welt-Zustand-Ableitung)
+
+`SnapshotMeta` (das Snapshot-Listing) traegt **keine** Agent-/Raum-Counts, und der
+Snapshot-Payload ist ein bincode-2-BLOB (in Bun nicht dekodierbar). Daher wird der
+Welt-Zustand zum Snapshot-Zeitpunkt **deterministisch aus dem EventStore abgeleitet**
+(den das Dashboard ohnehin read-only liest) — kein neuer Rust-Endpoint, kein Gateway,
+kein LLM-Call (token-safe):
+
+- **`active_agent_count`** = `agent_count` aus dem naechsten `tick_snapshot`-Event
+  bei/vor `tick`. Authoritativ und deckungsgleich mit der Live-Agents-View.
+- **`present_agent_count`** + **Raum-Belegung** = Replay der `agent_spawned` /
+  `transit_completed` / `agent_despawned`-Events bis `last_event_id` (Agents im
+  Gebaeude inkl. Off-Shift, mit ihrem zuletzt bekannten Raum).
+
+---
+
+## Acceptance Criteria — Evidence
+
+### AC-1: UI listet Snapshots mit Tier-Badge, Zeitstempel, Tick, Groesse entlang einer Zeitachse
+
+**Status: PASS**
+
+API-Beleg (echte VM-Daten):
+```
+$ curl -s http://10.0.0.240:8000/api/control/snapshots
+[{"id":"019e7409-...","tier":"hourly","tick":1476529,"sim_hour":21.745188,
+  "payload_size_bytes":566324,"created_at_ms":1780063232607}, ... 59 Snapshots]
+```
+Playwright-Screenshot `issue384-ac1-timeline.png`: visuelle Zeitachse mit
+Achsen-Labels (17.3.2026 → 29.5.2026), tier-codierten Markern (hourly gruen,
+monthly orange), Legende, sowie Snapshot-Liste (59) mit Spalten Tier-Badge,
+Zeitstempel, Tick, Sim Hour, Groesse.
+
+### AC-2: Auswahl eines Snapshots zeigt den Welt-Zustand (Agent-/Raum-Counts) dieses Zeitpunkts
+
+**Status: PASS**
+
+API-Beleg (Snapshot tick 1476529):
+```
+$ curl -s "http://10.0.0.240:8000/api/control/snapshot-state?snapshot_id=019e7409-625d-7703-95eb-2bee0815a7c3"
+{"snapshot_id":"019e7409-...","tier":"hourly","tick":1476529,"last_event_id":10735662,
+ "active_agent_count":26,"present_agent_count":43,"room_count":12,
+ "rooms":[{"room_id":"buero-dev-1","name":"Entwicklungsbüro 1","occupant_count":9}, ...]}
+```
+Konsistenz-Check: `active_agent_count` (26) == Live-`/api/agents` aktive Agents (26).
+Summe der Raum-Belegung (9+6+6+4+3+3+3+2+2+2+2+1) == `present_agent_count` (43).
+
+Unit-Test `control.test.ts` "derives agent and room counts at the snapshot boundary":
+verifiziert Replay-Grenze (`last_event_id`), Despawn-Handling, Events hinter der
+Grenze werden ignoriert, Raum-Namen-Aufloesung. PASS.
+
+Playwright-Screenshots `issue384-ac2-worldstate.png` (26 aktive / 43 im Gebaeude /
+12 belegte Raeume + Meta) und `issue384-ac2-rooms.png` (Pro-Raum-Belegung mit
+Umlaut-korrekten Raum-Namen + Restore-Button).
+
+### AC-3: Restore-Button loest Hot-Swap-Restore via bestehende API aus (mit Confirm-Dialog)
+
+**Status: PASS**
+
+Confirm-Dialog beim Klick verifiziert (Playwright: Klick → Dialog erscheint →
+`dialog-dismiss` bricht ab, kein Restore). Anschliessend Restore ausgeloest;
+Daemon-Journal (10.0.0.240) bestaetigt den vollen Hot-Swap-Pfad ueber die
+bestehende Operator-API:
+```
+INFO sentinel_daemon::operator_api: Restore via Operator-API angefordert snapshot_id=019e7409-...
+INFO sentinel_daemon::orchestrator: Hot-Swap Restore gestartet snapshot_id=019e7409-...
+INFO sentinel_daemon::orchestrator: Pre-Restore Snapshot erstellt (Rollback-Punkt) snapshot_id=019e7442-...
+INFO sentinel_daemon::orchestrator: Agent-Prozesse fuer Restore terminiert terminated=26
+INFO sentinel_daemon::orchestrator: Projection Snapshot-Seeding abgeschlossen agents_seeded=26 rooms_seeded=11
+INFO sentinel_daemon::orchestrator: Hot-Swap Restore abgeschlossen snapshot_id=019e7409-... tick=1476529 agents=26
+```
+Restore ist reversibel — der Daemon erstellt automatisch einen Pre-Restore-Rollback-Snapshot.
+
+### AC-4: Nach Restore aktualisiert sich das Dashboard live (WebSocket Event)
+
+**Status: PASS**
+
+Latenter Bug gefixt: der bisherige `snapshot_restored`-Handler in `app.js` rief
+undefinierte Funktionen `loadAgents()`/`loadRooms()` auf (ReferenceError) — ersetzt
+durch `reloadAfterRestore()` (Fetch `/api/agents` + `/api/rooms`, Re-Render).
+
+Runtime-Beleg via Spy-WebSocket auf `/ws` (Playwright `eval`): nach Restore
+empfangene Frame-Sequenz:
+```
+["health_update","snapshot_restored","agent_update","room_update",
+ "cockpit_update","chaos_update","activity_update"]
+```
+Der Server broadcastet `snapshot_restored`; `resetWatermarks()` erzwingt den
+folgenden vollen `agent_update`/`room_update`-Broadcast. Playwright-Screenshot
+`issue384-ac4-live-agents.png`: Agents-View zeigt ohne manuellen Reload den
+wiederhergestellten Zustand (`autonomy:bio_emergency T1476609`, direkt nach
+Restore-Tick 1476529).
+
+### AC-5: Playwright-Verifikation: Snapshot waehlen, Restore ausloesen, Screenshot
+
+**Status: PASS**
+
+Vollstaendiger E2E-Durchlauf gegen `http://10.0.0.240:8000` mit playwright-cli:
+Navigation Zeitreise-Tab → Snapshot-Marker waehlen → Welt-Zustand → Confirm-Dialog →
+Restore → Live-Update. Screenshots: `issue384-ac1-timeline.png`,
+`issue384-ac2-worldstate.png`, `issue384-ac2-rooms.png`,
+`issue384-ac3-restore-feedback.png`, `issue384-ac4-live-agents.png`
+(in `/home/jan/Pictures/Screenshots/`).
+
+---
+
+## Deploy + Health (Deploy-VM 10.0.0.240)
+
+```
+$ grep ExecStart /etc/systemd/system/sentinel-dashboard.service
+  ExecStart=/usr/local/bin/bun run start   (WorkingDirectory=/opt/sentinel/dashboard, PORT=8000)
+$ sudo systemctl restart sentinel-dashboard → active, "Dashboard running on http://localhost:8000"
+$ systemctl is-active sentinel-dashboard sentinel-daemon sentinel-projection → active/active/active
+$ journalctl -u sentinel-daemon (3 min) → 0 panics / FATAL
+```
+`cortex-gateway` blieb wie gefordert INACTIVE (Token-Schutz); #384 benoetigt keinen
+Gateway und keine LLM-Calls.
+
+## Nicht getestet / Hinweise
+
+- Tier-Filter/Such-UI: nicht in Scope (#384 verlangt nur Navigation + Restore).
+- `buero-design` ohne ROOM_METADATA-Eintrag faellt graceful auf die room_id zurueck
+  (bestehende Config-Drift, nicht Teil dieses Issues).
+
+## Confidence
+
+**95 %** — Alle 5 ACs mit Command+Output bzw. Screenshot im laufenden System belegt
+(Backend-API gegen echte Daten, Hot-Swap-Restore im Daemon-Journal, Live-Update via
+WS-Frame). Restzweifel nur bzgl. langfristiger UI-Robustheit bei stark wachsender
+Snapshot-Zahl (Timeline-Marker-Dichte).


### PR DESCRIPTION
## Summary

Implementiert die Time-Travel Debugging UI (TOGAF Cluster 11) als neue **Zeitreise**-View im Dashboard. Operatoren koennen Snapshots jetzt visuell entlang der Zeitachse durchblaettern, den Welt-Zustand eines gewaehlten Zeitpunkts ansehen und einen Hot-Swap-Restore mit Confirm-Dialog ausloesen. Reine Frontend-/Dashboard-Arbeit — das Backend (WorldSnapshot, Hot-Swap-Restore, Tiered Retention) existierte bereits und wurde nicht veraendert. Kein Gateway, keine LLM-Calls (token-safe).

## Changes

- **`dashboard/public/js/timetravel.js`** (NEU): Zeitreise-View — visuelle Snapshot-Zeitachse mit tier-codierten Markern + Legende, auswaehlbare Snapshot-Liste, Welt-Zustand-Detailpanel, Restore-Flow mit Confirm-Dialog. Nur `textContent`, kein `innerHTML`.
- **`dashboard/src/db.ts`**: `getSnapshotWorldState()` — leitet den Welt-Zustand zum Snapshot-Zeitpunkt deterministisch aus dem EventStore ab (Replay von `agent_spawned`/`transit_completed`/`agent_despawned` bis `last_event_id` + authoritativer `active_agent_count` aus dem naechsten `tick_snapshot`).
- **`dashboard/src/routes/control.ts`**: `GET /api/control/snapshot-state` (read-only, lokaler DB-Zugriff).
- **`dashboard/src/types.ts`**: `SnapshotWorldState`, `SnapshotRoomOccupancy`.
- **`dashboard/public/index.html`**: Nav-Button "Zeitreise" + View-Section.
- **`dashboard/public/js/app.js`**: Wiring der neuen View + **Bugfix**: der `snapshot_restored`-WS-Handler rief undefinierte `loadAgents()`/`loadRooms()` (ReferenceError) — ersetzt durch `reloadAfterRestore()` (Fetch + Re-Render).
- **`dashboard/public/css/style.css`**: Timeline-/Detail-Panel-Styles.
- **`dashboard/src/__tests__/control.test.ts`**: 3 Tests fuer `snapshot-state` (Replay-Grenze, 404, 400).
- **`CHANGELOG.md`**, **`docs/togaf-gap-v22.md`** (Cluster 11 ⏳→✅), **`test-384-verification.md`**.

## Linked Issues

Addresses #384

## Test Plan

```
$ bun run typecheck     # tsc --noEmit → EXIT 0 (lokal + auf Deploy-VM)
$ bun test              # 78 pass / 0 fail / 673 expect() (11 Dateien), inkl. 3 neue snapshot-state-Tests
# Deploy auf VM 10.0.0.240 (/opt/sentinel/dashboard), systemctl restart sentinel-dashboard → active, 0 Panics, Gateway INACTIVE
# Playwright-E2E gegen http://10.0.0.240:8000: Zeitreise-Tab → Snapshot → Welt-Zustand → Confirm → Restore → Live-Update; 5 Screenshots
```

## Benchmarks

Keine Performance-Benchmarks erforderlich (UI-Feature, kein Hot-Path). Laufzeit-Charakteristik der Welt-Zustand-Ableitung: gefilterter Event-Replay ueber `idx_events_type` (~133k Lifecycle-/Transit-Events gesamt, `id <= last_event_id`) — sub-sekunden pro Snapshot-Auswahl gegen die echte VM-DB (10.7M Events).

## Evidence (AC Mapping)

| AC | Beschreibung | Verdikt |
|----|--------------|---------|
| AC-1 | Snapshots mit Tier-Badge, Zeitstempel, Tick, Groesse entlang Zeitachse | PASS — Screenshot `issue384-ac1-timeline.png` |
| AC-2 | Auswahl zeigt Welt-Zustand (Agent-/Raum-Counts) | PASS — Unit-Test + Screenshots `issue384-ac2-*.png` |
| AC-3 | Restore via bestehende API mit Confirm-Dialog | PASS — Daemon-Journal Hot-Swap |
| AC-4 | Dashboard aktualisiert sich live (WebSocket) | PASS — Spy-WS Frame-Sequenz |
| AC-5 | Playwright-Verifikation mit Screenshots | PASS — 5 Screenshots |

Konkrete Befehle + Outputs (gegen echte Deploy-VM 10.0.0.240):

```bash
# AC-1: Snapshot-Liste (59 Snapshots)
$ curl -s http://10.0.0.240:8000/api/control/snapshots | head -c 200
[{"id":"019e7409-...","tier":"hourly","tick":1476529,"sim_hour":21.745188,
  "payload_size_bytes":566324,"created_at_ms":1780063232607}, ...]

# AC-2: Welt-Zustand zum Snapshot-Zeitpunkt (active==Live-View 26, present 43, 12 Raeume)
$ curl -s "http://10.0.0.240:8000/api/control/snapshot-state?snapshot_id=019e7409-625d-7703-95eb-2bee0815a7c3"
{"snapshot_id":"019e7409-...","tick":1476529,"active_agent_count":26,
 "present_agent_count":43,"room_count":12,"rooms":[{"room_id":"buero-dev-1",
 "name":"Entwicklungsbüro 1","occupant_count":9}, ...]}

# AC-3: Hot-Swap-Restore via bestehende Operator-API (aus Daemon-Journal)
$ ssh ubuntu@10.0.0.240 "journalctl -u sentinel-daemon | grep -i restore"
INFO operator_api: Restore via Operator-API angefordert snapshot_id=019e7409-...
INFO orchestrator: Hot-Swap Restore gestartet snapshot_id=019e7409-...
INFO orchestrator: Pre-Restore Snapshot erstellt (Rollback-Punkt) snapshot_id=019e7442-...
INFO orchestrator: Hot-Swap Restore abgeschlossen snapshot_id=019e7409-... tick=1476529 agents=26

# AC-4: Live-Update — Spy-WebSocket auf /ws empfaengt nach Restore:
["snapshot_restored","agent_update","room_update","cockpit_update","chaos_update","activity_update"]
```

Vollstaendiger Report: `test-384-verification.md`.

## Checklist

- [x] Alle 5 ACs einzeln mit Evidence (Command+Output / Screenshot) im laufenden System belegt
- [x] `bun run typecheck` + `bun test` gruen (lokal + VM)
- [x] Nur `textContent`, kein `innerHTML`
- [x] Auf Deploy-VM deployed + verifiziert (0 Panics, Gateway INACTIVE)
- [x] CHANGELOG.md + togaf-gap-v22.md (Cluster 11 ✅) aktualisiert
- [x] Restore reversibel (Pre-Restore-Rollback-Snapshot)
- [ ] Merge durch Hauptsession (NICHT selbst mergen)
