### PR TITLE
docs: add acronym glossary links (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Issue #336: added a compact acronym index to the glossary and linked the first README uses of project acronyms to it.
 - Updated the enforced Rust/DEV-010 toolchain contract to 1.95.0, refreshed vulnerable or yanked transitive dependencies, pinned the reproducible RustSec audit command, and moved the Cortex Gateway to the patched Go 1.26.5 toolchain.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Release](https://img.shields.io/github/v/release/silentspike/project-sentinel?include_prereleases&label=release)](https://github.com/silentspike/project-sentinel/releases)
 [![Stack: Rust 1.93+ / Go 1.26+](https://img.shields.io/badge/stack-rust%201.93%2B%20%2F%20go%201.26%2B-orange.svg)](#)
 
+Acronym reference: [OSSF Scorecard](docs/glossary.md#acronyms).
+
 A reference testbed for runtime governance of LLM coding agents:
 sandbox each agent, audit each action, and verify failure modes before
 customers run agents against production code.
@@ -25,10 +27,10 @@ operate: per-agent sandboxing (bwrap + Landlock + cgroups + netns),
 event-sourced audit trails, three independent control planes, and a
 9/9-passing breakout test report.
 
-The full stack is documented as a TOGAF v22.1 architecture and runs on a
+The full stack is documented as a [TOGAF](docs/glossary.md#acronyms) v22.1 architecture and runs on a
 provisioned VM. The included docker demo is a deliberate behavioral
 subset: it shows the workload and dashboard, but not the kernel-bound
-parts (eBPF, Landlock, FUSE) that need a real host.
+parts ([eBPF](docs/glossary.md#acronyms), Landlock, FUSE) that need a real host.
 
 [Architecture Guide (TOGAF v22.1)](docs/architecture/togaf-architecture-guide.html) ·
 [Sandbox Test Report (9/9)](docs/security-test-report.md) ·
@@ -56,6 +58,10 @@ environment:
    underpins the workload.
 
 ## Architecture at a Glance
+
+The quality and memory plane uses [NATS](docs/glossary.md#acronyms)
+JetStream for event streaming and an [NMDA](docs/glossary.md#acronyms)
+night-run for memory consolidation.
 
 ```mermaid
 flowchart TB
@@ -128,7 +134,7 @@ For deliberate deviations from the spec see
 
 | Tool        | Version  | Purpose                       |
 |-------------|----------|-------------------------------|
-| Rust        | 1.93+    | ECS world, all Rust crates    |
+| Rust        | 1.93+    | [ECS](docs/glossary.md#acronyms) world, all Rust crates    |
 | Go          | 1.23+    | Gateway, judge, nats-bridge   |
 | Bun         | 1.x      | Dashboard                     |
 | cargo-remote (optional) | latest | Remote build server  |
@@ -290,7 +296,7 @@ target; the docker demo is a deliberate behavioral subset.
 | Cortex Gateway 7-step pipeline + 10-rule synthesis engine | ✅ implemented + exercised | yes | yes |
 | Console (SolidJS + Rust WebTransport) | ✅ implemented + exercised | yes | yes |
 | sentinel-judge quality + drift monitoring (NATS streaming) | ✅ implemented + exercised | yes | yes |
-| sentinel-projection CQRS read-models | ✅ implemented + exercised | yes | yes |
+| sentinel-projection [CQRS](docs/glossary.md#acronyms) read-models | ✅ implemented + exercised | yes | yes |
 | sentinel-nightrun batch consolidation, deterministic replay | ✅ implemented, manual trigger | yes | yes |
 | **bwrap + Landlock per-agent isolation** | ✅ implemented + 9/9 breakout-tested (`crates/sentinel-sandbox/`) | **no (kernel-caps)** | **yes** |
 | **cgroups v2 per-agent caps** | ✅ implemented | **no (kernel-caps)** | **yes** |
@@ -379,7 +385,7 @@ private development and public visibility, not the start of the project.
 CI on `main`: ci, lint, coverage, supply-chain (cargo-deny, npm-audit,
 go-vuln, rust-audit), conventional-commits, dependency-freshness — green.
 CodeQL goes green on the first scheduled run after the public flip
-(GHAS gating). Security: dependency audit + `gitleaks` + `trufflehog` clean,
+([GHAS](docs/glossary.md#acronyms) gating). Security: dependency audit + `gitleaks` + `trufflehog` clean,
 9/9 sandbox breakout tests passing on a privileged host.
 
 See [docs/known-limitations.md](docs/known-limitations.md) for full caveats

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -130,3 +130,16 @@ sensations rather than as out-of-band signals.
 | API timeout      | migraine                  |
 | RAM pressure     | trouble concentrating     |
 | Network latency  | "having a slow day"       |
+
+## Acronyms
+
+- **TOGAF** - The Open Group Architecture Framework (the architecture framework this project follows, v22.1).
+- **SBOM** - Software Bill of Materials (machine-readable dependency and component inventory).
+- **GHAS** - GitHub Advanced Security (secret scanning, code scanning, and dependency review).
+- **OSSF Scorecard** - Open Source Security Foundation Scorecard (automated repository security assessment).
+- **CQRS** - Command Query Responsibility Segregation (write/read model separation; here the event store feeds projections).
+- **ECS** - Entity Component System (data-oriented simulation architecture implemented with `bevy_ecs`).
+- **NMDA** - N-Methyl-D-Aspartate receptor (the neuroscience mechanism behind sleep-driven synaptic and memory consolidation; namesake of the night-run consolidation cycle described in the "NMDA Night-Run" section above).
+- **eBPF** - extended Berkeley Packet Filter (kernel-mode observability probes implemented with aya-rs).
+- **NATS** - the messaging and event-streaming system used as the event bus (NATS JetStream and the Go bridge).
+- **MITM** - Man-in-the-Middle (the gateway intercepts and enriches LLM requests; see the architecture documentation).


### PR DESCRIPTION
## Summary
Add a compact acronym index to the project glossary and link the first applicable README uses to that index.

## Changes
- Add ten one-line project-specific definitions under `docs/glossary.md#Acronyms`.
- Link the eight acronyms that already occur in README prose or approved reference text.
- Preserve the OSSF badge and Mermaid diagram unchanged.
- Record the documentation update under `CHANGELOG.md` Unreleased / Changed.

## Linked Issues
Addresses #336.

## Test Plan
```console
$ typos README.md docs/glossary.md CHANGELOG.md
[exit 0]

$ git diff --check origin/main...HEAD
[exit 0]
```

## Benchmarks
Not applicable. This is a documentation-only change with no runtime or performance surface.

## Evidence (AC Mapping)
| AC | Requirement | Evidence |
| --- | --- | --- |
| AC-1 | One Acronyms section with ten correct one-line definitions | One H2 and ten exact term bullets; incorrect NMDA/NATS expansions absent; glossary remains ASCII |
| AC-2 | README links first applicable uses to the glossary | Exactly eight rendered links; TOGAF, eBPF, NATS, NMDA, ECS, CQRS, GHAS, and the approved OSSF reference are linked; SBOM/MITM were not invented |
| Delivery | Preserve unrelated content and document the change | Exact three-file diff; badge and Mermaid unchanged; one Unreleased changelog line; static checks pass |

```console
$ rg -c '^## Acronyms$' docs/glossary.md
1
$ rg -c '^- \*\*(TOGAF|SBOM|GHAS|OSSF Scorecard|CQRS|ECS|NMDA|eBPF|NATS|MITM)\*\* - ' docs/glossary.md
10
$ rg -o 'docs/glossary\.md#acronyms' README.md | wc -l
8
$ git diff --name-only origin/main...HEAD
CHANGELOG.md
README.md
docs/glossary.md
$ jq -Rs '{text:.,mode:"gfm",context:"silentspike/project-sentinel"}' README.md | gh api markdown --input - | rg -o 'href="docs/glossary.md#acronyms"' | wc -l
8
```

The same GFM check renders one `Acronyms` H2. README SBOM/MITM additions and known incorrect NMDA/NATS expansions produce zero matches. Badge and Mermaid source compare byte-identically with `origin/main`.

## Checklist
- [x] Ten required acronym definitions added
- [x] Eight applicable README first-use links added
- [x] SBOM and MITM not introduced into README
- [x] OSSF badge and Mermaid diagram preserved
- [x] Changelog updated
- [x] GitHub GFM rendering checked
- [x] `typos` and `git diff --check` pass
- [x] Documentation-only scope; no build, deploy, or runtime mutation required
- [x] Uses `Addresses #336` without an auto-close keyword
