### PR TITLE
docs(togaf): correct agent network model to full cage (#75)

### DIFF
--- a/crates/sentinel-sandbox/README.md
+++ b/crates/sentinel-sandbox/README.md
@@ -7,7 +7,7 @@
 ## Interfaces
 
 - `SandboxEnforcer` starts and tracks isolated agent processes.
-- `BwrapConfig`, `LandlockRuleset`, `NetworkNsConfig`, and `CgroupLimits` describe isolation policy.
+- `BwrapConfig`, `LandlockRuleset`, and `CgroupLimits` describe isolation policy (network: full cage via `bwrap --unshare-all`, post-spawn isolation verified against the child PID).
 - `AgentProcess` and `SandboxHandle` represent managed runtime state.
 - `psi_publisher` exposes pressure metrics for bio stress and monitoring.
 - `BwrapNanoRuntime` implements the shared `NanoRuntime` contract for the

--- a/docs/architecture/togaf-architecture-guide.html
+++ b/docs/architecture/togaf-architecture-guide.html
@@ -769,10 +769,10 @@ PRAGMA page_size = 8192;              -- optimized for NVMe sectors
   --bind /ram/agents/thomas /home/thomas \
   --tmpfs /tmp \
   --proc /proc --dev /dev \
-  --unshare-all --share-net \
+  --unshare-all \
   --die-with-parent \
   -- /usr/bin/agent-runtime</pre>
-                <p class="text-sm mb-3">Each agent sees <strong class="text-bright">only</strong> its own home directory (sentinel-fs CAS mount) and the company data (read-only). Starts in <strong class="text-bright">&lt;10ms</strong> (Docker: 500ms+). <span class="text-dim text-[0.78rem]">Validated: Anthropic uses an identical bwrap+Landlock stack for Claude Code<sup><a href="#ref-28" class="text-neon-blue no-underline text-[0.7rem] font-bold">[28]</a></sup></span></p>
+                <p class="text-sm mb-3">Each agent sees <strong class="text-bright">only</strong> its own home directory (sentinel-fs CAS mount) and the company data (read-only). Starts in <strong class="text-bright">&lt;10ms</strong> (Docker: 500ms+). The agent has <strong class="text-bright">no network</strong> (full cage via <code class="font-mono text-neon-blue text-[0.8em]">--unshare-all</code>, loopback only): all LLM calls are proxied by the daemon to the Cortex Gateway on the host (MITM-enforced) &mdash; the sandbox process makes no network calls itself, so <code class="font-mono text-neon-blue text-[0.8em]">--share-net</code> is deliberately not set (it would bypass the MITM). <span class="text-dim text-[0.78rem]">Validated: Anthropic uses an identical bwrap+Landlock stack for Claude Code<sup><a href="#ref-28" class="text-neon-blue no-underline text-[0.7rem] font-bold">[28]</a></sup></span></p>
                 <h4 class="font-mono font-bold text-[0.8rem] text-accent-gold uppercase mt-4 mb-2 tracking-wider">Landlock ruleset (per agent)</h4>
                 <div class="space-y-1 text-sm">
                     <div class="flex gap-3 py-1.5 border-b border-border/60"><strong class="text-bright w-20 shrink-0">Read</strong><span>Agent definition, company data, shared resources</span></div>


### PR DESCRIPTION
## Summary
The TOGAF architecture guide documented `bwrap --unshare-all --share-net`, which would put agents on the **host network** (a MITM-gateway bypass). This corrects it to the verified, stronger reality: **full cage** (`--unshare-all`, loopback only).

## Changes
- `docs/architecture/togaf-architecture-guide.html`: bwrap block `--unshare-all --share-net` → `--unshare-all`; added the network-model rationale (agents make no network calls; the daemon proxies LLM to the Cortex Gateway on the host, MITM-enforced; `--share-net` deliberately not set).
- `crates/sentinel-sandbox/README.md`: dropped the deleted `NetworkNsConfig` type; note the full-cage + post-spawn-verifier model.

## Linked Issues
Partially addresses #75 (the TOGAF/README hygiene part; the live ACs + close are tracked on #75).

## Test Plan
Docs-only, no code change. Verified the HTML edit is well-formed (flag line + paragraph), the `[28]` reference anchor is intact, and the README list still reads correctly. The German SSOT copy (`/home/jan/togaf-llm-architecture-guide.html`) was corrected in parallel, language-split (never `cp`-synced).

## Benchmarks
n/a (documentation only).

## Evidence (AC Mapping)
| AC | Evidence |
| --- | --- |
| AC-1 (#75: full cage is the model the TOGAF now documents) | Live on `ubuntu@10.0.0.240` (see command/output below): each agent in its own net namespace, loopback only, external blocked, 26 distinct netns for 26 agents. |

Concrete live output backing the AC row (daemon `58a54d92`, 2026-06-16):
```bash
$ sudo nsenter -t <agent-runtime-pid> -n ip -br addr
lo               UNKNOWN        127.0.0.1/8 ::1/128

$ sudo nsenter -t <agent-runtime-pid> -n bash -c 'timeout 3 bash -c "echo > /dev/tcp/1.1.1.1/443"'; echo "exit=$?"
exit=1                       # external host blocked (full cage)

$ for p in $(pgrep -x agent-runtime); do sudo readlink /proc/$p/ns/net; done | sort -u | wc -l
26                           # 26 distinct net namespaces for 26 agents (no shared segment)
```

## Checklist
- [x] TOGAF flag corrected to the verified reality (`--unshare-all`)
- [x] Rationale added (daemon-proxy / MITM, no agent network)
- [x] Dead `NetworkNsConfig` removed from README
- [x] Both copies updated, language-split (EN repo here, DE SSOT directly)
- [x] No code change; no Closes (live ACs gate the #75 close)