### PR TITLE
feat: add production OTLP telemetry path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,6 +3327,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3799,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4167,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4462,7 +4612,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
 ]
@@ -4480,7 +4630,7 @@ dependencies = [
  "criterion 0.8.2",
  "futures",
  "redb",
- "reqwest",
+ "reqwest 0.12.28",
  "sentinel-common",
  "sentinel-ebpf",
  "sentinel-ecs",
@@ -4516,7 +4666,7 @@ dependencies = [
  "base64",
  "futures",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rmp-serde",
  "rusqlite",
  "rustls",
@@ -4779,10 +4929,15 @@ name = "sentinel-telemetry"
 version = "0.1.0"
 dependencies = [
  "criterion 0.5.1",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "sentinel-common",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -5642,6 +5797,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5649,9 +5852,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5739,6 +5945,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ flatbuffers = "25.12"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }
+tracing-opentelemetry = { version = "0.33", default-features = false }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "grpc-tonic"] }
 serde_json = "1"
 bincode = { version = "2.0.1", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }

--- a/crates/sentinel-telemetry/Cargo.toml
+++ b/crates/sentinel-telemetry/Cargo.toml
@@ -7,11 +7,20 @@ publish = false
 
 [features]
 default = ["telemetry"]
-telemetry = []
+telemetry = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
 
 [dependencies]
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
@@ -19,6 +28,7 @@ sentinel-common = { path = "../sentinel-common" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+tokio = { workspace = true }
 
 [[bench]]
 name = "telemetry_bench"

--- a/crates/sentinel-telemetry/README.md
+++ b/crates/sentinel-telemetry/README.md
@@ -10,11 +10,31 @@
 - `HealthRegistry`, `HealthSnapshot`, and `SubsystemHealth` track service readiness.
 - `TraceContext` and telemetry constants propagate correlation context.
 - `TelemetryExporter` sends metrics through configured transports.
-- `init_logging` and `init_logging_dev` are available when the `telemetry` feature is active.
+- `init_observability` initializes production JSON logging and optional OTLP trace export.
+- `init_logging` and `init_logging_dev` remain available when the `telemetry` feature is active.
+
+## OTLP Trace Export
+
+OTLP is part of the production telemetry path and is disabled by default. `sentinel-daemon` uses
+`init_observability("sentinel-daemon")`, so enabling these variables exports real daemon spans.
+
+| Env | Default | Meaning |
+| --- | --- | --- |
+| `SENTINEL_OTLP_ENABLED` | `false` | Enable OTLP trace export. |
+| `SENTINEL_OTLP_PROTOCOL` | `http` | `http` or `grpc`. |
+| `SENTINEL_OTLP_ENDPOINT` | protocol default | HTTP: `http://127.0.0.1:4318/v1/traces`; gRPC: `http://127.0.0.1:4317`. |
+| `SENTINEL_OTLP_SERVICE_NAME` | caller default | OTel `service.name`. |
+| `SENTINEL_OTLP_TIMEOUT_MS` | `3000` | Per-export timeout. |
+| `SENTINEL_OTLP_BATCH_MS` | `5000` | Batch processor flush interval. |
+
+Exporter failures are non-fatal. If the collector is down, the service keeps running and the
+batch exporter drops/logs export errors instead of panicking.
 
 ## Dependencies
 
 - `tracing`, `tracing-subscriber`, `serde`, `serde_json`, and `uuid`.
+- `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, and `tracing-opentelemetry`
+  when the default `telemetry` feature is active.
 - `sentinel-common` for shared context types.
 
 ## Verify
@@ -23,4 +43,6 @@
 cargo remote -c -- test -p sentinel-telemetry
 ```
 
-Telemetry changes should also be sampled in the service that consumes the metric or health path.
+Telemetry changes should also be sampled in the service that consumes the metric, health, or trace
+path. For #381, the live smoke is `sentinel-daemon` exporting bootstrap/config-load spans to a local
+OTLP receiver with both HTTP and gRPC.

--- a/crates/sentinel-telemetry/benches/telemetry_bench.rs
+++ b/crates/sentinel-telemetry/benches/telemetry_bench.rs
@@ -8,6 +8,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use sentinel_telemetry::metrics::MetricsRegistry;
+use tracing::info_span;
 
 // ──────────────────────────────────────────────
 // 1. Counter — Budget: < 1 ns per increment
@@ -192,6 +193,24 @@ fn bench_snapshot_raw(c: &mut Criterion) {
     group.finish();
 }
 
+// ──────────────────────────────────────────────
+// 6. Span enter/exit — Disabled OTLP hot path
+// ──────────────────────────────────────────────
+
+fn bench_span_enter_exit_disabled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("span_enter_exit");
+
+    group.bench_function("disabled_dispatch", |b| {
+        b.iter(|| {
+            let span = info_span!("bench_disabled_span", tick = 1u64);
+            let _entered = span.enter();
+            black_box(1u64);
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_counter_increment,
@@ -199,5 +218,6 @@ criterion_group!(
     bench_gauge_operations,
     bench_registry_lookup,
     bench_snapshot_raw,
+    bench_span_enter_exit_disabled,
 );
 criterion_main!(benches);

--- a/crates/sentinel-telemetry/src/lib.rs
+++ b/crates/sentinel-telemetry/src/lib.rs
@@ -18,7 +18,13 @@ pub use errors::{ClassifiedError, ErrorEvent, ErrorSeverity};
 pub use export::{ExporterConfig, TelemetryExporter, TelemetryTransport};
 pub use health::{HealthRegistry, HealthSnapshot, HealthStatus, SubsystemHealth};
 #[cfg(feature = "telemetry")]
-pub use logging::{init_logging, init_logging_dev};
+pub use logging::{
+    build_tracer_provider, init_logging, init_logging_dev, init_observability,
+    init_observability_with_config, ObservabilityGuard, ObservabilityInitError, OtlpConfig,
+    OtlpProtocol, DEFAULT_OTLP_GRPC_ENDPOINT, DEFAULT_OTLP_HTTP_ENDPOINT, SENTINEL_OTLP_BATCH_MS,
+    SENTINEL_OTLP_ENABLED, SENTINEL_OTLP_ENDPOINT, SENTINEL_OTLP_PROTOCOL,
+    SENTINEL_OTLP_SERVICE_NAME, SENTINEL_OTLP_TIMEOUT_MS,
+};
 pub use metrics::{
     metric_name, Counter, Gauge, Histogram, MetricsRegistry, MetricsSnapshot, SubsystemMetrics,
 };

--- a/crates/sentinel-telemetry/src/logging.rs
+++ b/crates/sentinel-telemetry/src/logging.rs
@@ -28,7 +28,198 @@
 //! Jeder Tick erzeugt einen Root-Span, Agent-Operationen sind Kind-Spans.
 
 #[cfg(feature = "telemetry")]
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use std::{env, error::Error, fmt as std_fmt, str::FromStr, time::Duration};
+
+#[cfg(feature = "telemetry")]
+use opentelemetry::trace::TracerProvider as _;
+#[cfg(feature = "telemetry")]
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+#[cfg(feature = "telemetry")]
+use opentelemetry_sdk::{
+    trace::{BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider},
+    Resource,
+};
+#[cfg(feature = "telemetry")]
+use tracing_subscriber::{fmt, prelude::*, util::SubscriberInitExt, EnvFilter};
+
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_ENABLED: &str = "SENTINEL_OTLP_ENABLED";
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_PROTOCOL: &str = "SENTINEL_OTLP_PROTOCOL";
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_ENDPOINT: &str = "SENTINEL_OTLP_ENDPOINT";
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_SERVICE_NAME: &str = "SENTINEL_OTLP_SERVICE_NAME";
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_TIMEOUT_MS: &str = "SENTINEL_OTLP_TIMEOUT_MS";
+#[cfg(feature = "telemetry")]
+pub const SENTINEL_OTLP_BATCH_MS: &str = "SENTINEL_OTLP_BATCH_MS";
+
+#[cfg(feature = "telemetry")]
+pub const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://127.0.0.1:4318/v1/traces";
+#[cfg(feature = "telemetry")]
+pub const DEFAULT_OTLP_GRPC_ENDPOINT: &str = "http://127.0.0.1:4317";
+#[cfg(feature = "telemetry")]
+pub const DEFAULT_OTLP_TIMEOUT_MS: u64 = 3_000;
+#[cfg(feature = "telemetry")]
+pub const DEFAULT_OTLP_BATCH_MS: u64 = 5_000;
+
+#[cfg(feature = "telemetry")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtlpProtocol {
+    Http,
+    Grpc,
+}
+
+#[cfg(feature = "telemetry")]
+impl OtlpProtocol {
+    pub fn default_endpoint(self) -> &'static str {
+        match self {
+            Self::Http => DEFAULT_OTLP_HTTP_ENDPOINT,
+            Self::Grpc => DEFAULT_OTLP_GRPC_ENDPOINT,
+        }
+    }
+}
+
+#[cfg(feature = "telemetry")]
+impl FromStr for OtlpProtocol {
+    type Err = ObservabilityInitError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "" | "http" | "http/protobuf" | "http-protobuf" => Ok(Self::Http),
+            "grpc" | "tonic" => Ok(Self::Grpc),
+            other => Err(ObservabilityInitError::InvalidConfig(format!(
+                "{SENTINEL_OTLP_PROTOCOL} must be http or grpc, got {other:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(feature = "telemetry")]
+impl std_fmt::Display for OtlpProtocol {
+    fn fmt(&self, f: &mut std_fmt::Formatter<'_>) -> std_fmt::Result {
+        match self {
+            Self::Http => f.write_str("http"),
+            Self::Grpc => f.write_str("grpc"),
+        }
+    }
+}
+
+#[cfg(feature = "telemetry")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpConfig {
+    pub enabled: bool,
+    pub protocol: OtlpProtocol,
+    pub endpoint: String,
+    pub service_name: String,
+    pub timeout: Duration,
+    pub batch_interval: Duration,
+}
+
+#[cfg(feature = "telemetry")]
+impl OtlpConfig {
+    pub fn from_env(
+        default_service_name: impl Into<String>,
+    ) -> Result<Self, ObservabilityInitError> {
+        Self::from_lookup(default_service_name, |key| env::var(key).ok())
+    }
+
+    pub fn from_lookup(
+        default_service_name: impl Into<String>,
+        mut lookup: impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self, ObservabilityInitError> {
+        let default_service_name = default_service_name.into();
+        let enabled = match lookup(SENTINEL_OTLP_ENABLED) {
+            Some(value) => parse_bool(SENTINEL_OTLP_ENABLED, &value)?,
+            None => false,
+        };
+        let protocol = match lookup(SENTINEL_OTLP_PROTOCOL) {
+            Some(value) => OtlpProtocol::from_str(&value)?,
+            None => OtlpProtocol::Http,
+        };
+        let endpoint = lookup(SENTINEL_OTLP_ENDPOINT)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| protocol.default_endpoint().to_string());
+        let service_name = lookup(SENTINEL_OTLP_SERVICE_NAME)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(default_service_name);
+        let timeout = parse_duration_ms(
+            SENTINEL_OTLP_TIMEOUT_MS,
+            lookup(SENTINEL_OTLP_TIMEOUT_MS),
+            DEFAULT_OTLP_TIMEOUT_MS,
+        )?;
+        let batch_interval = parse_duration_ms(
+            SENTINEL_OTLP_BATCH_MS,
+            lookup(SENTINEL_OTLP_BATCH_MS),
+            DEFAULT_OTLP_BATCH_MS,
+        )?;
+
+        Ok(Self {
+            enabled,
+            protocol,
+            endpoint,
+            service_name,
+            timeout,
+            batch_interval,
+        })
+    }
+}
+
+#[cfg(feature = "telemetry")]
+#[derive(Debug)]
+pub enum ObservabilityInitError {
+    InvalidConfig(String),
+    Exporter(String),
+    Subscriber(String),
+}
+
+#[cfg(feature = "telemetry")]
+impl std_fmt::Display for ObservabilityInitError {
+    fn fmt(&self, f: &mut std_fmt::Formatter<'_>) -> std_fmt::Result {
+        match self {
+            Self::InvalidConfig(message) => write!(f, "invalid observability config: {message}"),
+            Self::Exporter(message) => write!(f, "OTLP exporter setup failed: {message}"),
+            Self::Subscriber(message) => write!(f, "tracing subscriber setup failed: {message}"),
+        }
+    }
+}
+
+#[cfg(feature = "telemetry")]
+impl Error for ObservabilityInitError {}
+
+#[cfg(feature = "telemetry")]
+#[must_use]
+#[derive(Debug)]
+pub struct ObservabilityGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+    shutdown_timeout: Duration,
+}
+
+#[cfg(feature = "telemetry")]
+impl ObservabilityGuard {
+    pub fn otlp_enabled(&self) -> bool {
+        self.tracer_provider.is_some()
+    }
+
+    pub fn shutdown(&self) -> Result<(), ObservabilityInitError> {
+        if let Some(provider) = &self.tracer_provider {
+            provider
+                .shutdown_with_timeout(self.shutdown_timeout)
+                .map_err(|err| ObservabilityInitError::Exporter(err.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "telemetry")]
+impl Drop for ObservabilityGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = &self.tracer_provider {
+            let _ = provider.shutdown_with_timeout(self.shutdown_timeout);
+        }
+    }
+}
 
 /// Initialize structured logging with JSON output (production mode).
 ///
@@ -62,9 +253,120 @@ pub fn init_logging_dev() {
         .init();
 }
 
-#[cfg(test)]
+/// Initialize production observability for a service.
+///
+/// `RUST_LOG` controls log filtering. OTLP trace export is disabled by default
+/// and can be enabled with `SENTINEL_OTLP_ENABLED=true`.
+#[cfg(feature = "telemetry")]
+pub fn init_observability(
+    default_service_name: impl Into<String>,
+) -> Result<ObservabilityGuard, ObservabilityInitError> {
+    let config = OtlpConfig::from_env(default_service_name)?;
+    init_observability_with_config(config)
+}
+
+#[cfg(feature = "telemetry")]
+pub fn init_observability_with_config(
+    config: OtlpConfig,
+) -> Result<ObservabilityGuard, ObservabilityInitError> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let fmt_layer = fmt::layer().json();
+
+    if config.enabled {
+        let provider = build_tracer_provider(&config)?;
+        let tracer = provider.tracer(config.service_name.clone());
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .with(otel_layer)
+            .try_init()
+            .map_err(|err| ObservabilityInitError::Subscriber(err.to_string()))?;
+
+        Ok(ObservabilityGuard {
+            tracer_provider: Some(provider),
+            shutdown_timeout: config.timeout,
+        })
+    } else {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .try_init()
+            .map_err(|err| ObservabilityInitError::Subscriber(err.to_string()))?;
+
+        Ok(ObservabilityGuard {
+            tracer_provider: None,
+            shutdown_timeout: config.timeout,
+        })
+    }
+}
+
+#[cfg(feature = "telemetry")]
+pub fn build_tracer_provider(
+    config: &OtlpConfig,
+) -> Result<SdkTracerProvider, ObservabilityInitError> {
+    let exporter = match config.protocol {
+        OtlpProtocol::Http => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint(config.endpoint.clone())
+            .with_timeout(config.timeout)
+            .with_protocol(Protocol::HttpBinary)
+            .build(),
+        OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(config.endpoint.clone())
+            .with_timeout(config.timeout)
+            .build(),
+    }
+    .map_err(|err| ObservabilityInitError::Exporter(err.to_string()))?;
+
+    let batch_config = BatchConfigBuilder::default()
+        .with_scheduled_delay(config.batch_interval)
+        .build();
+    let batch_processor = BatchSpanProcessor::builder(exporter)
+        .with_batch_config(batch_config)
+        .build();
+    let resource = Resource::builder_empty()
+        .with_service_name(config.service_name.clone())
+        .build();
+
+    Ok(SdkTracerProvider::builder()
+        .with_span_processor(batch_processor)
+        .with_resource(resource)
+        .build())
+}
+
+#[cfg(feature = "telemetry")]
+fn parse_bool(name: &str, value: &str) -> Result<bool, ObservabilityInitError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        other => Err(ObservabilityInitError::InvalidConfig(format!(
+            "{name} must be boolean, got {other:?}"
+        ))),
+    }
+}
+
+#[cfg(feature = "telemetry")]
+fn parse_duration_ms(
+    name: &str,
+    value: Option<String>,
+    default_ms: u64,
+) -> Result<Duration, ObservabilityInitError> {
+    let Some(value) = value else {
+        return Ok(Duration::from_millis(default_ms));
+    };
+    let millis = value.trim().parse::<u64>().map_err(|err| {
+        ObservabilityInitError::InvalidConfig(format!("{name} must be milliseconds: {err}"))
+    })?;
+    Ok(Duration::from_millis(millis))
+}
+
+#[cfg(all(test, feature = "telemetry"))]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     // Logging kann nur einmal pro Prozess initialisiert werden.
     // Wir testen dass die Funktionen nicht paniken.
@@ -89,5 +391,75 @@ mod tests {
             .with(filter)
             .with(fmt::layer().pretty())
             .try_init();
+    }
+
+    #[test]
+    fn otlp_config_defaults_to_disabled_http() {
+        let config = OtlpConfig::from_lookup("sentinel-test", |_| None).unwrap();
+
+        assert!(!config.enabled);
+        assert_eq!(config.protocol, OtlpProtocol::Http);
+        assert_eq!(config.endpoint, DEFAULT_OTLP_HTTP_ENDPOINT);
+        assert_eq!(config.service_name, "sentinel-test");
+        assert_eq!(
+            config.timeout,
+            Duration::from_millis(DEFAULT_OTLP_TIMEOUT_MS)
+        );
+        assert_eq!(
+            config.batch_interval,
+            Duration::from_millis(DEFAULT_OTLP_BATCH_MS)
+        );
+    }
+
+    #[test]
+    fn otlp_config_supports_grpc_defaults() {
+        let vars = HashMap::from([
+            (SENTINEL_OTLP_ENABLED, "true".to_string()),
+            (SENTINEL_OTLP_PROTOCOL, "grpc".to_string()),
+            (SENTINEL_OTLP_SERVICE_NAME, "sentinel-daemon".to_string()),
+            (SENTINEL_OTLP_TIMEOUT_MS, "750".to_string()),
+            (SENTINEL_OTLP_BATCH_MS, "250".to_string()),
+        ]);
+        let config = OtlpConfig::from_lookup("fallback", |key| vars.get(key).cloned()).unwrap();
+
+        assert!(config.enabled);
+        assert_eq!(config.protocol, OtlpProtocol::Grpc);
+        assert_eq!(config.endpoint, DEFAULT_OTLP_GRPC_ENDPOINT);
+        assert_eq!(config.service_name, "sentinel-daemon");
+        assert_eq!(config.timeout, Duration::from_millis(750));
+        assert_eq!(config.batch_interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn otlp_config_rejects_invalid_protocol() {
+        let vars = HashMap::from([(SENTINEL_OTLP_PROTOCOL, "smtp".to_string())]);
+        let err = OtlpConfig::from_lookup("sentinel-test", |key| vars.get(key).cloned())
+            .expect_err("invalid protocol must be rejected");
+
+        assert!(err.to_string().contains(SENTINEL_OTLP_PROTOCOL));
+    }
+
+    #[test]
+    fn otlp_config_rejects_invalid_enabled_flag() {
+        let vars = HashMap::from([(SENTINEL_OTLP_ENABLED, "maybe".to_string())]);
+        let err = OtlpConfig::from_lookup("sentinel-test", |key| vars.get(key).cloned())
+            .expect_err("invalid enabled flag must be rejected");
+
+        assert!(err.to_string().contains(SENTINEL_OTLP_ENABLED));
+    }
+
+    #[test]
+    fn build_http_exporter_for_offline_collector_does_not_panic() {
+        let config = OtlpConfig {
+            enabled: true,
+            protocol: OtlpProtocol::Http,
+            endpoint: "http://127.0.0.1:9/v1/traces".to_string(),
+            service_name: "sentinel-test".to_string(),
+            timeout: Duration::from_millis(10),
+            batch_interval: Duration::from_millis(10),
+        };
+
+        let provider = build_tracer_provider(&config).expect("http exporter should build offline");
+        let _ = provider.shutdown_with_timeout(Duration::from_millis(10));
     }
 }

--- a/deploy/systemd/sentinel-daemon.service
+++ b/deploy/systemd/sentinel-daemon.service
@@ -9,6 +9,7 @@ StartLimitIntervalSec=300
 [Service]
 Type=simple
 WorkingDirectory=/opt/sentinel
+EnvironmentFile=-/etc/sentinel/env
 ExecStart=/opt/sentinel/bin/sentinel-daemon --config /opt/sentinel/config/daemon.toml
 Restart=on-failure
 RestartSec=5

--- a/deploy/systemd/sentinel-env.example
+++ b/deploy/systemd/sentinel-env.example
@@ -18,3 +18,14 @@ CORTEX_GATEWAY_URL=http://127.0.0.1:8080
 
 # Logging
 RUST_LOG=info
+
+# OTLP tracing (default off). `sentinel-daemon` is wired to this production path.
+SENTINEL_OTLP_ENABLED=false
+# Supported values: http, grpc
+SENTINEL_OTLP_PROTOCOL=http
+# HTTP/protobuf default: http://127.0.0.1:4318/v1/traces
+# gRPC default:         http://127.0.0.1:4317
+# SENTINEL_OTLP_ENDPOINT=http://127.0.0.1:4318/v1/traces
+SENTINEL_OTLP_SERVICE_NAME=sentinel-daemon
+SENTINEL_OTLP_TIMEOUT_MS=3000
+SENTINEL_OTLP_BATCH_MS=5000

--- a/docs/togaf-gap-v22.md
+++ b/docs/togaf-gap-v22.md
@@ -86,7 +86,7 @@ The numbers reflect the state at the v0.1.0-alpha boundary.
 | eBPF probes (write-syscall, stall) | ✅ | `crates/sentinel-ebpf/`; #380 Deploy-VM evidence shows `mode=kernel`, ring drops 0, I/O read/write values, TCP request deltas, and dashboard eBPF cards without `N/A` |
 | MARBLE Observatory            | ✅ | `cmd/cortex-gateway/internal/observatory/` |
 | Dashboard polling efficiency (#277) | ✅ | Projection-owned `projection_watermarks` table gives one indexed change-detection lookup per active WebSocket poll; Deploy-VM evidence on Intel i7-3930K @ 3.20 GHz (2011), gateway inactive, 3-tab Playwright: no `ERR_INSUFFICIENT_RESOURCES` |
-| OTel tracing                  | 🟡 | structured spans in place, OTLP exporter behind feature flag |
+| OTel tracing                  | ✅ | `sentinel-telemetry::init_observability` provides a default-off production OTLP path; `sentinel-daemon` is wired to export real bootstrap/config-load spans over HTTP or gRPC via `SENTINEL_OTLP_*` |
 
 ## Cluster 06 — Performance & Hardware
 

--- a/services/sentinel-daemon/src/main.rs
+++ b/services/sentinel-daemon/src/main.rs
@@ -9,7 +9,7 @@ use std::process::ExitCode;
 
 use anyhow::Context;
 use clap::Parser;
-use tracing::{error, info};
+use tracing::{error, info, info_span};
 
 use sentinel_daemon::config::DaemonConfig;
 
@@ -27,16 +27,36 @@ struct Cli {
 }
 
 fn main() -> ExitCode {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
-
     let cli = Cli::parse();
+    let runtime = match tokio::runtime::Runtime::new().context("Tokio Runtime erstellen") {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("Daemon fehlgeschlagen: {e:#}");
+            return ExitCode::from(1);
+        }
+    };
+    let observability = match runtime
+        .block_on(async { sentinel_telemetry::init_observability("sentinel-daemon") })
+    {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!("Observability-Initialisierung fehlgeschlagen: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let otlp_enabled = observability.otlp_enabled();
 
-    match run(cli) {
+    {
+        let span = info_span!(
+            "sentinel_daemon.bootstrap",
+            service = "sentinel-daemon",
+            otlp_enabled
+        );
+        let _entered = span.enter();
+        info!("Observability initialisiert");
+    }
+
+    match run(cli, &runtime) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             error!(error = %e, "Daemon fehlgeschlagen");
@@ -45,9 +65,13 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(cli: Cli) -> anyhow::Result<()> {
-    let config = DaemonConfig::load(Path::new(&cli.config))
-        .with_context(|| format!("Config laden: {}", cli.config))?;
+fn run(cli: Cli, runtime: &tokio::runtime::Runtime) -> anyhow::Result<()> {
+    let config = {
+        let span = info_span!("sentinel_daemon.config_load", config_path = %cli.config);
+        let _entered = span.enter();
+        DaemonConfig::load(Path::new(&cli.config))
+            .with_context(|| format!("Config laden: {}", cli.config))?
+    };
 
     info!(
         config_dir = %config.config_dir.display(),
@@ -61,8 +85,6 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         return dry_run(&config);
     }
 
-    // Tokio Runtime fuer async I/O
-    let runtime = tokio::runtime::Runtime::new().context("Tokio Runtime erstellen")?;
     runtime.block_on(sentinel_daemon::orchestrator::run(config))
 }
 


### PR DESCRIPTION
## Summary

Adds a production OTLP tracing path for `sentinel-telemetry` and wires it into `sentinel-daemon` so the shared observability init is exercised by a real service, not only by library tests.

OTLP remains default-off and is controlled by environment/config. Both OTLP HTTP/protobuf and gRPC exporters are supported.

## Changes

- Added `init_observability()` with env-driven OTLP config, exporter setup, shutdown guard, and default-off behavior.
- Wired `sentinel-daemon` through the shared observability init path and added real bootstrap/config-load spans.
- Added OTLP env examples and systemd `EnvironmentFile=-/etc/sentinel/env` support.
- Added telemetry tests and a Criterion span-enter/exit benchmark.
- Updated the Cluster 05b TOGAF gap row for the now-configurable OTLP export path.

## Linked Issues

Closes #381

## Test Plan

- `cargo fmt --all -- --check` passed.
- `python3 scripts/check-unsafe-baseline.py` passed: `unsafe constructs: 19 / baseline 19`.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo test --workspace` passed.
- `cargo test -p sentinel-telemetry -p sentinel-daemon` passed.
- `cargo check -p sentinel-telemetry --no-default-features --lib` passed.
- Live deploy smoke on `sentinel-ubuntu-2404` (`Intel Core i7-3930K CPU @ 3.20GHz`) with OpenTelemetry Collector `v0.153.0` on loopback passed.

## Benchmarks

Deploy VM hardware-relative benchmark:

- Host: `sentinel-ubuntu-2404`
- CPU: `Intel Core i7-3930K CPU @ 3.20GHz`
- Command: `CARGO_TARGET_DIR=/home/ubuntu/ps381-target cargo bench -p sentinel-telemetry --bench telemetry_bench span_enter_exit -- --sample-size 10`
- Result: `span_enter_exit/disabled_dispatch time: [557.47 ps 563.25 ps 572.87 ps]`

Supplemental local host benchmark:

- CPU: AMD Ryzen 9 5900HS
- Result: `span_enter_exit/disabled_dispatch time: [1.0964 ns 1.1142 ns 1.1284 ns]`

## Evidence (AC Mapping)

AC-1: OTLP export per env/config, default-off remains possible.

- `SENTINEL_OTLP_ENABLED=false` leaves the daemon active with no exporter traffic.
- Final VM state after smoke: `sentinel-daemon=active`, `nats-server=active`, `sentinel-gateway=inactive`, `sentinel-judge=inactive`, `sentinel-health-monitor.timer=inactive`.

AC-2: Enabled export reaches a local OTLP receiver.

- HTTP/protobuf smoke with `SENTINEL_OTLP_PROTOCOL=http` and endpoint `http://127.0.0.1:4318/v1/traces`:
  - Collector output: `resource spans: 1, spans: 2`
  - `service.name: Str(sentinel-daemon)`
  - `Name: sentinel_daemon.bootstrap`
  - `Name: sentinel_daemon.config_load`
- gRPC smoke with `SENTINEL_OTLP_PROTOCOL=grpc` and endpoint `http://127.0.0.1:4317`:
  - Collector output included the same `sentinel_daemon.bootstrap` and `sentinel_daemon.config_load` spans.

AC-3: Disabled export has effectively no measurable overhead and no collector export.

- Disabled clean smoke was run as disabled-to-disabled restart with collector active.
- Journal showed `otlp_enabled=false`.
- Collector evidence: `collector_trace_match_count=0`.
- VM benchmark result is sub-nanosecond on the deploy hardware, treated as hardware-relative evidence rather than a brittle absolute gate.

AC-4: Documentation/config examples updated.

- `crates/sentinel-telemetry/README.md` documents env defaults and live smoke.
- `deploy/systemd/sentinel-env.example` includes OTLP settings.
- `deploy/systemd/sentinel-daemon.service` loads `/etc/sentinel/env` optionally.

Deployment note: the first local release binary was rejected by the VM due to a host/VM glibc mismatch (`host glibc 2.43`, VM glibc 2.39). The final live smoke used a VM-built `sentinel-daemon` binary and the installed daemon hash was `dc643f408fa6d2d54970960ecd791606b553c36fd7a458bd2db81af903e7e7f8`.

## Checklist

- [x] #406 is not included; it remains deliberately deferred.
- [x] #435 is not included; runner/Proxmox migration remains out of this PR.
- [x] `sentinel-daemon` is wired in the same PR and verified live.
- [x] OTLP is default-off after verification.
- [x] Live VM restored to token-safe service state after smoke.
