### PR TITLE
fix(#481): Outbox-Orphan-Pruning + systemweite Retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,10 @@ jobs:
         uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d # v1.44.0
 
   # ──────────────────────────────────────────────
-  # Rust - only when crates/ or Cargo.* changed
+  # Rust static analysis - fmt + clippy + machete
+  # Parallel to rust-doc / rust-test / rust-ebpf (fans across runners)
   # ──────────────────────────────────────────────
-  rust:
+  rust-static:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.config == 'true'
     runs-on: ${{ vars.RUNNER_MODE == 'hosted' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64"]') }}
@@ -97,25 +98,20 @@ jobs:
       CARGO_BUILD_JOBS: ${{ vars.RUNNER_MODE == 'hosted' && '2' || '3' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: rustfmt, clippy
-
-      # Self-hosted: persistent local cache
       - name: Configure local cache (self-hosted)
         if: vars.RUNNER_MODE != 'hosted'
         run: |
           export CARGO_TARGET_DIR="$HOME/.cache/project-sentinel/cargo-target/${{ runner.name }}/target"
           mkdir -p "$CARGO_TARGET_DIR"
           echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
-
-      # Hosted: actions-based Rust cache
       - name: Rust cache (hosted)
         if: vars.RUNNER_MODE == 'hosted'
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: sentinel-hosted
+          shared-key: sentinel-hosted-static
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -123,10 +119,64 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Unused dependencies
+        uses: taiki-e/install-action@288875dd3d64326724fa6d9593062d9f8ba0b131 # v2.67.30
+        with:
+          tool: cargo-machete
+      - run: cargo machete || echo "::warning::Unused dependencies found (non-blocking)"
+
+  # ──────────────────────────────────────────────
+  # Rust docs - rustdoc warnings (own compile, parallel)
+  # ──────────────────────────────────────────────
+  rust-doc:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.config == 'true'
+    runs-on: ${{ vars.RUNNER_MODE == 'hosted' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64"]') }}
+    env:
+      CARGO_BUILD_JOBS: ${{ vars.RUNNER_MODE == 'hosted' && '2' || '3' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - name: Configure local cache (self-hosted)
+        if: vars.RUNNER_MODE != 'hosted'
+        run: |
+          export CARGO_TARGET_DIR="$HOME/.cache/project-sentinel/cargo-target/${{ runner.name }}/target"
+          mkdir -p "$CARGO_TARGET_DIR"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
+      - name: Rust cache (hosted)
+        if: vars.RUNNER_MODE == 'hosted'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: sentinel-hosted-doc
+
       - name: Rustdoc warnings
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --no-deps --document-private-items
+
+  # ──────────────────────────────────────────────
+  # Rust tests - workspace + snapshot tests (own compile, parallel)
+  # ──────────────────────────────────────────────
+  rust-test:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.config == 'true'
+    runs-on: ${{ vars.RUNNER_MODE == 'hosted' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64"]') }}
+    env:
+      CARGO_BUILD_JOBS: ${{ vars.RUNNER_MODE == 'hosted' && '2' || '3' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - name: Configure local cache (self-hosted)
+        if: vars.RUNNER_MODE != 'hosted'
+        run: |
+          export CARGO_TARGET_DIR="$HOME/.cache/project-sentinel/cargo-target/${{ runner.name }}/target"
+          mkdir -p "$CARGO_TARGET_DIR"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
+      - name: Rust cache (hosted)
+        if: vars.RUNNER_MODE == 'hosted'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: sentinel-hosted-test
 
       - name: Tests
         run: cargo test --workspace
@@ -136,6 +186,32 @@ jobs:
           command -v cargo-insta >/dev/null 2>&1 || cargo install cargo-insta --locked
           cargo insta test -p sentinel-ecs --test snapshot_perception --check
           cargo insta test -p sentinel-physics --test snapshot_perception --check
+
+  # ──────────────────────────────────────────────
+  # Rust eBPF feature - separate feature compile (parallel)
+  # ──────────────────────────────────────────────
+  rust-ebpf:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.config == 'true'
+    runs-on: ${{ vars.RUNNER_MODE == 'hosted' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64"]') }}
+    env:
+      CARGO_BUILD_JOBS: ${{ vars.RUNNER_MODE == 'hosted' && '2' || '3' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          components: clippy
+      - name: Configure local cache (self-hosted)
+        if: vars.RUNNER_MODE != 'hosted'
+        run: |
+          export CARGO_TARGET_DIR="$HOME/.cache/project-sentinel/cargo-target/${{ runner.name }}/target"
+          mkdir -p "$CARGO_TARGET_DIR"
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> "$GITHUB_ENV"
+      - name: Rust cache (hosted)
+        if: vars.RUNNER_MODE == 'hosted'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: sentinel-hosted-ebpf
 
       # eBPF: install kernel headers on hosted, soft-fail if unavailable
       - name: Install eBPF dependencies (hosted)
@@ -149,12 +225,6 @@ jobs:
 
       - name: Tests (eBPF feature)
         run: cargo test -p sentinel-ebpf --features ebpf || ${{ vars.RUNNER_MODE == 'hosted' && 'echo "::warning::eBPF tests failed (kernel headers may be missing)"' || 'exit 1' }}
-
-      - name: Unused dependencies
-        uses: taiki-e/install-action@288875dd3d64326724fa6d9593062d9f8ba0b131 # v2.67.30
-        with:
-          tool: cargo-machete
-      - run: cargo machete || echo "::warning::Unused dependencies found (non-blocking)"
 
   # ──────────────────────────────────────────────
   # Go - only when cmd/ changed
@@ -260,14 +330,17 @@ jobs:
   # ──────────────────────────────────────────────
   ci-pass:
     if: always()
-    needs: [lint, rust, go, console, schemas]
+    needs: [lint, rust-static, rust-doc, rust-test, rust-ebpf, go, console, schemas]
     runs-on: ${{ vars.RUNNER_MODE == 'hosted' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64"]') }}
     steps:
       - name: Evaluate results
         run: |
           results=(
             "${{ needs.lint.result }}"
-            "${{ needs.rust.result }}"
+            "${{ needs.rust-static.result }}"
+            "${{ needs.rust-doc.result }}"
+            "${{ needs.rust-test.result }}"
+            "${{ needs.rust-ebpf.result }}"
             "${{ needs.go.result }}"
             "${{ needs.console.result }}"
             "${{ needs.schemas.result }}"

--- a/crates/sentinel-hippocampus/src/store.rs
+++ b/crates/sentinel-hippocampus/src/store.rs
@@ -17,6 +17,8 @@ const CACHE_STATE: TableDefinition<&str, &[u8]> = TableDefinition::new("cache_st
 const GOALS: TableDefinition<&str, &[u8]> = TableDefinition::new("goals");
 const ARCHIVE: TableDefinition<&str, &[u8]> = TableDefinition::new("archive");
 
+const MAX_EPISODES_PER_AGENT: usize = 1000;
+
 /// Persistent state for narrative memory (serializable for redb storage).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NarrativeState {
@@ -61,7 +63,12 @@ impl HippocampusStore {
 
     /// Store episodes for an agent (overwrites existing).
     pub fn store_episodes(&self, agent: &str, eps: &[Episode]) -> anyhow::Result<()> {
-        let json = serde_json::to_vec(eps)?;
+        let retained = if eps.len() > MAX_EPISODES_PER_AGENT {
+            &eps[eps.len() - MAX_EPISODES_PER_AGENT..]
+        } else {
+            eps
+        };
+        let json = serde_json::to_vec(retained)?;
         let write_txn = self.db.begin_write()?;
         {
             let mut table = write_txn.open_table(EPISODES)?;
@@ -85,7 +92,7 @@ impl HippocampusStore {
         }
     }
 
-    /// Append episodes to an agent's existing list.
+    /// Append episodes to an agent's existing list. Caps at 1000 live episodes per agent.
     pub fn append_episodes(&self, agent: &str, new: &[Episode]) -> anyhow::Result<()> {
         let mut existing = self.load_episodes(agent)?;
         existing.extend_from_slice(new);
@@ -302,8 +309,8 @@ impl HippocampusStore {
         let mut existing = self.load_archive(agent)?;
         existing.extend_from_slice(new);
         // Cap at 1000 episodes — drop oldest if exceeding
-        if existing.len() > 1000 {
-            let excess = existing.len() - 1000;
+        if existing.len() > MAX_EPISODES_PER_AGENT {
+            let excess = existing.len() - MAX_EPISODES_PER_AGENT;
             existing.drain(..excess);
         }
         self.store_archive(agent, &existing)
@@ -411,6 +418,20 @@ mod tests {
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].summary, "Erstes");
         assert_eq!(loaded[1].summary, "Zweites");
+    }
+
+    #[test]
+    fn test_live_episodes_cap_at_1000() {
+        let (store, _dir) = temp_store();
+        let many: Vec<Episode> = (0..1100)
+            .map(|i| make_episode(i, &format!("Episode {i}")))
+            .collect();
+
+        store.append_episodes("Thomas", &many).unwrap();
+        let loaded = store.load_episodes("Thomas").unwrap();
+        assert_eq!(loaded.len(), 1000);
+        assert_eq!(loaded[0].summary, "Episode 100");
+        assert_eq!(loaded[999].summary, "Episode 1099");
     }
 
     #[test]

--- a/crates/sentinel-limbo/src/event_store.rs
+++ b/crates/sentinel-limbo/src/event_store.rs
@@ -47,6 +47,8 @@ const CREATE_IDX_EVENTS_CORRELATION: &str =
     "CREATE INDEX IF NOT EXISTS idx_events_correlation ON events(correlation_id)";
 const CREATE_IDX_EVENTS_CAUSATION: &str =
     "CREATE INDEX IF NOT EXISTS idx_events_causation ON events(causation_id)";
+const CREATE_IDX_EVENTS_EVENT_ID: &str =
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_event_id ON events(event_id)";
 const CREATE_IDX_EVENTS_OPERATION: &str =
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_events_operation ON events(operation_id)";
 
@@ -58,11 +60,15 @@ CREATE TABLE IF NOT EXISTS outbox (
     payload TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     created_at INTEGER NOT NULL,
-    published_at INTEGER
+    published_at INTEGER,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
 )";
 
 const CREATE_IDX_OUTBOX_PENDING: &str =
     "CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(status) WHERE status = 'pending'";
+const CREATE_IDX_OUTBOX_EVENT_ID: &str =
+    "CREATE INDEX IF NOT EXISTS idx_outbox_event_id ON outbox(event_id)";
 
 const CREATE_SNAPSHOTS: &str = "
 CREATE TABLE IF NOT EXISTS snapshots (
@@ -197,9 +203,12 @@ impl EventStore {
         conn.execute(CREATE_IDX_EVENTS_TYPE, [])?;
         conn.execute(CREATE_IDX_EVENTS_CORRELATION, [])?;
         conn.execute(CREATE_IDX_EVENTS_CAUSATION, [])?;
+        conn.execute(CREATE_IDX_EVENTS_EVENT_ID, [])?;
         conn.execute(CREATE_IDX_EVENTS_OPERATION, [])?;
         conn.execute_batch(CREATE_OUTBOX)?;
+        Self::ensure_outbox_migrations(&conn)?;
         conn.execute(CREATE_IDX_OUTBOX_PENDING, [])?;
+        conn.execute(CREATE_IDX_OUTBOX_EVENT_ID, [])?;
         conn.execute_batch(CREATE_SNAPSHOTS)?;
         conn.execute(CREATE_IDX_SNAPSHOTS_AGGREGATE, [])?;
         conn.execute_batch(CREATE_WORLD_SNAPSHOTS)?;
@@ -223,6 +232,31 @@ impl EventStore {
             conn: Arc::new(Mutex::new(conn)),
             path: PathBuf::from(path),
         })
+    }
+
+    fn ensure_outbox_migrations(conn: &Connection) -> anyhow::Result<()> {
+        if !Self::table_has_column(conn, "outbox", "retry_count")? {
+            conn.execute(
+                "ALTER TABLE outbox ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
+                [],
+            )?;
+        }
+        if !Self::table_has_column(conn, "outbox", "last_error")? {
+            conn.execute("ALTER TABLE outbox ADD COLUMN last_error TEXT", [])?;
+        }
+        Ok(())
+    }
+
+    fn table_has_column(conn: &Connection, table: &str, column: &str) -> anyhow::Result<bool> {
+        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let name: String = row.get(1)?;
+            if name == column {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Oeffnet den Event Store **read-only** — fuer reine Consumer (z.B. Dashboard/CAS-Pusher),
@@ -586,13 +620,14 @@ impl EventStore {
         last_event_id: i64,
     ) -> anyhow::Result<i64> {
         let _telemetry_start = std::time::Instant::now();
-        let conn = self
+        let mut conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let tx = conn.transaction()?;
 
         // Aktuelle Version ermitteln
-        let current_version: i32 = conn
+        let current_version: i32 = tx
             .query_row(
                 "SELECT COALESCE(MAX(version), 0) FROM snapshots WHERE aggregate_id = ?1",
                 params![aggregate_id],
@@ -605,7 +640,7 @@ impl EventStore {
             .unwrap_or_default()
             .as_millis() as i64;
 
-        conn.execute(
+        tx.execute(
             "INSERT INTO snapshots (aggregate_id, snapshot_type, payload, last_event_id, version, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 aggregate_id,
@@ -616,7 +651,12 @@ impl EventStore {
                 now_ms,
             ],
         )?;
-        let row_id = conn.last_insert_rowid();
+        let row_id = tx.last_insert_rowid();
+        tx.execute(
+            "DELETE FROM snapshots WHERE aggregate_id = ?1 AND id <> ?2",
+            params![aggregate_id, row_id],
+        )?;
+        tx.commit()?;
         #[cfg(feature = "telemetry")]
         {
             let reg = sentinel_telemetry::MetricsRegistry::global();
@@ -654,6 +694,32 @@ impl EventStore {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Loescht alte Snapshot-Versionen und behaelt pro Aggregate nur die neueste Version.
+    ///
+    /// Diese Retention betrifft die kompakte `snapshots`-Tabelle, nicht die immutable
+    /// `world_snapshots` Time-Machine-Tabelle.
+    pub fn retain_latest_snapshots(&self) -> anyhow::Result<u64> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let deleted = conn.execute(
+            "DELETE FROM snapshots
+             WHERE id NOT IN (
+                 SELECT (
+                     SELECT s2.id
+                     FROM snapshots s2
+                     WHERE s2.aggregate_id = aggregates.aggregate_id
+                     ORDER BY s2.version DESC, s2.id DESC
+                     LIMIT 1
+                 )
+                 FROM (SELECT DISTINCT aggregate_id FROM snapshots) aggregates
+             )",
+            [],
+        )? as u64;
+        Ok(deleted)
     }
 
     // ── Outbox ──────────────────────────────────
@@ -797,13 +863,67 @@ impl EventStore {
     /// Nutzt die shared Connection — kein separater Thread, kein Lock-Konflikt.
     /// Gibt die Anzahl geloeschter Rows zurueck (0 = fertig).
     pub fn prune_batch(&self, cutoff_event_id: i64, batch_size: i64) -> anyhow::Result<u64> {
+        if batch_size <= 0 {
+            return Ok(0);
+        }
+
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
+        let tx = conn.transaction()?;
+
+        tx.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS prune_batch_ids (
+                id INTEGER PRIMARY KEY,
+                event_id TEXT NOT NULL
+            );
+            DELETE FROM prune_batch_ids;",
+        )?;
+
+        let selected = tx.execute(
+            "INSERT INTO prune_batch_ids(id, event_id)
+             SELECT id, event_id
+             FROM events
+             WHERE id < ?1
+             ORDER BY id
+             LIMIT ?2",
+            params![cutoff_event_id, batch_size],
+        )? as u64;
+
+        if selected == 0 {
+            tx.commit()?;
+            return Ok(0);
+        }
+
+        tx.execute(
+            "DELETE FROM outbox
+             WHERE event_id IN (SELECT event_id FROM prune_batch_ids)",
+            [],
+        )?;
+        tx.execute(
+            "DELETE FROM events
+             WHERE id IN (SELECT id FROM prune_batch_ids)",
+            [],
+        )?;
+        tx.commit()?;
+
+        Ok(selected)
+    }
+
+    /// Loescht Outbox-Zeilen, deren Event bereits nicht mehr existiert.
+    ///
+    /// Fuer Live-Grossdatenbanken ist der bevorzugte Pfad die Offline-CTAS-Kompaktion.
+    /// Diese Methode ist als Maintenance-/Test-Primitive gedacht.
+    pub fn delete_orphan_outbox(&self) -> anyhow::Result<u64> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("Lock poisoned: {e}"))?;
         let deleted = conn.execute(
-            "DELETE FROM events WHERE id IN (SELECT id FROM events WHERE id < ?1 LIMIT ?2)",
-            params![cutoff_event_id, batch_size],
+            "DELETE FROM outbox
+             WHERE event_id NOT IN (SELECT event_id FROM events)",
+            [],
         )? as u64;
         Ok(deleted)
     }
@@ -1353,6 +1473,224 @@ mod tests {
     }
 
     #[test]
+    fn test_outbox_event_id_index_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-outbox-index.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let conn = store.conn();
+        let exists: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_event_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1);
+
+        let exists: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_outbox_event_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1);
+
+        let mut stmt = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 DELETE FROM outbox
+                 WHERE event_id IN (
+                     SELECT event_id FROM events WHERE id < 100 ORDER BY id LIMIT 10
+                 )",
+            )
+            .unwrap();
+        let details = stmt
+            .query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        assert!(
+            details.contains("idx_outbox_event_id"),
+            "outbox delete should use idx_outbox_event_id, plan:\n{details}"
+        );
+    }
+
+    #[test]
+    fn test_open_migrates_legacy_outbox_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-legacy-outbox.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT NOT NULL UNIQUE,
+                    event_type TEXT NOT NULL,
+                    aggregate_id TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    correlation_id TEXT NOT NULL,
+                    causation_id TEXT,
+                    operation_id TEXT NOT NULL,
+                    tick INTEGER NOT NULL,
+                    timestamp_ms INTEGER NOT NULL,
+                    schema_version INTEGER NOT NULL DEFAULT 1,
+                    compensation_type TEXT NOT NULL DEFAULT 'none'
+                );
+                CREATE TABLE outbox (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT NOT NULL REFERENCES events(event_id),
+                    topic TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at INTEGER NOT NULL,
+                    published_at INTEGER
+                );",
+            )
+            .unwrap();
+        }
+
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+        let conn = store.conn();
+        assert!(EventStore::table_has_column(&conn, "outbox", "retry_count").unwrap());
+        assert!(EventStore::table_has_column(&conn, "outbox", "last_error").unwrap());
+    }
+
+    #[test]
+    fn test_prune_batch_deletes_outbox_for_all_statuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-prune-outbox.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let events = [
+            test_event("agent_action_received", "AGENT-01"),
+            test_event("agent_action_received", "AGENT-02"),
+            test_event("agent_action_received", "AGENT-03"),
+            test_event("agent_action_received", "AGENT-04"),
+        ];
+        for event in &events {
+            store
+                .append_with_outbox(event, "sentinel/events/agent_action_received/test")
+                .unwrap();
+        }
+
+        {
+            let conn = store.conn();
+            conn.execute(
+                "UPDATE outbox SET status = 'published' WHERE event_id = ?1",
+                params![events[0].event_id],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE outbox SET status = 'failed' WHERE event_id = ?1",
+                params![events[1].event_id],
+            )
+            .unwrap();
+        }
+
+        let cutoff: i64 = {
+            let conn = store.conn();
+            conn.query_row(
+                "SELECT id FROM events WHERE event_id = ?1",
+                params![events[3].event_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        let deleted = store.prune_batch(cutoff, 10).unwrap();
+        assert_eq!(deleted, 3);
+
+        let conn = store.conn();
+        let event_count: i64 = conn
+            .query_row("SELECT count(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+        let outbox_count: i64 = conn
+            .query_row("SELECT count(*) FROM outbox", [], |row| row.get(0))
+            .unwrap();
+        let remaining_event_id: String = conn
+            .query_row("SELECT event_id FROM outbox", [], |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(event_count, 1);
+        assert_eq!(outbox_count, 1);
+        assert_eq!(remaining_event_id, events[3].event_id);
+    }
+
+    #[test]
+    fn test_prune_batch_works_with_foreign_keys_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-prune-fk.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        {
+            let conn = store.conn();
+            conn.execute_batch("PRAGMA foreign_keys = ON").unwrap();
+            let fk_enabled: i64 = conn
+                .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(fk_enabled, 1);
+        }
+
+        let event = test_event("agent_action_received", "AGENT-01");
+        store
+            .append_with_outbox(&event, "sentinel/events/agent_action_received/AGENT-01")
+            .unwrap();
+
+        let deleted = store.prune_batch(i64::MAX, 10).unwrap();
+        assert_eq!(deleted, 1);
+
+        let conn = store.conn();
+        let orphan_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM outbox o
+                 WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.event_id = o.event_id)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphan_count, 0);
+    }
+
+    #[test]
+    fn test_delete_orphan_outbox_removes_only_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-orphan-cleanup.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let event = test_event("agent_action_received", "AGENT-01");
+        store
+            .append_with_outbox(&event, "sentinel/events/agent_action_received/AGENT-01")
+            .unwrap();
+
+        {
+            let conn = store.conn();
+            conn.execute_batch("PRAGMA foreign_keys = OFF").unwrap();
+            conn.execute(
+                "INSERT INTO outbox (event_id, topic, payload, status, created_at)
+                 VALUES ('missing-event', 'sentinel/events/test/missing', '{}', 'pending', 1)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let deleted = store.delete_orphan_outbox().unwrap();
+        assert_eq!(deleted, 1);
+
+        let conn = store.conn();
+        let outbox_count: i64 = conn
+            .query_row("SELECT count(*) FROM outbox", [], |row| row.get(0))
+            .unwrap();
+        let remaining_event_id: String = conn
+            .query_row("SELECT event_id FROM outbox", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(outbox_count, 1);
+        assert_eq!(remaining_event_id, event.event_id);
+    }
+
+    #[test]
     fn test_get_events_by_aggregate() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test-aggregate.db");
@@ -1447,6 +1785,47 @@ mod tests {
         assert_eq!(snap2.version, 2);
         assert_eq!(snap2.last_event_id, 10);
         assert_eq!(snap2.payload, r#"{"hunger":80}"#);
+    }
+
+    #[test]
+    fn test_retain_latest_snapshots_keeps_latest_per_aggregate() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-snap-retention.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        store
+            .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":50}"#, 5)
+            .unwrap();
+        store
+            .save_snapshot("AGENT-01", "bio_state", r#"{"hunger":80}"#, 10)
+            .unwrap();
+        store
+            .save_snapshot("AGENT-02", "bio_state", r#"{"hunger":30}"#, 7)
+            .unwrap();
+
+        let deleted = store.retain_latest_snapshots().unwrap();
+        assert_eq!(deleted, 0);
+
+        let conn = store.conn();
+        let snapshot_count: i64 = conn
+            .query_row("SELECT count(*) FROM snapshots", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(snapshot_count, 2);
+        let agent_01_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM snapshots WHERE aggregate_id = 'AGENT-01'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(agent_01_count, 1);
+        drop(conn);
+
+        let snap = store.get_latest_snapshot("AGENT-01").unwrap().unwrap();
+        assert_eq!(snap.version, 2);
+        assert_eq!(snap.payload, r#"{"hunger":80}"#);
+        let snap = store.get_latest_snapshot("AGENT-02").unwrap().unwrap();
+        assert_eq!(snap.version, 1);
     }
 
     /// AC5: Rebuild aus Events - Reihenfolge und Daten bleiben erhalten.
@@ -1646,6 +2025,25 @@ mod tests {
             result.is_err(),
             "DELETE auf jungen Snapshot sollte vom Trigger blockiert werden"
         );
+    }
+
+    #[test]
+    fn test_snapshot_immutable_trigger_installed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test-immutable-trigger.db");
+        let store = EventStore::open(path.to_str().unwrap()).unwrap();
+
+        let conn = store.conn();
+        let trigger_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'trigger' AND name = 'protect_recent_snapshots'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(trigger_sql.contains("BEFORE DELETE ON world_snapshots"));
+        assert!(trigger_sql.contains("604800000"));
     }
 
     /// #264: Immutable Snapshots — DELETE auf alten Snapshot funktioniert.

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,4 +1,5 @@
 github.com/silentspike/project-sentinel/pkg/sentinel-go v0.0.0-20260426185014-30c7fd621515/go.mod h1:O23Is4HFuLB04LZFerrjWhIsX/W9wWmlGRlusXQVUdM=
+github.com/silentspike/project-sentinel/pkg/sentinel-go v0.0.0-20260528210141-be607cd65df5/go.mod h1:2AQrmE0MhYRgEDeR6foQTIL0ocx4GeFKQV6RJPSABDI=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=

--- a/pkg/sentinel-go/eventstore/store.go
+++ b/pkg/sentinel-go/eventstore/store.go
@@ -68,6 +68,7 @@ CREATE INDEX IF NOT EXISTS idx_events_aggregate ON events(aggregate_id, id);
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type, id);
 CREATE INDEX IF NOT EXISTS idx_events_correlation ON events(correlation_id);
 CREATE INDEX IF NOT EXISTS idx_events_causation ON events(causation_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_event_id ON events(event_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_events_operation ON events(operation_id)
 `
 
@@ -78,10 +79,15 @@ const createOutbox = `CREATE TABLE IF NOT EXISTS outbox (
 	payload TEXT NOT NULL,
 	status TEXT NOT NULL DEFAULT 'pending',
 	created_at INTEGER NOT NULL,
-	published_at INTEGER
+	published_at INTEGER,
+	retry_count INTEGER NOT NULL DEFAULT 0,
+	last_error TEXT
 )`
 
-const createOutboxIndex = `CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(status) WHERE status = 'pending'`
+const createOutboxIndex = `
+CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(status) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_outbox_event_id ON outbox(event_id)
+`
 
 const pragmas = `
 PRAGMA journal_mode = WAL;
@@ -117,12 +123,57 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("eventstore create outbox: %w", err)
 	}
+	if err := ensureOutboxColumns(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	if _, err := db.Exec(createOutboxIndex); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("eventstore create outbox index: %w", err)
 	}
 
 	return &Store{db: db}, nil
+}
+
+func ensureOutboxColumns(db *sql.DB) error {
+	if ok, err := tableHasColumn(db, "outbox", "retry_count"); err != nil {
+		return err
+	} else if !ok {
+		if _, err := db.Exec(`ALTER TABLE outbox ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("eventstore migrate outbox retry_count: %w", err)
+		}
+	}
+	if ok, err := tableHasColumn(db, "outbox", "last_error"); err != nil {
+		return err
+	} else if !ok {
+		if _, err := db.Exec(`ALTER TABLE outbox ADD COLUMN last_error TEXT`); err != nil {
+			return fmt.Errorf("eventstore migrate outbox last_error: %w", err)
+		}
+	}
+	return nil
+}
+
+func tableHasColumn(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return false, fmt.Errorf("eventstore table info %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, fmt.Errorf("eventstore scan table info %s: %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // AppendWithOutbox atomically inserts a DomainEvent and an outbox entry

--- a/pkg/sentinel-go/eventstore/store_test.go
+++ b/pkg/sentinel-go/eventstore/store_test.go
@@ -1,10 +1,13 @@
 package eventstore
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func tempDB(t *testing.T) (*Store, string) {
@@ -57,6 +60,87 @@ func TestOpenAndClose(t *testing.T) {
 	}
 	if pending != 0 {
 		t.Errorf("expected 0 pending outbox, got %d", pending)
+	}
+}
+
+func TestSchemaIndexes(t *testing.T) {
+	store, _ := tempDB(t)
+
+	for _, name := range []string{"idx_events_event_id", "idx_outbox_event_id"} {
+		var count int
+		if err := store.db.QueryRow(
+			`SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = ?`,
+			name,
+		).Scan(&count); err != nil {
+			t.Fatalf("query index %s: %v", name, err)
+		}
+		if count != 1 {
+			t.Fatalf("expected index %s to exist, found %d", name, count)
+		}
+	}
+
+	for _, name := range []string{"retry_count", "last_error"} {
+		ok, err := tableHasColumn(store.db, "outbox", name)
+		if err != nil {
+			t.Fatalf("query outbox column %s: %v", name, err)
+		}
+		if !ok {
+			t.Fatalf("expected outbox column %s to exist", name)
+		}
+	}
+}
+
+func TestOpenMigratesLegacyOutboxColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.db")
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_id TEXT NOT NULL UNIQUE,
+		event_type TEXT NOT NULL,
+		aggregate_id TEXT NOT NULL,
+		payload TEXT NOT NULL,
+		correlation_id TEXT NOT NULL,
+		causation_id TEXT,
+		operation_id TEXT NOT NULL,
+		tick INTEGER NOT NULL,
+		timestamp_ms INTEGER NOT NULL,
+		schema_version INTEGER NOT NULL DEFAULT 1,
+		compensation_type TEXT NOT NULL DEFAULT 'none'
+	);
+	CREATE TABLE outbox (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_id TEXT NOT NULL REFERENCES events(event_id),
+		topic TEXT NOT NULL,
+		payload TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'pending',
+		created_at INTEGER NOT NULL,
+		published_at INTEGER
+	);`); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open legacy db: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	for _, name := range []string{"retry_count", "last_error"} {
+		ok, err := tableHasColumn(store.db, "outbox", name)
+		if err != nil {
+			t.Fatalf("query migrated column %s: %v", name, err)
+		}
+		if !ok {
+			t.Fatalf("expected migrated outbox column %s to exist", name)
+		}
 	}
 }
 

--- a/services/sentinel-daemon/src/bin/sentinel-db-maint.rs
+++ b/services/sentinel-daemon/src/bin/sentinel-db-maint.rs
@@ -1,0 +1,451 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+use sentinel_limbo::rusqlite::{params, Connection};
+use sentinel_limbo::EventStore;
+use serde_json::json;
+
+const MAX_PLAUSIBLE_SIM_TICK_EXCLUSIVE: i64 = 1_000_000_000;
+const EVOLUTION_PER_AGENT_FIELD_KEEP: i64 = 2000;
+const EVOLUTION_GLOBAL_HIGH_WATER: i64 = 499_000;
+const EVOLUTION_GLOBAL_RETAIN: i64 = 490_000;
+const EVENTS_DB_MAX_BYTES: u64 = 200 * 1024 * 1024;
+const EVOLUTION_DB_MAX_BYTES: u64 = 50 * 1024 * 1024;
+
+#[derive(Parser)]
+#[command(name = "sentinel-db-maint")]
+#[command(about = "Offline SQLite maintenance for Sentinel data stores")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    InspectEvents {
+        #[arg(long)]
+        path: PathBuf,
+    },
+    CompactEvents {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        output: PathBuf,
+    },
+    InspectEvolution {
+        #[arg(long)]
+        path: PathBuf,
+    },
+    CompactEvolution {
+        #[arg(long)]
+        input: PathBuf,
+        #[arg(long)]
+        output: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::InspectEvents { path } => inspect_events(&path),
+        Command::CompactEvents { input, output } => compact_events(&input, &output),
+        Command::InspectEvolution { path } => inspect_evolution(&path),
+        Command::CompactEvolution { input, output } => compact_evolution(&input, &output),
+    }
+}
+
+fn inspect_events(path: &Path) -> Result<()> {
+    let conn = Connection::open(path).with_context(|| format!("open {}", path.display()))?;
+    let events = scalar_i64(&conn, "SELECT count(*) FROM events")?;
+    let outbox = scalar_i64(&conn, "SELECT count(*) FROM outbox")?;
+    let orphan_outbox = scalar_i64(
+        &conn,
+        "SELECT count(*) FROM outbox
+         WHERE event_id NOT IN (SELECT event_id FROM events)",
+    )?;
+    let snapshots = scalar_i64(&conn, "SELECT count(*) FROM snapshots")?;
+    let duplicate_snapshot_aggregates = scalar_i64(
+        &conn,
+        "SELECT count(*) FROM (
+             SELECT aggregate_id FROM snapshots GROUP BY aggregate_id HAVING count(*) > 1
+         )",
+    )?;
+    let immutable_trigger = scalar_i64(
+        &conn,
+        "SELECT count(*) FROM sqlite_master
+         WHERE type = 'trigger'
+           AND name = 'protect_recent_snapshots'
+           AND sql LIKE '%BEFORE DELETE ON world_snapshots%'",
+    )?;
+    let events_event_id_index = index_exists(&conn, "idx_events_event_id")?;
+    let outbox_event_id_index = index_exists(&conn, "idx_outbox_event_id")?;
+    let integrity = integrity_check(&conn)?;
+    println!(
+        "{}",
+        json!({
+            "events": events,
+            "outbox": outbox,
+            "orphan_outbox": orphan_outbox,
+            "snapshots": snapshots,
+            "duplicate_snapshot_aggregates": duplicate_snapshot_aggregates,
+            "protect_recent_snapshots_trigger": immutable_trigger == 1,
+            "idx_events_event_id": events_event_id_index,
+            "idx_outbox_event_id": outbox_event_id_index,
+            "integrity_check": integrity,
+        })
+    );
+    Ok(())
+}
+
+fn compact_events(input: &Path, output: &Path) -> Result<()> {
+    require_output_absent(output)?;
+    let output_str = output
+        .to_str()
+        .with_context(|| format!("non-UTF8 output path {}", output.display()))?;
+    let store = EventStore::open(output_str)?;
+    drop(store);
+
+    let mut conn = Connection::open(output)?;
+    conn.execute(
+        "ATTACH DATABASE ?1 AS src",
+        params![input.display().to_string()],
+    )?;
+
+    let source_has_retry_count = table_has_column(&conn, "src", "outbox", "retry_count")?;
+    let source_has_last_error = table_has_column(&conn, "src", "outbox", "last_error")?;
+
+    let tx = conn.transaction()?;
+    tx.execute_batch(
+        "INSERT INTO events
+         (id, event_id, event_type, aggregate_id, payload, correlation_id, causation_id,
+          operation_id, tick, timestamp_ms, schema_version, compensation_type)
+         SELECT id, event_id, event_type, aggregate_id, payload, correlation_id, causation_id,
+                operation_id, tick, timestamp_ms, schema_version, compensation_type
+         FROM src.events
+         ORDER BY id;
+
+         INSERT INTO snapshots
+         (id, aggregate_id, snapshot_type, payload, last_event_id, version, created_at)
+         SELECT s.id, s.aggregate_id, s.snapshot_type, s.payload, s.last_event_id, s.version, s.created_at
+         FROM src.snapshots s
+         WHERE s.id IN (
+             SELECT (
+                 SELECT s2.id
+                 FROM src.snapshots s2
+                 WHERE s2.aggregate_id = aggregates.aggregate_id
+                 ORDER BY s2.version DESC, s2.id DESC
+                 LIMIT 1
+             )
+             FROM (SELECT DISTINCT aggregate_id FROM src.snapshots) aggregates
+         )
+         ORDER BY s.id;
+
+         INSERT INTO world_snapshots
+         (id, tier, tick, sim_hour, last_event_id, payload_size, payload, created_at)
+         SELECT id, tier, tick, sim_hour, last_event_id, payload_size, payload, created_at
+         FROM src.world_snapshots
+         ORDER BY tick;
+
+         INSERT INTO projection_offsets
+         (projection_name, last_event_id, updated_at)
+         SELECT projection_name, last_event_id, updated_at
+         FROM src.projection_offsets;",
+    )?;
+
+    let retry_count_expr = if source_has_retry_count {
+        "COALESCE(o.retry_count, 0)"
+    } else {
+        "0"
+    };
+    let last_error_expr = if source_has_last_error {
+        "o.last_error"
+    } else {
+        "NULL"
+    };
+    tx.execute_batch(&format!(
+        "INSERT INTO outbox
+         (id, event_id, topic, payload, status, created_at, published_at, retry_count, last_error)
+         SELECT o.id, o.event_id, o.topic, o.payload, o.status, o.created_at, o.published_at,
+                {retry_count_expr}, {last_error_expr}
+         FROM src.outbox o
+         WHERE o.status IN ('pending', 'failed')
+           AND o.event_id IN (SELECT event_id FROM src.events)
+         ORDER BY o.id;"
+    ))?;
+
+    preserve_sqlite_sequence(&tx, "events")?;
+    preserve_sqlite_sequence(&tx, "outbox")?;
+    preserve_sqlite_sequence(&tx, "snapshots")?;
+    tx.commit()?;
+
+    checkpoint_wal(&conn)?;
+    validate_events_output(&conn, output)?;
+    inspect_events(output)
+}
+
+fn inspect_evolution(path: &Path) -> Result<()> {
+    let conn = Connection::open(path).with_context(|| format!("open {}", path.display()))?;
+    let rows = scalar_i64(&conn, "SELECT count(*) FROM personality_evolution")?;
+    let invalid_ticks = scalar_i64(
+        &conn,
+        "SELECT count(*) FROM personality_evolution
+         WHERE tick < 0 OR tick >= 1000000000",
+    )?;
+    let over_limit_groups = scalar_i64(
+        &conn,
+        "SELECT count(*) FROM (
+             SELECT agent_id, field
+             FROM personality_evolution
+             GROUP BY agent_id, field
+             HAVING count(*) > 2000
+         )",
+    )?;
+    let max_tick = optional_i64(&conn, "SELECT max(tick) FROM personality_evolution")?;
+    let integrity = integrity_check(&conn)?;
+    println!(
+        "{}",
+        json!({
+            "personality_evolution": rows,
+            "invalid_ticks": invalid_ticks,
+            "over_limit_groups": over_limit_groups,
+            "max_tick": max_tick,
+            "integrity_check": integrity,
+        })
+    );
+    Ok(())
+}
+
+fn compact_evolution(input: &Path, output: &Path) -> Result<()> {
+    require_output_absent(output)?;
+    let mut conn = Connection::open(output)?;
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         CREATE TABLE personality_evolution (
+             id INTEGER PRIMARY KEY AUTOINCREMENT,
+             agent_id TEXT NOT NULL,
+             tick INTEGER NOT NULL,
+             field TEXT NOT NULL,
+             change_type TEXT NOT NULL,
+             old_value TEXT,
+             new_value TEXT NOT NULL,
+             reason TEXT NOT NULL,
+             nmda_score REAL,
+             source TEXT NOT NULL DEFAULT 'realtime_judge',
+             created_at_ms INTEGER NOT NULL
+         );
+         CREATE INDEX idx_evolution_agent ON personality_evolution(agent_id, tick);
+         CREATE INDEX idx_evolution_source ON personality_evolution(source);
+         CREATE INDEX idx_evolution_agent_field_id
+             ON personality_evolution(agent_id, field, id DESC);",
+    )?;
+    conn.execute(
+        "ATTACH DATABASE ?1 AS src",
+        params![input.display().to_string()],
+    )?;
+
+    let tx = conn.transaction()?;
+    tx.execute(
+        "INSERT INTO personality_evolution
+         (id, agent_id, tick, field, change_type, old_value, new_value, reason,
+          nmda_score, source, created_at_ms)
+         SELECT id, agent_id, tick, field, change_type, old_value, new_value, reason,
+                nmda_score, source, created_at_ms
+         FROM (
+             SELECT *,
+                    row_number() OVER (
+                        PARTITION BY agent_id, field
+                        ORDER BY id DESC
+                    ) AS retention_rank
+             FROM src.personality_evolution
+             WHERE tick >= 0 AND tick < ?1
+         )
+         WHERE retention_rank <= ?2
+         ORDER BY id",
+        params![
+            MAX_PLAUSIBLE_SIM_TICK_EXCLUSIVE,
+            EVOLUTION_PER_AGENT_FIELD_KEEP
+        ],
+    )?;
+
+    let count: i64 = tx.query_row("SELECT COUNT(*) FROM personality_evolution", [], |row| {
+        row.get(0)
+    })?;
+    if count > EVOLUTION_GLOBAL_HIGH_WATER {
+        tx.execute(
+            "DELETE FROM personality_evolution
+             WHERE id <= (
+                 SELECT id
+                 FROM personality_evolution
+                 ORDER BY id DESC
+                 LIMIT 1 OFFSET ?1
+             )",
+            params![EVOLUTION_GLOBAL_RETAIN],
+        )?;
+    }
+    preserve_sqlite_sequence(&tx, "personality_evolution")?;
+    tx.commit()?;
+
+    checkpoint_wal(&conn)?;
+    validate_evolution_output(&conn, output)?;
+    inspect_evolution(output)
+}
+
+fn require_output_absent(path: &Path) -> Result<()> {
+    if path.exists() {
+        bail!("output already exists: {}", path.display());
+    }
+    Ok(())
+}
+
+fn scalar_i64(conn: &Connection, sql: &str) -> Result<i64> {
+    conn.query_row(sql, [], |row| row.get(0))
+        .with_context(|| format!("query scalar failed: {sql}"))
+}
+
+fn optional_i64(conn: &Connection, sql: &str) -> Result<Option<i64>> {
+    conn.query_row(sql, [], |row| row.get(0))
+        .with_context(|| format!("query optional scalar failed: {sql}"))
+}
+
+fn index_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+            params![name],
+            |row| row.get(0),
+        )
+        .with_context(|| format!("query index existence failed: {name}"))?;
+    Ok(count == 1)
+}
+
+fn integrity_check(conn: &Connection) -> Result<String> {
+    conn.query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .context("integrity_check failed")
+}
+
+fn checkpoint_wal(conn: &Connection) -> Result<()> {
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .context("wal checkpoint failed")
+}
+
+fn table_has_column(conn: &Connection, schema: &str, table: &str, column: &str) -> Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA {schema}.table_info({table})"))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn preserve_sqlite_sequence(
+    tx: &sentinel_limbo::rusqlite::Transaction<'_>,
+    table: &str,
+) -> Result<()> {
+    let fallback = match table {
+        "events" => "SELECT COALESCE(max(id), 0) FROM events",
+        "outbox" => "SELECT COALESCE(max(id), 0) FROM outbox",
+        "snapshots" => "SELECT COALESCE(max(id), 0) FROM snapshots",
+        "personality_evolution" => "SELECT COALESCE(max(id), 0) FROM personality_evolution",
+        _ => bail!("unsupported sqlite_sequence table: {table}"),
+    };
+    tx.execute(
+        "DELETE FROM sqlite_sequence WHERE name = ?1",
+        params![table],
+    )?;
+    tx.execute(
+        &format!(
+            "INSERT INTO sqlite_sequence(name, seq)
+             SELECT ?1, COALESCE(
+                 (SELECT seq FROM src.sqlite_sequence WHERE name = ?1),
+                 ({fallback})
+             )"
+        ),
+        params![table],
+    )?;
+    Ok(())
+}
+
+fn validate_events_output(conn: &Connection, path: &Path) -> Result<()> {
+    let integrity = integrity_check(conn)?;
+    if integrity != "ok" {
+        bail!("events output integrity_check failed: {integrity}");
+    }
+    let orphan_outbox = scalar_i64(
+        conn,
+        "SELECT count(*) FROM outbox
+         WHERE event_id NOT IN (SELECT event_id FROM events)",
+    )?;
+    if orphan_outbox != 0 {
+        bail!("events output has {orphan_outbox} orphan outbox rows");
+    }
+    let duplicate_snapshot_aggregates = scalar_i64(
+        conn,
+        "SELECT count(*) FROM (
+             SELECT aggregate_id FROM snapshots GROUP BY aggregate_id HAVING count(*) > 1
+         )",
+    )?;
+    if duplicate_snapshot_aggregates != 0 {
+        bail!("events output has duplicate snapshot aggregates: {duplicate_snapshot_aggregates}");
+    }
+    let immutable_trigger = scalar_i64(
+        conn,
+        "SELECT count(*) FROM sqlite_master
+         WHERE type = 'trigger'
+           AND name = 'protect_recent_snapshots'
+           AND sql LIKE '%BEFORE DELETE ON world_snapshots%'",
+    )?;
+    if immutable_trigger != 1 {
+        bail!("protect_recent_snapshots trigger missing from events output");
+    }
+    if !index_exists(conn, "idx_events_event_id")? {
+        bail!("idx_events_event_id missing from events output");
+    }
+    if !index_exists(conn, "idx_outbox_event_id")? {
+        bail!("idx_outbox_event_id missing from events output");
+    }
+    let size = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .len();
+    if size >= EVENTS_DB_MAX_BYTES {
+        bail!("events output too large: {size} bytes, limit is {EVENTS_DB_MAX_BYTES} bytes");
+    }
+    Ok(())
+}
+
+fn validate_evolution_output(conn: &Connection, path: &Path) -> Result<()> {
+    let integrity = integrity_check(conn)?;
+    if integrity != "ok" {
+        bail!("evolution output integrity_check failed: {integrity}");
+    }
+    let invalid_ticks = scalar_i64(
+        conn,
+        "SELECT count(*) FROM personality_evolution
+         WHERE tick < 0 OR tick >= 1000000000",
+    )?;
+    if invalid_ticks != 0 {
+        bail!("evolution output has {invalid_ticks} invalid ticks");
+    }
+    let over_limit_groups = scalar_i64(
+        conn,
+        "SELECT count(*) FROM (
+             SELECT agent_id, field
+             FROM personality_evolution
+             GROUP BY agent_id, field
+             HAVING count(*) > 2000
+         )",
+    )?;
+    if over_limit_groups != 0 {
+        bail!("evolution output has {over_limit_groups} over-limit groups");
+    }
+    let size = std::fs::metadata(path)
+        .with_context(|| format!("stat {}", path.display()))?
+        .len();
+    if size >= EVOLUTION_DB_MAX_BYTES {
+        bail!("evolution output too large: {size} bytes, limit is {EVOLUTION_DB_MAX_BYTES} bytes");
+    }
+    Ok(())
+}

--- a/services/sentinel-daemon/src/operator_api.rs
+++ b/services/sentinel-daemon/src/operator_api.rs
@@ -807,7 +807,16 @@ fn handle_http_request(request: HttpRequest, state: &AppState) -> HttpResponse {
                     serde_json::json!({"accepted": false, "message": "Zu wenige Snapshots fuer Pruning"}),
                 );
             }
-            let prune_point = snapshots[snapshots.len() - 2].last_event_id;
+            let prune_point = match crate::snapshot::prune_cutoff_from_ordered_snapshots(&snapshots)
+            {
+                Some(cutoff) => cutoff,
+                None => {
+                    return json_response(
+                        200,
+                        serde_json::json!({"accepted": false, "message": "Zu wenige Snapshots fuer Pruning"}),
+                    );
+                }
+            };
             if !state.event_store.can_prune(prune_point).unwrap_or(false) {
                 return json_response(
                     200,

--- a/services/sentinel-daemon/src/orchestrator.rs
+++ b/services/sentinel-daemon/src/orchestrator.rs
@@ -53,6 +53,63 @@ use crate::runtime_health;
 use crate::shift::{agents_for_shift, detect_current_shift, detect_shift_from_sim_hour};
 use crate::signal::wait_for_shutdown;
 
+const PERSONALITY_EVOLUTION_PER_AGENT_FIELD_KEEP: i64 = 2000;
+const PERSONALITY_EVOLUTION_GLOBAL_HIGH_WATER: i64 = 499_000;
+const PERSONALITY_EVOLUTION_GLOBAL_RETAIN: i64 = 490_000;
+
+fn retain_personality_evolution_agent_field(
+    evo_db: &sentinel_limbo::rusqlite::Connection,
+    agent_id: &str,
+    field: &str,
+) -> Result<()> {
+    evo_db
+        .execute(
+            "DELETE FROM personality_evolution
+             WHERE agent_id = ?1
+               AND field = ?2
+               AND id <= (
+                 SELECT id
+                 FROM personality_evolution
+                 WHERE agent_id = ?1 AND field = ?2
+                 ORDER BY id DESC
+                 LIMIT 1 OFFSET ?3
+               )",
+            sentinel_limbo::rusqlite::params![
+                agent_id,
+                field,
+                PERSONALITY_EVOLUTION_PER_AGENT_FIELD_KEEP
+            ],
+        )
+        .context("personality_evolution agent-field retention failed")?;
+    Ok(())
+}
+
+fn retain_personality_evolution_global(
+    evo_db: &sentinel_limbo::rusqlite::Connection,
+) -> Result<()> {
+    let count: i64 = evo_db
+        .query_row("SELECT COUNT(*) FROM personality_evolution", [], |row| {
+            row.get(0)
+        })
+        .context("personality_evolution global retention count failed")?;
+    if count <= PERSONALITY_EVOLUTION_GLOBAL_HIGH_WATER {
+        return Ok(());
+    }
+    evo_db
+        .execute(
+            "DELETE FROM personality_evolution
+             WHERE id <= (
+               SELECT id
+               FROM personality_evolution
+               ORDER BY id DESC
+               LIMIT 1 OFFSET ?1
+             )",
+            sentinel_limbo::rusqlite::params![PERSONALITY_EVOLUTION_GLOBAL_RETAIN],
+        )
+        .context("personality_evolution global retention failed")?;
+    Ok(())
+}
+
 /// Mapping von shift_set auf (start_hour, end_hour).
 fn shift_hours(shift_set: u8) -> (u8, u8) {
     match shift_set {
@@ -3122,12 +3179,11 @@ fn ecs_tick_loop(
                         _cutoff,
                     ) => {
                         // Auto-detect cutoff: behalte die 2 neuesten World-Snapshots (Restore-Puffer),
-                        // prune alle Events davor. list_world_snapshots() liefert ORDER BY tick DESC,
-                        // also ist der zweitneueste Snapshot Index 1 (NICHT len-2 = zweitältester — #475:
-                        // der Index-Bug ergab einen uralten cutoff < min(event_id) → prune loeschte nie etwas).
+                        // prune alle Events davor.
                         if let Ok(snapshots) = event_store_for_prune.list_world_snapshots() {
-                            if snapshots.len() >= 2 {
-                                let prune_point = snapshots[1].last_event_id;
+                            if let Some(prune_point) =
+                                crate::snapshot::prune_cutoff_from_ordered_snapshots(&snapshots)
+                            {
                                 snapshot_manager.start_prune(prune_point);
                             }
                         }
@@ -3972,6 +4028,28 @@ fn ecs_tick_loop(
                                 ],
                             ).is_ok() {
                                 written += 1;
+                                if let Err(retention_err) =
+                                    retain_personality_evolution_agent_field(
+                                        &evo_db,
+                                        &agent_id,
+                                        "memory_consolidation",
+                                    )
+                                {
+                                    warn!(
+                                        agent = %agent_id,
+                                        error = %retention_err,
+                                        "personality_evolution: agent-field retention fehlgeschlagen"
+                                    );
+                                }
+                            }
+                        }
+                        if written > 0 {
+                            if let Err(retention_err) = retain_personality_evolution_global(&evo_db)
+                            {
+                                warn!(
+                                    error = %retention_err,
+                                    "personality_evolution: global retention fehlgeschlagen"
+                                );
                             }
                         }
                         info!(
@@ -5879,6 +5957,65 @@ mod tests {
         assert!(
             !agent_under_active_healing(&health, AgentId(99)),
             "unknown -> despawn ok"
+        );
+    }
+
+    #[test]
+    fn personality_evolution_agent_field_retention_uses_insert_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("evolution.db");
+        let db = sentinel_limbo::rusqlite::Connection::open(path).unwrap();
+        db.execute_batch(
+            "CREATE TABLE personality_evolution (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT NOT NULL,
+                tick INTEGER NOT NULL,
+                field TEXT NOT NULL,
+                change_type TEXT NOT NULL,
+                old_value TEXT,
+                new_value TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                nmda_score REAL,
+                source TEXT NOT NULL DEFAULT 'night_run',
+                created_at_ms INTEGER NOT NULL
+            );
+            CREATE INDEX idx_evolution_agent_field_id
+            ON personality_evolution(agent_id, field, id DESC);",
+        )
+        .unwrap();
+
+        db.execute(
+            "INSERT INTO personality_evolution
+             (agent_id, tick, field, change_type, new_value, reason, source, created_at_ms)
+             VALUES ('AGENT-01', 1780475609399, 'memory_consolidation', 'night_run', 'legacy', 'legacy ms tick', 'night_run', 1)",
+            [],
+        )
+        .unwrap();
+        for tick in 0..PERSONALITY_EVOLUTION_PER_AGENT_FIELD_KEEP {
+            db.execute(
+                "INSERT INTO personality_evolution
+                 (agent_id, tick, field, change_type, new_value, reason, source, created_at_ms)
+                 VALUES ('AGENT-01', ?1, 'memory_consolidation', 'night_run', 'real', 'real sim tick', 'night_run', ?2)",
+                sentinel_limbo::rusqlite::params![1_900_000 + tick, 2 + tick],
+            )
+            .unwrap();
+        }
+
+        retain_personality_evolution_agent_field(&db, "AGENT-01", "memory_consolidation").unwrap();
+
+        let (count, max_tick): (i64, i64) = db
+            .query_row(
+                "SELECT count(*), max(tick)
+                 FROM personality_evolution
+                 WHERE agent_id = 'AGENT-01' AND field = 'memory_consolidation'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, PERSONALITY_EVOLUTION_PER_AGENT_FIELD_KEEP);
+        assert!(
+            max_tick < 1_000_000_000,
+            "legacy millisecond tick was retained: {max_tick}"
         );
     }
 }

--- a/services/sentinel-daemon/src/snapshot.rs
+++ b/services/sentinel-daemon/src/snapshot.rs
@@ -15,6 +15,15 @@ use tracing::{debug, info};
 
 use crate::config::RetentionConfig;
 
+/// Waehlt den Cutoff fuer Pruning aus `list_world_snapshots()`-Ergebnissen.
+///
+/// Die Liste ist nach `tick DESC` sortiert. Index 1 ist der zweitneueste
+/// Restore-Puffer; `len() - 2` waere der zweitaelteste Snapshot und kann nach
+/// CTAS-Kompaktion dauerhaft unter `min(events.id)` liegen.
+pub(crate) fn prune_cutoff_from_ordered_snapshots(snapshots: &[SnapshotMeta]) -> Option<i64> {
+    snapshots.get(1).map(|snapshot| snapshot.last_event_id)
+}
+
 /// Verwaltet World Snapshots mit Tiered Retention.
 pub struct SnapshotManager {
     config: RetentionConfig,
@@ -167,7 +176,7 @@ impl SnapshotManager {
     /// Promoted Snapshots durch die Tiers und loescht abgelaufene.
     ///
     /// Promoted Snapshots durch die Tiers und loescht abgelaufene.
-    /// Auto-Prune loescht Events vor dem zweitaeltesten Snapshot.
+    /// Auto-Prune loescht Events vor dem zweitneuesten Snapshot.
     pub fn maintain(&mut self, event_store: &Arc<EventStore>) -> anyhow::Result<MaintenanceReport> {
         let snapshots = event_store.list_world_snapshots()?;
         if snapshots.is_empty() {
@@ -249,8 +258,7 @@ impl SnapshotManager {
         // Auto-Prune: Cutoff setzen, prune_tick() arbeitet 1 Batch/Tick ab
         if self.config.auto_prune && !self.is_pruning() {
             let current_snapshots = event_store.list_world_snapshots().unwrap_or_default();
-            if current_snapshots.len() >= 2 {
-                let prune_point = current_snapshots[current_snapshots.len() - 2].last_event_id;
+            if let Some(prune_point) = prune_cutoff_from_ordered_snapshots(&current_snapshots) {
                 if event_store.can_prune(prune_point).unwrap_or(false) {
                     self.start_prune(prune_point);
                 }
@@ -305,4 +313,33 @@ impl SnapshotManager {
 pub struct MaintenanceReport {
     pub promoted: u32,
     pub deleted: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(tick: u64, last_event_id: i64) -> SnapshotMeta {
+        SnapshotMeta {
+            id: format!("snap-{tick}"),
+            tier: SnapshotTier::Hourly,
+            tick,
+            sim_hour: 0.0,
+            last_event_id,
+            payload_size_bytes: 0,
+            created_at_ms: 0,
+        }
+    }
+
+    #[test]
+    fn prune_cutoff_uses_second_newest_snapshot() {
+        let snapshots = vec![meta(300, 30), meta(200, 20), meta(100, 10)];
+        assert_eq!(prune_cutoff_from_ordered_snapshots(&snapshots), Some(20));
+    }
+
+    #[test]
+    fn prune_cutoff_requires_two_snapshots() {
+        assert_eq!(prune_cutoff_from_ordered_snapshots(&[]), None);
+        assert_eq!(prune_cutoff_from_ordered_snapshots(&[meta(100, 10)]), None);
+    }
 }

--- a/services/sentinel-judge/internal/persistence/evolution.go
+++ b/services/sentinel-judge/internal/persistence/evolution.go
@@ -3,9 +3,18 @@ package persistence
 import (
 	"database/sql"
 	"fmt"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
+)
+
+const (
+	maxRowsPerAgentField      = 2000
+	globalRetentionCheckEvery = 100
+	globalRetentionHighWater  = 499000
+	globalRetentionRetainRows = 490000
+	maxPlausibleSimTickExcl   = int64(1_000_000_000)
 )
 
 // EvolutionEntry represents a single personality evolution record.
@@ -23,7 +32,9 @@ type EvolutionEntry struct {
 
 // EvolutionStore manages personality_evolution persistence.
 type EvolutionStore struct {
-	db *sql.DB
+	db                         *sql.DB
+	mu                         sync.Mutex
+	writesSinceGlobalRetention int
 }
 
 // OpenEvolution opens or creates the evolution database.
@@ -51,23 +62,97 @@ func OpenEvolution(path string) (*EvolutionStore, error) {
 
 // Write inserts a personality evolution entry.
 func (s *EvolutionStore) Write(entry EvolutionEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	now := time.Now().UnixMilli()
 	source := entry.Source
 	if source == "" {
 		source = "realtime_judge"
 	}
 
-	_, err := s.db.Exec(`INSERT INTO personality_evolution
-		(agent_id, tick, field, change_type, old_value, new_value, reason, nmda_score, source, created_at_ms)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("evolution begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`INSERT INTO personality_evolution
+			(agent_id, tick, field, change_type, old_value, new_value, reason, nmda_score, source, created_at_ms)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		entry.AgentID, entry.Tick, entry.Field, entry.ChangeType,
 		entry.OldValue, entry.NewValue, entry.Reason, entry.NMDAScore,
 		source, now,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("evolution write: %w", err)
 	}
+
+	if err := s.enforceAgentFieldRetentionTx(tx, entry.AgentID, entry.Field, maxRowsPerAgentField); err != nil {
+		return err
+	}
+
+	s.writesSinceGlobalRetention++
+	if s.writesSinceGlobalRetention >= globalRetentionCheckEvery {
+		if err := s.enforceGlobalRetentionTx(tx, globalRetentionHighWater, globalRetentionRetainRows); err != nil {
+			return err
+		}
+		s.writesSinceGlobalRetention = 0
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("evolution commit: %w", err)
+	}
 	return nil
+}
+
+func (s *EvolutionStore) enforceAgentFieldRetentionTx(tx *sql.Tx, agentID, field string, keep int) error {
+	_, err := tx.Exec(`DELETE FROM personality_evolution
+		WHERE agent_id = ?
+		  AND field = ?
+		  AND id <= (
+			SELECT id
+			FROM personality_evolution
+			WHERE agent_id = ? AND field = ?
+			ORDER BY id DESC
+			LIMIT 1 OFFSET ?
+		  )`,
+		agentID, field, agentID, field, keep,
+	)
+	if err != nil {
+		return fmt.Errorf("evolution agent-field retention: %w", err)
+	}
+	return nil
+}
+
+func (s *EvolutionStore) enforceGlobalRetentionTx(tx *sql.Tx, highWater, retainRows int) error {
+	var count int
+	if err := tx.QueryRow("SELECT COUNT(*) FROM personality_evolution").Scan(&count); err != nil {
+		return fmt.Errorf("evolution global retention count: %w", err)
+	}
+	if count <= highWater {
+		return nil
+	}
+	_, err := tx.Exec(`DELETE FROM personality_evolution
+		WHERE id <= (
+			SELECT id
+			FROM personality_evolution
+			ORDER BY id DESC
+			LIMIT 1 OFFSET ?
+		)`, retainRows)
+	if err != nil {
+		return fmt.Errorf("evolution global retention: %w", err)
+	}
+	return nil
+}
+
+// DeleteInvalidTicks removes legacy rows whose tick is not a plausible simulation tick.
+// It is intended for offline migration/compaction before the judge is restarted.
+func (s *EvolutionStore) DeleteInvalidTicks() (int64, error) {
+	res, err := s.db.Exec("DELETE FROM personality_evolution WHERE tick < 0 OR tick >= ?", maxPlausibleSimTickExcl)
+	if err != nil {
+		return 0, fmt.Errorf("evolution delete invalid ticks: %w", err)
+	}
+	return res.RowsAffected()
 }
 
 // GetByAgent returns all evolution entries for an agent, ordered by tick.

--- a/services/sentinel-judge/internal/persistence/evolution_test.go
+++ b/services/sentinel-judge/internal/persistence/evolution_test.go
@@ -110,3 +110,132 @@ func TestEvolutionEmptyAgent(t *testing.T) {
 		t.Errorf("expected 0 entries for unknown agent, got %d", len(entries))
 	}
 }
+
+func TestEvolutionRetentionKeepsNewestIDsNotLargestTicks(t *testing.T) {
+	store := tempEvolution(t)
+
+	if err := store.Write(EvolutionEntry{
+		AgentID:    "AGENT-01",
+		Tick:       1_780_000_000_000,
+		Field:      "drift_score",
+		ChangeType: "drift",
+		NewValue:   "legacy-ms",
+		Reason:     "legacy realtime judge row",
+		Source:     "realtime_judge",
+	}); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	for i := 0; i < maxRowsPerAgentField; i++ {
+		if err := store.Write(EvolutionEntry{
+			AgentID:    "AGENT-01",
+			Tick:       int64(1_900_000 + i),
+			Field:      "drift_score",
+			ChangeType: "drift",
+			NewValue:   "real-sim",
+			Reason:     "post-fix row",
+			Source:     "realtime_judge",
+		}); err != nil {
+			t.Fatalf("write real row %d: %v", i, err)
+		}
+	}
+
+	var count int64
+	var maxTick int64
+	if err := store.db.QueryRow(`SELECT count(*), max(tick)
+		FROM personality_evolution
+		WHERE agent_id = 'AGENT-01' AND field = 'drift_score'`).Scan(&count, &maxTick); err != nil {
+		t.Fatalf("query retained rows: %v", err)
+	}
+	if count != maxRowsPerAgentField {
+		t.Fatalf("retained rows = %d, want %d", count, maxRowsPerAgentField)
+	}
+	if maxTick >= maxPlausibleSimTickExcl {
+		t.Fatalf("legacy ms tick was retained: max tick = %d", maxTick)
+	}
+}
+
+func TestEvolutionRetentionIsPerAgentField(t *testing.T) {
+	store := tempEvolution(t)
+
+	for i := 0; i < maxRowsPerAgentField+1; i++ {
+		if err := store.Write(EvolutionEntry{
+			AgentID:    "AGENT-01",
+			Tick:       int64(i),
+			Field:      "quality_score",
+			ChangeType: "quality",
+			NewValue:   "1",
+			Reason:     "test",
+		}); err != nil {
+			t.Fatalf("write quality: %v", err)
+		}
+		if err := store.Write(EvolutionEntry{
+			AgentID:    "AGENT-01",
+			Tick:       int64(i),
+			Field:      "fatigue_score",
+			ChangeType: "fatigue",
+			NewValue:   "0.1",
+			Reason:     "test",
+		}); err != nil {
+			t.Fatalf("write fatigue: %v", err)
+		}
+	}
+
+	rows, err := store.db.Query(`SELECT field, count(*)
+		FROM personality_evolution
+		WHERE agent_id = 'AGENT-01'
+		GROUP BY field`)
+	if err != nil {
+		t.Fatalf("query groups: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var field string
+		var count int64
+		if err := rows.Scan(&field, &count); err != nil {
+			t.Fatalf("scan group: %v", err)
+		}
+		counts[field] = count
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if counts["quality_score"] != maxRowsPerAgentField {
+		t.Fatalf("quality rows = %d, want %d", counts["quality_score"], maxRowsPerAgentField)
+	}
+	if counts["fatigue_score"] != maxRowsPerAgentField {
+		t.Fatalf("fatigue rows = %d, want %d", counts["fatigue_score"], maxRowsPerAgentField)
+	}
+}
+
+func TestDeleteInvalidTicks(t *testing.T) {
+	store := tempEvolution(t)
+
+	for _, entry := range []EvolutionEntry{
+		{AgentID: "AGENT-01", Tick: 42, Field: "drift_score", ChangeType: "drift", NewValue: "ok", Reason: "test"},
+		{AgentID: "AGENT-01", Tick: -1, Field: "drift_score", ChangeType: "drift", NewValue: "bad-negative", Reason: "test"},
+		{AgentID: "AGENT-01", Tick: maxPlausibleSimTickExcl, Field: "drift_score", ChangeType: "drift", NewValue: "bad-ms", Reason: "test"},
+	} {
+		if err := store.Write(entry); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	deleted, err := store.DeleteInvalidTicks()
+	if err != nil {
+		t.Fatalf("DeleteInvalidTicks: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+
+	entries, err := store.GetByAgent("AGENT-01")
+	if err != nil {
+		t.Fatalf("GetByAgent: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Tick != 42 {
+		t.Fatalf("remaining entries = %+v, want only tick 42", entries)
+	}
+}

--- a/services/sentinel-judge/internal/persistence/schema.go
+++ b/services/sentinel-judge/internal/persistence/schema.go
@@ -18,5 +18,6 @@ const createEvolutionTable = `CREATE TABLE IF NOT EXISTS personality_evolution (
 
 const createEvolutionIndices = `
 CREATE INDEX IF NOT EXISTS idx_evolution_agent ON personality_evolution(agent_id, tick);
-CREATE INDEX IF NOT EXISTS idx_evolution_source ON personality_evolution(source)
+CREATE INDEX IF NOT EXISTS idx_evolution_source ON personality_evolution(source);
+CREATE INDEX IF NOT EXISTS idx_evolution_agent_field_id ON personality_evolution(agent_id, field, id DESC)
 `

--- a/services/sentinel-judge/internal/service/stream.go
+++ b/services/sentinel-judge/internal/service/stream.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/silentspike/project-sentinel/pkg/sentinel-go/judge"
@@ -22,16 +24,16 @@ import (
 
 // StreamConsumer processes events from NATS JetStream in realtime.
 type StreamConsumer struct {
-	js       jetstream.JetStream
-	cfg      *config.Config
-	drift    *judge.DriftDetector
-	quality  *judge.QualityScorer
-	fatigue  *judge.FatigueDetector
-	swap     *judge.SwapTrigger
-	alerter  *alerter.Alerter
-	evol     *persistence.EvolutionStore
-	logger   *slog.Logger
-	ebpf     *EBPFStore // ADR-001: eBPF enrichment for drift-detection
+	js      jetstream.JetStream
+	cfg     *config.Config
+	drift   *judge.DriftDetector
+	quality *judge.QualityScorer
+	fatigue *judge.FatigueDetector
+	swap    *judge.SwapTrigger
+	alerter *alerter.Alerter
+	evol    *persistence.EvolutionStore
+	logger  *slog.Logger
+	ebpf    *EBPFStore // ADR-001: eBPF enrichment for drift-detection
 
 	// Message buffer per agent for heuristic analysis
 	mu       sync.RWMutex
@@ -69,14 +71,15 @@ func (sc *StreamConsumer) DriftDetector() *judge.DriftDetector {
 }
 
 const maxMessagesPerAgent = 20
+const maxPlausibleSimTickExclusive = int64(1_000_000_000)
 
 // Run starts the streaming consumer. Blocks until ctx is cancelled.
 func (sc *StreamConsumer) Run(ctx context.Context) error {
 	// Create or get durable pull consumer
 	consumer, err := sc.js.CreateOrUpdateConsumer(ctx, messaging.StreamEvents, jetstream.ConsumerConfig{
-		Durable:       sc.cfg.NATS.ConsumerName,
-		AckPolicy:     jetstream.AckExplicitPolicy,
-		MaxDeliver:    3,
+		Durable:    sc.cfg.NATS.ConsumerName,
+		AckPolicy:  jetstream.AckExplicitPolicy,
+		MaxDeliver: 3,
 		FilterSubjects: []string{
 			"sentinel.events.agent_action_received.*",
 			"sentinel.events.agent_chat.*",
@@ -148,6 +151,10 @@ func (sc *StreamConsumer) processMessage(msg jetstream.Msg) {
 		_ = msg.Ack()
 		return
 	}
+	tick, hasTick := extractSimTick(msg.Headers(), payload)
+	if !hasTick {
+		sc.logger.Warn("event missing valid simulation tick; evolution write disabled", "agent", agentID)
+	}
 	content, _ := payload["content"].(string)
 	if content == "" {
 		content, _ = payload["msg"].(string)
@@ -168,15 +175,13 @@ func (sc *StreamConsumer) processMessage(msg jetstream.Msg) {
 	sc.mu.Unlock()
 
 	// Run heuristic pipeline
-	sc.runHeuristics(agentID, content, recentMessages)
+	sc.runHeuristics(agentID, content, recentMessages, tick, hasTick)
 
 	_ = msg.Ack()
 }
 
 // runHeuristics executes the 4-algorithm heuristic pipeline on agent messages.
-func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMessages []string) {
-	now := time.Now().UnixMilli()
-
+func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMessages []string, tick int64, writeEvolution bool) {
 	// 1. Drift Detection (enriched with eBPF signal per ADR-001)
 	driftResult := sc.drift.CheckDrift(agentID, recentMessages)
 	driftScore := driftResult.DriftScore
@@ -207,17 +212,19 @@ func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMes
 		})
 	}
 
-	// Write drift evolution entry (enriched score)
-	if err := sc.evol.Write(persistence.EvolutionEntry{
-		AgentID:    agentID,
-		Tick:       now,
-		Field:      "drift_score",
-		ChangeType: "drift",
-		NewValue:   fmt.Sprintf("%.4f", driftScore),
-		Reason:     driftResult.Details,
-		Source:     "realtime_judge",
-	}); err != nil {
-		sc.logger.Warn("failed to write drift evolution", "agent", agentID, "error", err)
+	if writeEvolution {
+		// Write drift evolution entry (enriched score)
+		if err := sc.evol.Write(persistence.EvolutionEntry{
+			AgentID:    agentID,
+			Tick:       tick,
+			Field:      "drift_score",
+			ChangeType: "drift",
+			NewValue:   fmt.Sprintf("%.4f", driftScore),
+			Reason:     driftResult.Details,
+			Source:     "realtime_judge",
+		}); err != nil {
+			sc.logger.Warn("failed to write drift evolution", "agent", agentID, "error", err)
+		}
 	}
 
 	// 2. Quality Scoring
@@ -234,17 +241,19 @@ func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMes
 		})
 	}
 
-	// Write quality evolution entry
-	if err := sc.evol.Write(persistence.EvolutionEntry{
-		AgentID:    agentID,
-		Tick:       now,
-		Field:      "quality_score",
-		ChangeType: "quality",
-		NewValue:   fmt.Sprintf("%d", qualityResult.Score),
-		Reason:     qualityResult.Details,
-		Source:     "realtime_judge",
-	}); err != nil {
-		sc.logger.Warn("failed to write quality evolution", "agent", agentID, "error", err)
+	if writeEvolution {
+		// Write quality evolution entry
+		if err := sc.evol.Write(persistence.EvolutionEntry{
+			AgentID:    agentID,
+			Tick:       tick,
+			Field:      "quality_score",
+			ChangeType: "quality",
+			NewValue:   fmt.Sprintf("%d", qualityResult.Score),
+			Reason:     qualityResult.Details,
+			Source:     "realtime_judge",
+		}); err != nil {
+			sc.logger.Warn("failed to write quality evolution", "agent", agentID, "error", err)
+		}
 	}
 
 	// 3. Fatigue Detection
@@ -261,32 +270,36 @@ func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMes
 		})
 	}
 
-	// Write fatigue evolution entry
-	if err := sc.evol.Write(persistence.EvolutionEntry{
-		AgentID:    agentID,
-		Tick:       now,
-		Field:      "fatigue_score",
-		ChangeType: "fatigue",
-		NewValue:   fmt.Sprintf("%.4f", fatigueResult.FatigueScore),
-		Reason:     fatigueResult.Details,
-		Source:     "realtime_judge",
-	}); err != nil {
-		sc.logger.Warn("failed to write fatigue evolution", "agent", agentID, "error", err)
+	if writeEvolution {
+		// Write fatigue evolution entry
+		if err := sc.evol.Write(persistence.EvolutionEntry{
+			AgentID:    agentID,
+			Tick:       tick,
+			Field:      "fatigue_score",
+			ChangeType: "fatigue",
+			NewValue:   fmt.Sprintf("%.4f", fatigueResult.FatigueScore),
+			Reason:     fatigueResult.Details,
+			Source:     "realtime_judge",
+		}); err != nil {
+			sc.logger.Warn("failed to write fatigue evolution", "agent", agentID, "error", err)
+		}
 	}
 
 	// Write NMDA relevance score (max of drift + fatigue as proxy)
 	nmdaVal := math.Max(driftResult.DriftScore, fatigueResult.FatigueScore)
-	if err := sc.evol.Write(persistence.EvolutionEntry{
-		AgentID:    agentID,
-		Tick:       now,
-		Field:      "nmda_score",
-		ChangeType: "nmda_relevance",
-		NewValue:   fmt.Sprintf("%.4f", nmdaVal),
-		Reason:     "max(drift, fatigue) as NMDA relevance proxy",
-		Source:     "realtime_judge",
-		NMDAScore:  &nmdaVal,
-	}); err != nil {
-		sc.logger.Warn("failed to write nmda_score", "agent", agentID, "error", err)
+	if writeEvolution {
+		if err := sc.evol.Write(persistence.EvolutionEntry{
+			AgentID:    agentID,
+			Tick:       tick,
+			Field:      "nmda_score",
+			ChangeType: "nmda_relevance",
+			NewValue:   fmt.Sprintf("%.4f", nmdaVal),
+			Reason:     "max(drift, fatigue) as NMDA relevance proxy",
+			Source:     "realtime_judge",
+			NMDAScore:  &nmdaVal,
+		}); err != nil {
+			sc.logger.Warn("failed to write nmda_score", "agent", agentID, "error", err)
+		}
 	}
 
 	// 4. Swap Decision
@@ -301,6 +314,47 @@ func (sc *StreamConsumer) runHeuristics(agentID, latestMessage string, recentMes
 			Details:  swapDecision.Reason,
 		})
 	}
+}
+
+func extractSimTick(headers nats.Header, payload map[string]any) (int64, bool) {
+	if raw := headers.Get("X-Tick"); raw != "" {
+		return parseSimTick(raw)
+	}
+	for _, key := range []string{"tick", "sim_tick"} {
+		if tick, ok := payloadTick(payload[key]); ok {
+			return tick, true
+		}
+	}
+	return 0, false
+}
+
+func payloadTick(value any) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		if math.Trunc(v) != v {
+			return 0, false
+		}
+		return validateSimTick(int64(v))
+	case string:
+		return parseSimTick(v)
+	default:
+		return 0, false
+	}
+}
+
+func parseSimTick(raw string) (int64, bool) {
+	tick, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return validateSimTick(tick)
+}
+
+func validateSimTick(tick int64) (int64, bool) {
+	if tick < 0 || tick >= maxPlausibleSimTickExclusive {
+		return 0, false
+	}
+	return tick, true
 }
 
 // severityAtLeast checks if actual severity meets or exceeds the threshold.

--- a/services/sentinel-judge/internal/service/stream_test.go
+++ b/services/sentinel-judge/internal/service/stream_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestExtractSimTickFromHeader(t *testing.T) {
+	headers := nats.Header{}
+	headers.Set("X-Tick", "2009340")
+
+	tick, ok := extractSimTick(headers, map[string]any{"tick": float64(1)})
+	if !ok {
+		t.Fatal("expected header tick to parse")
+	}
+	if tick != 2009340 {
+		t.Fatalf("tick = %d, want 2009340", tick)
+	}
+}
+
+func TestExtractSimTickFromPayloadFallback(t *testing.T) {
+	tick, ok := extractSimTick(nats.Header{}, map[string]any{"sim_tick": float64(2009341)})
+	if !ok {
+		t.Fatal("expected payload tick to parse")
+	}
+	if tick != 2009341 {
+		t.Fatalf("tick = %d, want 2009341", tick)
+	}
+}
+
+func TestExtractSimTickRejectsLegacyMilliseconds(t *testing.T) {
+	headers := nats.Header{}
+	headers.Set("X-Tick", "1780475609399")
+
+	if tick, ok := extractSimTick(headers, map[string]any{}); ok {
+		t.Fatalf("legacy millisecond tick parsed as valid: %d", tick)
+	}
+}
+
+func TestExtractSimTickRejectsFractionalPayloadTick(t *testing.T) {
+	if tick, ok := extractSimTick(nats.Header{}, map[string]any{"tick": 12.5}); ok {
+		t.Fatalf("fractional payload tick parsed as valid: %d", tick)
+	}
+}


### PR DESCRIPTION
## Was

Behebt die **F2-Wurzel** und führt **systemweite Retention** ein (#481), plus die verkettete Outbox-/Event-Store-Ursache aus #259/#263/#475.

**Korrigierte Diagnose:** Der Stau war **nicht** mehr fehlende NATS-Subject-Sanitization (die Go-Bridge hat sie längst). Die 3.418 dauerhaft `pending` Outbox-Rows waren **Orphans**: `prune_batch` löschte Events, aber nie die zugehörigen Outbox-Zeilen → der INNER JOIN in `GetOutboxBatch` lässt sie fallen → nie publiziert/failed → blockieren `can_prune` dauerhaft.

## Änderungen

- **`prune_batch`** löscht jetzt zuerst **alle** Outbox-Zeilen der geprunten Events (jeder Status), dann die Events — über eine feste TEMP-Batch-Menge. `idx_outbox_event_id` ergänzt (Kind-Spalte war unindexiert).
- **`sentinel-db-maint`** (neues Bin): Orphan-Cleanup + offline **CTAS-Kompaktion** (events.db/evolution.db), kein `VACUUM`.
- **Judge**: `personality_evolution.tick` kommt aus `X-Tick`/Payload statt `time.Now().UnixMilli()`; Legacy-ms-Ticks (`>= 1e9`) werden verworfen.
- **Evolution-Retention** nach `id DESC` (nicht `tick` — gemischte ms/sim-Ticks), max 2000 je `(agent_id, field)`, global gedrosselt.
- **Snapshots**: nur höchste `version` je `aggregate_id`. Prune-Cutoff = **zweitneuester** Snapshot (war zweitältester).
- **Hippocampus**: Live- + Archive-Episoden auf 1000/Agent begrenzt (Growth-Stop; redb schrumpft physisch nicht).
- **CI**: monolithischer `rust`-Job in **4 parallele Jobs** (static/doc/test/ebpf) gesplittet, je eigener rust-cache-Key — fächert über mehrere Runner.

## Live verifiziert (Deploy-VM, 1h-Soak)

| Metrik | Vorher | Nachher |
|---|---|---|
| events.db | 3,8 G | **127 M** |
| evolution.db | 794 M | **296 K** |
| hippocampus.redb | 369 M | **27 M** |
| outbox pending / orphans | 3418 / 3418 | **0 / 0** |
| snapshots (total/distinct) | 8038 / 1 | **1 / 1** |
| max(tick) evolution | 1,78e12 (ms) | **1.467.901** (sim) |
| #264 Immutable-Trigger | — | **intakt** (`protect_recent_snapshots`) |

Tests grün: `cargo test` (limbo/runtime/daemon/hippocampus), `go test ./...` (eventstore/judge/nats-bridge), VM-Benchmarks (platform_controlplane/event_store).

## Hinweise

- **`Addresses`**, kein `Closes` — die Issues werden erst nach Merge + erneuter Live-Verifikation auf `status:verified` geschlossen (kein Self-Merge).
- Bekannte Mini-Redundanz: `idx_events_event_id` ist angelegt, obwohl `event_id` schon inline-`UNIQUE` ist — **bewusst belassen**, weil exakt dieser Code live verifiziert wurde (Divergenz zum verifizierten Stand wäre riskanter). Cleanup als Follow-up.

Addresses #481 #259 #263 #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
