### PR TITLE
test: make circuit breaker coverage deterministic

### DIFF
--- a/services/sentinel-daemon/src/llm_bridge.rs
+++ b/services/sentinel-daemon/src/llm_bridge.rs
@@ -1717,7 +1717,7 @@ pub mod bridge {
         fn circuit_breaker_updates_open_signal() {
             let open_signal = Arc::new(AtomicBool::new(false));
             let mut breaker =
-                CircuitBreaker::new(2, Duration::from_millis(1), Arc::clone(&open_signal));
+                CircuitBreaker::new(2, Duration::from_secs(1), Arc::clone(&open_signal));
 
             assert!(!breaker.is_open());
             assert!(!open_signal.load(Ordering::Relaxed));
@@ -1730,7 +1730,8 @@ pub mod bridge {
             assert!(breaker.is_open());
             assert!(open_signal.load(Ordering::Relaxed));
 
-            std::thread::sleep(Duration::from_millis(2));
+            // Expire the stored deadline directly so instrumentation cannot race the clock.
+            breaker.last_failure = Some(Instant::now() - breaker.reset_duration);
             assert!(!breaker.is_open());
             assert!(!open_signal.load(Ordering::Relaxed));
 


### PR DESCRIPTION
## Summary

Makes the circuit-breaker signal test deterministic under coverage instrumentation. The production implementation is unchanged.

## Changes

- Replace the 1 ms reset window with a stable test-only duration.
- Expire the recorded deadline directly instead of relying on wall-clock sleep timing.

## Linked Issues

- Partially addresses #632

## Linked Issue Contract

- [x] Referenced issue has `quality:ready`
- [x] Referenced issue has a `scope:*` label
- [x] No unresolved spec gaps remain in referenced issue

## Test Plan

- [x] Targeted circuit-breaker test passes on the remote Rust builder under Rust 1.97.1
- [x] Full `sentinel-daemon --lib` test suite passes: 339 passed, 0 failed, 1 privileged host test ignored
- [x] Remote `cargo fmt --all -- --check` passes
- [x] Remote Clippy for daemon library/tests passes with `-D warnings`
- [x] `git diff --check` and targeted typos pass

## Benchmarks

N/A. This test-only change has no runtime or performance behavior. Remote build and test durations are correctness evidence only and are not benchmark evidence.

## Evidence (AC Mapping)

| Issue | AC-ID | Evidence (command/output/artifact) |
|------|-------|--------------------------------------|
| #632 | AC-4 | Remote targeted test and full daemon library suite under Rust 1.97.1; remote format and Clippy gates. |

```text
$ cargo remote ... -- test -p sentinel-daemon --lib circuit_breaker_updates_open_signal
running 1 test
...circuit_breaker_updates_open_signal ... ok
test result: ok. 1 passed; 0 failed

$ cargo remote ... -- test -p sentinel-daemon --lib
test result: ok. 339 passed; 0 failed; 1 ignored

$ cargo remote ... -- clippy -p sentinel-daemon --lib --tests -- -D warnings
Finished dev profile
```

## Checklist

- [x] CHANGELOG.md was already updated by #743; this follow-up changes test timing only
- [x] No breaking changes
- [x] Performance impact considered: none, test-only change
- [x] No secrets or internal IPs in code/docs
- [x] NOT Tested documented

## Notes

PR #743 merged as `1a4f44cbde2cf016ce12c96c68e7df91c41f0756`. Its merge-SHA Coverage workflow failed twice in `circuit_breaker_updates_open_signal`: coverage instrumentation could consume the 1 ms reset interval before the assertion. This PR removes that wall-clock race while preserving the same open/reset assertions.

Runtime target class: `NONE`
Deploy targets: none
Read-only targets: none
Forbidden targets: all runtime VMs
Benchmark targets: N/A
Rollback owner and method: ORC; revert this single test commit

## NOT Tested

- Runtime deployment and VM behavior: not applicable to this test-only follow-up.
- Performance benchmarks: N/A for a test-only timing contract.