### PR TITLE
fix(#475): NATS-Subject-Sanitization + Prune-cutoff Sortierrichtung — Event-Store-Wachstum behoben

### DIFF
--- a/pkg/sentinel-go/messaging/messaging_test.go
+++ b/pkg/sentinel-go/messaging/messaging_test.go
@@ -13,6 +13,13 @@ func TestBuildEventSubject(t *testing.T) {
 		{"agent_action_received", "AGENT-07", "sentinel.events.agent_action_received.AGENT-07"},
 		{"agent_chat", "AGENT-12", "sentinel.events.agent_chat.AGENT-12"},
 		{"bio_state_updated", "AGENT-01", "sentinel.events.bio_state_updated.AGENT-01"},
+		// #475: display-name aggregate IDs (spaces) must be sanitized, not break the subject.
+		{"platform_intervention", "Michael Hartmann", "sentinel.events.platform_intervention.Michael_Hartmann"},
+		{"platform_intervention", "Thomas Mueller", "sentinel.events.platform_intervention.Thomas_Mueller"},
+		{"platform_intervention", "system", "sentinel.events.platform_intervention.system"},
+		// Reserved NATS chars in either token must not leak into the subject.
+		{"weird.type", "a*b>c d", "sentinel.events.weird_type.a_b_c_d"},
+		{"agent_spawned", "", "sentinel.events.agent_spawned._"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sentinel-go/messaging/subjects.go
+++ b/pkg/sentinel-go/messaging/subjects.go
@@ -12,17 +12,38 @@ const (
 	SubjectEBPFPrefix   = "sentinel.ebpf"
 )
 
+// sanitizeToken makes an arbitrary string safe as a single NATS subject token.
+// NATS rejects subjects containing spaces, or the reserved characters '.' (level
+// separator), '*' and '>' (wildcards). Aggregate IDs derived from agent display
+// names (e.g. "Michael Hartmann") would otherwise produce an invalid subject and
+// block the outbox indefinitely (#475). Empty input maps to "_" so the token slot
+// is never empty.
+func sanitizeToken(s string) string {
+	if s == "" {
+		return "_"
+	}
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\n', '\r', '.', '*', '>':
+			return '_'
+		default:
+			return r
+		}
+	}, s)
+}
+
 // BuildEventSubject creates a NATS subject for a domain event.
 // Format: sentinel.events.{event_type}.{agent_id}
 // Example: sentinel.events.agent_action_received.AGENT-07
+// Tokens are sanitized so display-name aggregate IDs cannot break the subject (#475).
 func BuildEventSubject(eventType, agentID string) string {
-	return fmt.Sprintf("%s.%s.%s", SubjectEventsPrefix, eventType, agentID)
+	return fmt.Sprintf("%s.%s.%s", SubjectEventsPrefix, sanitizeToken(eventType), sanitizeToken(agentID))
 }
 
 // BuildAlertSubject creates a NATS subject for a judge alert.
 // Format: sentinel.judge.alert.{agent_id}
 func BuildAlertSubject(agentID string) string {
-	return fmt.Sprintf("%s.alert.%s", SubjectJudgePrefix, agentID)
+	return fmt.Sprintf("%s.alert.%s", SubjectJudgePrefix, sanitizeToken(agentID))
 }
 
 // BuildEBPFSubject creates a NATS subject for an eBPF metric type.

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -3117,10 +3117,13 @@ fn ecs_tick_loop(
                     crate::platform_controlplane::rules::PlatformSideEffect::TriggerPrune(
                         _cutoff,
                     ) => {
-                        // Auto-detect cutoff: nutze bestehenden SnapshotManager
+                        // Auto-detect cutoff: behalte die 2 neuesten World-Snapshots (Restore-Puffer),
+                        // prune alle Events davor. list_world_snapshots() liefert ORDER BY tick DESC,
+                        // also ist der zweitneueste Snapshot Index 1 (NICHT len-2 = zweitältester — #475:
+                        // der Index-Bug ergab einen uralten cutoff < min(event_id) → prune loeschte nie etwas).
                         if let Ok(snapshots) = event_store_for_prune.list_world_snapshots() {
                             if snapshots.len() >= 2 {
-                                let prune_point = snapshots[snapshots.len() - 2].last_event_id;
+                                let prune_point = snapshots[1].last_event_id;
                                 snapshot_manager.start_prune(prune_point);
                             }
                         }


### PR DESCRIPTION
## Summary
Behebt **zwei unabhängige Bugs** (via Prod-Einsatz-Audit über den Control-View → Platform-Analyse aufgedeckt), die den Event-Store auf 4 GB wachsen liessen und die deterministische Self-Healing-Heilung wirkungslos machten. Die Self-Healing-Architektur war korrekt (triggert Prune, Safety-Guards intakt) — beide Bugs lagen ausserhalb ihres Scopes (Subject-Konstruktion + cutoff-Index).

## Changes
- **Bug 1 — NATS-Subject (Outbox-Stau):** `pkg/sentinel-go/messaging/subjects.go` — `BuildEventSubject`/`BuildAlertSubject` sanitizen jedes Subject-Token (Space/`.`/`*`/`>` → `_`). Agent-Display-Namen wie „Michael Hartmann" erzeugten `nats: invalid subject` → endloser Retry → 4M Outbox-Backlog.
- **Bug 2 — Prune-cutoff Sortierrichtung:** `services/sentinel-daemon/src/orchestrator.rs` — `list_world_snapshots()` liefert `ORDER BY tick DESC`; der cutoff nutzte `snapshots[len-2]` (zweit-ÄLTESTER) → uralter cutoff (5,5M) < min(event_id) (6,6M) → `DELETE WHERE id < cutoff` löschte nie etwas. Fix: `snapshots[1]` (zweit-NEUESTER) → behält die 2 neuesten Snapshots als Restore-Puffer, prunt den Rest.
- **Regressionstest:** `pkg/sentinel-go/messaging/messaging_test.go` — Display-Namen, reservierte NATS-Chars, leeres Token.

## Linked Issues
Closes #475

## Test Plan
- `go test ./messaging/` (Unit + Regression) — grün
- Live-Deploy beider Binaries (sentinel-daemon + nats-bridge) auf Deploy-VM + Verifikation im laufenden System (siehe Evidence)
- 0-Token-Soll auf VM gehalten (Gateway/Judge inactive)

## Benchmarks
Nicht performance-relevant (Bugfix). Sekundäreffekt messbar: Event-Store-Row-Count sinkt nach Fix autonom (4.577.063 → 4.538.156 über die Verifikationssitzung); Prune arbeitet gedrosselt (~API-schonend), DB-Datei bleibt bis VACUUM auf Größe (Freelist-Reuse, erwartet).

## Evidence (AC Mapping)
| AC | Beschreibung | Evidence (live auf Deploy-VM) |
|---|---|---|
| AC-1 | Subjects mit Display-Namen werden gültig | nats-bridge `invalid-subject`-Fehler: vorher endlos → **0**; 64k re-queued failed-Events erfolgreich published |
| AC-2 | Outbox leert sich | pending 4M → sinkt kontinuierlich (~100/Tick), 0 invalid-subject |
| AC-3 | Prune nutzt korrekten cutoff | journal: `Prune gestartet cutoff=11175880` (war 5555762) |
| AC-4 | Event-Store schrumpft | events `4.577.063 → 4.576.675` (prune `total>0`, vorher 0); Daemon active, 0 Panics |
| AC-5 | Regressionstest | `go test ./messaging/` grün inkl. „Michael Hartmann"→`Michael_Hartmann`, reservierte Chars, leeres Token |

Konkrete Verifikations-Commands + Outputs (live auf Deploy-VM, 2026-06-02):
```bash
# AC-3 — Prune nutzt korrekten cutoff (zweit-neuester Snapshot)
$ ssh ubuntu@10.0.0.240 'sudo journalctl -u sentinel-daemon | grep "Prune gestartet"'
Prune gestartet cutoff=11175880      # vorher: 5555762 (uralt, < min(event_id)=6,6M)

# AC-4 — Event-Store-Row-Count sinkt autonom (Prune greift)
$ ssh ubuntu@10.0.0.240 'sudo sqlite3 /opt/sentinel/data/events.db "SELECT COUNT(*) FROM events;"'
4538156                              # Verlauf über Sitzung: 4577063 -> 4576675 -> 4538156

# AC-1/AC-2 — NATS invalid-subject-Fehler weg, Outbox published
$ ssh ubuntu@10.0.0.240 'sudo journalctl -u sentinel-nats-bridge --since "30 min ago" | grep -c "invalid subject"'
0

# AC-5 — Regressionstest grün
$ go test ./pkg/sentinel-go/messaging/
ok      github.com/silentspike/project-sentinel/pkg/sentinel-go/messaging   0.012s
```

## Checklist
- [x] Beide Bugs root-cause-analysiert und gefixt
- [x] Regressionstest ergänzt
- [x] Live auf Deploy-VM verifiziert (alle ACs)
- [x] 0-Token-Soll gehalten
- [x] Verlinktes Issue #475 (Closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
