### PR TITLE
test(daemon): full-roster cross-shift replay (#529 AC-5)

### DIFF
--- a/services/sentinel-daemon/src/replay.rs
+++ b/services/sentinel-daemon/src/replay.rs
@@ -668,6 +668,97 @@ mod tests {
         );
     }
 
+    #[test]
+    fn full_roster_cross_shift_replay_from_post_shift_anchor_is_exact() {
+        // #529 AC-5 (Skala): wie within_shift_…, aber mit dem ECHTEN Per-Shift-Roster aus
+        // config/agents/AGENT-*.toml und einem von `detect_shift_from_sim_hour` bestimmten
+        // Schichtwechsel. Ground-Truth laeuft ueber die Shift-Grenze (despawn alte Schicht, spawn
+        // neue); der Post-Shift-Anker (= was Snapshot-on-Shift erzeugt) + bounded Replay reproduziert
+        // die Ground-Truth byte-exakt (STRICT+CORE), 0 Mismatches, bei vollem Roster. Deterministisch,
+        // kein Daemon/keine VM — schliesst die residuale Skala-Luecke von AC-2 (N=4 -> realer Roster).
+        use crate::shift::{agents_for_shift, detect_shift_from_sim_hour};
+        use sentinel_common::agent_config::{
+            load_all_agents_with_validation, AgentConfigValidation,
+        };
+        use sentinel_ecs::{apply_capabilities, apply_personality};
+        use std::path::Path;
+
+        let agents_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config/agents");
+        let all = load_all_agents_with_validation(
+            Path::new(agents_dir),
+            AgentConfigValidation::with_max_agent_id(256),
+        )
+        .expect("echte Agent-Configs laden");
+        assert!(
+            all.len() >= 50,
+            "voller Roster geladen ({} Agents)",
+            all.len()
+        );
+
+        let spawn_shift = |world: &mut World, shift: u8| -> usize {
+            let active = agents_for_shift(&all, shift);
+            for a in &active {
+                let e = spawn_agent(
+                    world,
+                    AgentId(a.identity.id),
+                    &a.identity.name,
+                    &a.identity.role,
+                    a.identity.shift_set,
+                    &a.preferences.favorite_room,
+                );
+                apply_personality(world, e, &a.personality);
+                apply_capabilities(world, e, &a.capabilities);
+            }
+            active.len()
+        };
+        let despawn_shift = |world: &mut World, shift: u8| {
+            for a in agents_for_shift(&all, shift) {
+                despawn_agent_from_world(world, AgentId(a.identity.id));
+            }
+        };
+
+        // Echter Schichtwechsel 2 -> 3, wie der Daemon ihn per sim_hour erkennt.
+        let shift_a = detect_shift_from_sim_hour(14.0);
+        let shift_b = detect_shift_from_sim_hour(22.0);
+        assert_ne!(shift_a, shift_b, "echter Schichtwechsel");
+
+        let shift_tick = 25u64;
+        let target_tick = 55u64;
+        let events: Vec<DomainEvent> = vec![]; // reines Vorwaerts-Replay ueber den vollen Roster
+
+        // Ground-Truth: Schicht A aktiv -> bis shift_tick -> SCHICHTWECHSEL -> Post-Shift-Anker -> target.
+        let (mut w, mut sched) = world_with_agents(0);
+        w.resource_mut::<SimulationTime>().sim_hour = 14.0;
+        let n_a = spawn_shift(&mut w, shift_a);
+        run_ticks(&mut w, &mut sched, &events, 0, shift_tick);
+        despawn_shift(&mut w, shift_a);
+        let n_b = spawn_shift(&mut w, shift_b);
+        let post_shift_anchor = snapshot_ecs_state(&mut w); // = Snapshot-on-Shift @ shift_tick
+        run_ticks(&mut w, &mut sched, &events, shift_tick, target_tick);
+        let live = state_hashes(&mut w);
+
+        // Restore vom Post-Shift-Anker + Replay (innerhalb der neuen Schicht, kein Cross-Shift).
+        let (mut w2, mut sched2) = world_with_agents(0);
+        run_ticks(&mut w2, &mut sched2, &events, 0, shift_tick);
+        restore_ecs_state(&mut w2, &post_shift_anchor);
+        run_bounded_replay(&mut w2, &mut sched2, &events, shift_tick, target_tick).expect("replay");
+        let replayed = state_hashes(&mut w2);
+
+        println!(
+            "[AC-5] roster shift_a={n_a} -> shift_b={n_b} agents; STRICT live={} replay={}",
+            live.strict, replayed.strict
+        );
+        assert!(n_b >= 10, "voller Post-Shift-Roster aktiv ({n_b})");
+        assert_eq!(
+            live.strict, replayed.strict,
+            "STRICT: Full-Roster Cross-Shift Replay vom Post-Shift-Anker exakt (0 Mismatches)"
+        );
+        assert_eq!(
+            live.core, replayed.core,
+            "CORE: Full-Roster Cross-Shift Replay vom Post-Shift-Anker exakt (0 Mismatches)"
+        );
+    }
+
     // Hilfs-Tick-Loop fuer den Test (spiegelt run_bounded_replay ohne Resource-Gating, da die
     // Test-World ohnehin keine Limbo/Zenoh/Redb-Resources haelt).
     fn run_ticks(


### PR DESCRIPTION
## Summary

Closes the residual **scale** gap of #529's AC-5: the in-process cross-shift exactness was proven at N=4 (`within_shift_replay_from_post_shift_anchor_is_exact`); this proves it at the **real production roster** (26 active agents per shift), deterministically, with no daemon/VM.

Closes #529

## Changes

- New test `replay::tests::full_roster_cross_shift_replay_from_post_shift_anchor_is_exact`: loads the real per-shift roster from `config/agents/AGENT-*.toml`, runs ground-truth ticks across a real `detect_shift_from_sim_hour` boundary (shift 2 → 3: despawn old shift, spawn new shift), takes the **post-shift anchor** (= what #529's snapshot-on-shift produces), restores it + bounded-replays the post-shift window, and asserts STRICT+CORE equality with the ground-truth-forward hashes.

## Linked Issues

- Closes #529 (builds on PR #532 snapshot-on-shift, merged; PR #531 anchor-delta, merged)

## Linked Issue Contract

- [x] Referenced issue has `quality:ready`
- [x] Referenced issue has a `scope:*` label (`scope:full`)
- [x] No unresolved spec gaps remain in referenced issue

## Test Plan

- [x] `cargo remote -c -- test -p sentinel-daemon --lib full_roster_cross_shift_replay -- --nocapture` → 1 passed, STRICT live == replay
- [x] Real configs load on the build server (`config/agents` synced); 26 agents/shift active

## Benchmarks

n/a — a test, no runtime change. (#529 benchmark characterization unchanged: one extra snapshot per shift, replay windows stay within-shift.)

## Evidence (AC Mapping)

| Issue | AC-ID | Status | Evidence |
|------|-------|--------|----------|
| #529 | AC-5 (cross-shift restore exact at production scale) | PASS (deterministic, full roster) | output below — N=26 per shift, STRICT+CORE identical, 0 mismatches |

```
$ cargo remote -c -- test -p sentinel-daemon --lib full_roster_cross_shift_replay -- --nocapture
[AC-5] roster shift_a=26 -> shift_b=26 agents; STRICT live=aa096f7249fc0e01… replay=aa096f7249fc0e01…
test replay::tests::full_roster_cross_shift_replay_from_post_shift_anchor_is_exact ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 267 filtered out
```

## Checklist

- [x] CHANGELOG.md updated — n/a (test-only; #529's `### Added` already covers the feature)
- [x] No breaking changes (test only)
- [x] Performance impact considered (none; test)
- [x] No secrets or internal IPs in code/docs
- [x] NOT Tested documented (see below)

## Notes

AC-5 is now: the live restore machinery is demonstrated by #491; live snapshot-on-shift firing by #529 AC-3 (real daemon); and this test closes the residual **scale** gap deterministically at the full production roster. The only remaining piece is the live confirmation on the single running production daemon over a real wall-clock shift — the main-session deploy step (do not set `status:verified` from this PR; the close-gate keeps #529 open until then).

**Methodology note:** this runs in-process on purpose — a second full daemon on the production VM is unsafe (#279 runtime-reconcile treats production agent cgroups as orphans; see `.claude/rules/learnings.md`).

## NOT Tested

Live cross-shift restore on the running production daemon — main-session deploy step (real wall-clock shift produces the first shift-anchored snapshot; shadow-replay over it, #491 pattern). The exactness at production scale is what this test establishes deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)